### PR TITLE
feat: strip tracing from release binaries

### DIFF
--- a/src/bootstrap_cache/cache.rs
+++ b/src/bootstrap_cache/cache.rs
@@ -11,11 +11,11 @@ use super::config::BootstrapCacheConfig;
 use super::entry::{CachedPeer, ConnectionOutcome, PeerCapabilities, PeerSource};
 use super::persistence::{CacheData, CachePersistence};
 use super::selection::select_epsilon_greedy;
+use crate::{debug, info, warn};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::{RwLock, broadcast};
-use tracing::{debug, info, warn};
 
 /// Bootstrap cache event for notifications
 #[derive(Debug, Clone)]
@@ -441,8 +441,8 @@ impl BootstrapCache {
             loop {
                 tokio::select! {
                     _ = save_interval.tick() => {
-                        if let Err(e) = cache.save().await {
-                            warn!("Failed to save cache: {}", e);
+                        if let Err(_e) = cache.save().await {
+                            warn!("Failed to save cache: {}", _e);
                         }
                     }
                     _ = cleanup_interval.tick() => {

--- a/src/bootstrap_cache/persistence.rs
+++ b/src/bootstrap_cache/persistence.rs
@@ -24,6 +24,7 @@
 //! The ciphertext contains the JSON-serialized CacheData.
 
 use super::entry::CachedPeer;
+use crate::{debug, info, warn};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::{self, File, OpenOptions};
@@ -31,7 +32,6 @@ use std::io;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
-use tracing::{debug, info, warn};
 use zeroize::Zeroize;
 
 /// Serializable cache data structure

--- a/src/bootstrap_cache/token_store.rs
+++ b/src/bootstrap_cache/token_store.rs
@@ -9,10 +9,10 @@
 
 use crate::bootstrap_cache::BootstrapCache;
 use crate::token::TokenStore;
+use crate::{debug, warn};
 use bytes::Bytes;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
-use tracing::{debug, warn};
 
 /// A TokenStore implementation that persists tokens to the BootstrapCache.
 ///

--- a/src/candidate_discovery.rs
+++ b/src/candidate_discovery.rs
@@ -21,7 +21,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use tracing::{debug, error, info, warn};
+use crate::{debug, error, info, warn};
 
 use crate::{
     connection::nat_traversal::{CandidateSource, CandidateState},
@@ -847,8 +847,11 @@ impl CandidateDiscoveryManager {
                 // Step 1: Start interface scan if just entering phase (within first 50ms)
                 if started_at.elapsed().as_millis() < 50 {
                     let scan_result = self.interface_discovery.lock().start_scan();
-                    if let Err(e) = scan_result {
-                        error!("Failed to start interface scan for {:?}: {}", session_id, e);
+                    if let Err(_e) = scan_result {
+                        error!(
+                            "Failed to start interface scan for {:?}: {}",
+                            session_id, _e
+                        );
                     } else {
                         debug!("Started local interface scan for {:?}", session_id);
                         all_events.push(DiscoveryEvent::LocalScanningStarted);
@@ -1285,8 +1288,8 @@ impl CandidateDiscoveryManager {
         use crate::nat_traversal_api::CandidateAddress;
         let allow_loopback = self.config.allow_loopback;
 
-        if let Err(e) = CandidateAddress::validate_address(address) {
-            debug!("Address {} failed validation: {}", address, e);
+        if let Err(_e) = CandidateAddress::validate_address(address) {
+            debug!("Address {} failed validation: {}", address, _e);
             return false;
         }
 

--- a/src/candidate_discovery/linux.rs
+++ b/src/candidate_discovery/linux.rs
@@ -16,8 +16,8 @@ use std::{
     time::Instant,
 };
 
+use crate::{debug, error, info, warn};
 use nix::libc;
-use tracing::{debug, error, info, warn};
 
 use crate::candidate_discovery::{NetworkInterface, NetworkInterfaceDiscovery};
 
@@ -518,10 +518,10 @@ impl LinuxInterfaceDiscovery {
                         interfaces.push(interface);
                     }
                 }
-                Err(e) => {
+                Err(_e) => {
                     warn!(
                         "Failed to get interface details for {}: {:?}",
-                        interface_name, e
+                        interface_name, _e
                     );
                 }
             }
@@ -981,8 +981,8 @@ impl NetworkInterfaceDiscovery for LinuxInterfaceDiscovery {
 
         // Initialize netlink socket if monitoring is enabled
         if self.interface_config.enable_monitoring {
-            if let Err(e) = self.initialize_netlink_socket() {
-                warn!("Failed to initialize netlink socket: {:?}", e);
+            if let Err(_e) = self.initialize_netlink_socket() {
+                warn!("Failed to initialize netlink socket: {:?}", _e);
             }
         }
 
@@ -1048,8 +1048,8 @@ impl NetworkInterfaceDiscovery for LinuxInterfaceDiscovery {
                 self.scan_state = ScanState::Idle;
                 Some(results)
             }
-            ScanState::Failed { error } => {
-                warn!("Scan failed: {}", error);
+            ScanState::Failed { error: _error } => {
+                warn!("Scan failed: {}", _error);
                 self.scan_state = ScanState::Idle;
                 None
             }

--- a/src/candidate_discovery/macos.rs
+++ b/src/candidate_discovery/macos.rs
@@ -32,7 +32,7 @@ const SIOCGIFMTU: libc::c_ulong = 0xc0206933;
 // Used in FFI bindings
 const SIOCGIFADDR: libc::c_ulong = 0xc0206921;
 
-use tracing::{debug, error, info, warn};
+use crate::{debug, error, info, warn};
 
 use crate::candidate_discovery::{NetworkInterface, NetworkInterfaceDiscovery};
 

--- a/src/candidate_discovery/windows.rs
+++ b/src/candidate_discovery/windows.rs
@@ -35,7 +35,7 @@ use windows::Win32::{
     System::{IO::OVERLAPPED, Threading::WaitForSingleObject},
 };
 
-use tracing::{debug, error, info, warn};
+use crate::{debug, error, info, warn};
 
 use crate::candidate_discovery::{NetworkInterface, NetworkInterfaceDiscovery};
 

--- a/src/coding.rs
+++ b/src/coding.rs
@@ -133,7 +133,7 @@ pub trait BufMutExt {
     /// Write a variable-length integer, debug-asserting on overflow in debug builds
     fn write_var_or_debug_assert(&mut self, x: u64) {
         if self.write_var(x).is_err() {
-            tracing::error!("VarInt overflow: {} exceeds maximum", x);
+            crate::error!("VarInt overflow: {} exceeds maximum", x);
             debug_assert!(false, "VarInt overflow: {}", x);
         }
     }

--- a/src/compliance_validator/endpoint_tester.rs
+++ b/src/compliance_validator/endpoint_tester.rs
@@ -14,11 +14,11 @@ use crate::{
     high_level::{Connection, Endpoint},
     transport_parameters::TransportParameters,
 };
+use crate::{error, info, warn};
 use std::collections::HashMap;
 use std::net::ToSocketAddrs;
 use std::time::Duration;
 use tokio::time::timeout;
-use tracing::{error, info, warn};
 
 /// Known public QUIC endpoints for testing
 /// Last verified: 2025-07-25
@@ -106,8 +106,8 @@ impl EndpointTester {
 
     /// Test all endpoints
     pub async fn test_all_endpoints(&mut self) -> EndpointValidationReport {
-        self.init_endpoint().await.unwrap_or_else(|e| {
-            error!("Failed to initialize endpoint: {}", e);
+        self.init_endpoint().await.unwrap_or_else(|_e| {
+            error!("Failed to initialize endpoint: {}", _e);
         });
 
         let mut all_endpoints = PUBLIC_QUIC_ENDPOINTS

--- a/src/config/port_binding.rs
+++ b/src/config/port_binding.rs
@@ -59,7 +59,7 @@ mod socket2_impl {
             }
             // Try half the size
             size /= 2;
-            tracing::debug!(
+            crate::debug!(
                 "Send buffer size {} rejected, trying {} bytes",
                 size * 2,
                 size
@@ -89,7 +89,7 @@ mod socket2_impl {
             }
             // Try half the size
             size /= 2;
-            tracing::debug!(
+            crate::debug!(
                 "Recv buffer size {} rejected, trying {} bytes",
                 size * 2,
                 size
@@ -150,21 +150,21 @@ mod socket2_impl {
 
         // Apply buffer sizes with graceful fallback
         if let Some(size) = opts.send_buffer_size {
-            if let Err(e) = try_set_send_buffer(&socket, size) {
-                tracing::warn!(
+            if let Err(_e) = try_set_send_buffer(&socket, size) {
+                crate::warn!(
                     "Failed to set send buffer to {} bytes: {}. Using OS default.",
                     size,
-                    e
+                    _e
                 );
             }
         }
 
         if let Some(size) = opts.recv_buffer_size {
-            if let Err(e) = try_set_recv_buffer(&socket, size) {
-                tracing::warn!(
+            if let Err(_e) = try_set_recv_buffer(&socket, size) {
+                crate::warn!(
                     "Failed to set recv buffer to {} bytes: {}. Using OS default.",
                     size,
-                    e
+                    _e
                 );
             }
         }
@@ -219,28 +219,28 @@ mod socket2_impl {
             {
                 // On supported Unix platforms, try to set SO_REUSEPORT
                 // This is a best-effort attempt - failure is not critical
-                tracing::debug!("SO_REUSEPORT requested but skipped for compatibility");
+                crate::debug!("SO_REUSEPORT requested but skipped for compatibility");
             }
         }
 
         // Apply buffer sizes with graceful fallback
         // If the kernel rejects the requested size, try progressively smaller sizes
         if let Some(size) = opts.send_buffer_size {
-            if let Err(e) = try_set_send_buffer(&socket, size) {
-                tracing::warn!(
+            if let Err(_e) = try_set_send_buffer(&socket, size) {
+                crate::warn!(
                     "Failed to set send buffer to {} bytes: {}. Using OS default.",
                     size,
-                    e
+                    _e
                 );
             }
         }
 
         if let Some(size) = opts.recv_buffer_size {
-            if let Err(e) = try_set_recv_buffer(&socket, size) {
-                tracing::warn!(
+            if let Err(_e) = try_set_recv_buffer(&socket, size) {
+                crate::warn!(
                     "Failed to set recv buffer to {} bytes: {}. Using OS default.",
                     size,
-                    e
+                    _e
                 );
             }
         }
@@ -340,17 +340,17 @@ fn bind_single_socket(
                         let local_addr = socket
                             .local_addr()
                             .map_err(|e| EndpointConfigError::BindFailed(e.to_string()))?;
-                        tracing::info!(
+                        crate::info!(
                             "Created true dual-stack socket on {} (accepts IPv4 and IPv6)",
                             local_addr
                         );
                         std::mem::forget(socket);
                         return Ok(vec![local_addr]);
                     }
-                    Err(e) => {
-                        tracing::debug!(
+                    Err(_e) => {
+                        crate::debug!(
                             "True dual-stack socket failed: {:?}, falling back to separate sockets",
-                            e
+                            _e
                         );
                         // Fall through to separate socket binding
                     }
@@ -374,7 +374,7 @@ fn bind_single_socket(
                         .local_addr()
                         .map_err(|e| EndpointConfigError::BindFailed(e.to_string()))?;
 
-                    tracing::info!(
+                    crate::info!(
                         "Created separate IPv4 ({}) and IPv6 ({}) sockets (fallback mode)",
                         v4_local,
                         v6_local
@@ -383,13 +383,13 @@ fn bind_single_socket(
                     std::mem::forget(v6_socket);
                     Ok(vec![v4_local, v6_local])
                 }
-                Err(e) => {
+                Err(_e) => {
                     // IPv6 not available - gracefully degrade to IPv4-only
-                    tracing::debug!(
+                    crate::debug!(
                         "IPv6 socket creation failed ({:?}), using IPv4-only mode",
-                        e
+                        _e
                     );
-                    tracing::info!(
+                    crate::info!(
                         "Created IPv4-only socket on {} (IPv6 not available on this system)",
                         v4_local
                     );
@@ -459,7 +459,7 @@ pub fn bind_endpoint(config: &EndpointPortConfig) -> PortConfigResult<BoundSocke
                         return Err(EndpointConfigError::PortInUse(*port));
                     }
                     PortRetryBehavior::FallbackToOsAssigned => {
-                        tracing::warn!("Port {} in use, falling back to OS-assigned", port);
+                        crate::warn!("Port {} in use, falling back to OS-assigned", port);
                         bind_single_socket(0, &config.ip_mode, &config.socket_options)?
                     }
                     PortRetryBehavior::TryNext => {

--- a/src/congestion/bbr/mod.rs
+++ b/src/congestion/bbr/mod.rs
@@ -9,8 +9,8 @@ use std::any::Any;
 use std::fmt::Debug;
 use std::sync::Arc;
 
+use crate::{debug, warn};
 use rand::{Rng, SeedableRng};
-use tracing::{debug, warn};
 
 use crate::congestion::ControllerMetrics;
 use crate::congestion::bbr::bw_estimation::BandwidthEstimation;

--- a/src/connection/cid_state.rs
+++ b/src/connection/cid_state.rs
@@ -8,8 +8,8 @@
 //! Maintain the state of local connection IDs
 use std::collections::VecDeque;
 
+use crate::{debug, trace};
 use rustc_hash::FxHashSet;
-use tracing::{debug, trace};
 
 use crate::{Duration, Instant, TransportError, shared::IssuedCid};
 

--- a/src/connection/datagrams.rs
+++ b/src/connection/datagrams.rs
@@ -7,9 +7,9 @@
 
 use std::collections::VecDeque;
 
+use crate::{debug, trace};
 use bytes::Bytes;
 use thiserror::Error;
-use tracing::{debug, trace};
 
 use super::Connection;
 use crate::{

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -19,9 +19,9 @@ use bytes::{Bytes, BytesMut};
 use frame::StreamMetaVec;
 // Removed qlog feature
 
+use crate::{debug, error, info, trace, trace_span, warn};
 use rand::{Rng, SeedableRng, rngs::StdRng};
 use thiserror::Error;
-use tracing::{debug, error, info, trace, trace_span, warn};
 
 use crate::{
     Dir, Duration, EndpointConfig, Frame, INITIAL_MTU, Instant, MAX_CID_SIZE, MAX_STREAM_COUNT,
@@ -1408,12 +1408,12 @@ impl Connection {
         let challenge = self.rng.r#gen::<u64>();
 
         // Start validation for this candidate
-        if let Err(e) =
+        if let Err(_e) =
             self.nat_traversal
                 .as_mut()?
                 .start_validation(remote_sequence, challenge, now)
         {
-            warn!("Failed to start NAT traversal validation: {}", e);
+            warn!("Failed to start NAT traversal validation: {}", _e);
             return None;
         }
 
@@ -2063,8 +2063,8 @@ impl Connection {
         largest_sent_time: Instant,
     ) {
         match self.spaces[space].detect_ecn(newly_acked, ecn) {
-            Err(e) => {
-                debug!("halting ECN due to verification failure: {}", e);
+            Err(_e) => {
+                debug!("halting ECN due to verification failure: {}", _e);
                 self.path.sending_ecn = false;
                 // Wipe out the existing value because it might be garbage and could interfere with
                 // future attempts to use ECN on new paths.
@@ -2534,8 +2534,8 @@ impl Connection {
                     };
                     self.set_peer_params(params);
                 }
-                Err(e) => {
-                    error!("session ticket has malformed transport parameters: {}", e);
+                Err(_e) => {
+                    error!("session ticket has malformed transport parameters: {}", _e);
                     return;
                 }
             }
@@ -2729,8 +2729,8 @@ impl Connection {
                     remaining = rest;
                     self.handle_decode(now, remote, ecn, partial_decode);
                 }
-                Err(e) => {
-                    trace!("malformed header: {}", e);
+                Err(_e) => {
+                    trace!("malformed header: {}", _e);
                     return;
                 }
             }
@@ -2763,13 +2763,13 @@ impl Connection {
         stateless_reset: bool,
     ) {
         self.stats.udp_rx.ios += 1;
-        if let Some(ref packet) = packet {
+        if let Some(ref _packet) = packet {
             trace!(
                 "got {:?} packet ({} bytes) from {} using id {}",
-                packet.header.space(),
-                packet.payload.len() + packet.header_data.len(),
+                _packet.header.space(),
+                _packet.payload.len() + _packet.header_data.len(),
                 remote,
-                packet.header.dst_cid(),
+                _packet.header.dst_cid(),
             );
 
             // Trace packet received
@@ -2777,7 +2777,7 @@ impl Connection {
             {
                 use crate::trace_packet_received;
                 // Tracing imports handled by macros
-                let packet_size = packet.payload.len() + packet.header_data.len();
+                let packet_size = _packet.payload.len() + _packet.header_data.len();
                 trace_packet_received!(
                     &self.event_log,
                     self.trace_context.trace_id(),
@@ -2828,7 +2828,7 @@ impl Connection {
             }
             Ok((packet, number)) => {
                 let span = match number {
-                    Some(pn) => trace_span!("recv", space = ?packet.header.space(), pn),
+                    Some(_pn) => trace_span!("recv", space = ?packet.header.space(), _pn),
                     None => trace_span!("recv", space = ?packet.header.space()),
                 };
                 let _guard = span.enter();
@@ -2943,8 +2943,8 @@ impl Connection {
                 for result in frame::Iter::new(packet.payload.freeze())? {
                     let frame = match result {
                         Ok(frame) => frame,
-                        Err(err) => {
-                            debug!("frame decoding error: {err:?}");
+                        Err(_err) => {
+                            debug!("frame decoding error: {_err:?}");
                             continue;
                         }
                     };
@@ -3261,17 +3261,17 @@ impl Connection {
             // Crypto, Stream and Datagram frames are special cased in order no pollute
             // the log with payload data
             match &frame {
-                Frame::Crypto(f) => {
-                    trace!(offset = f.offset, len = f.data.len(), "got crypto frame");
+                Frame::Crypto(_f) => {
+                    trace!(offset = _f.offset, len = _f.data.len(), "got crypto frame");
                 }
-                Frame::Stream(f) => {
-                    trace!(id = %f.id, offset = f.offset, len = f.data.len(), fin = f.fin, "got stream frame");
+                Frame::Stream(_f) => {
+                    trace!(id = %_f.id, offset = _f.offset, len = _f.data.len(), fin = _f.fin, "got stream frame");
                 }
-                Frame::Datagram(f) => {
-                    trace!(len = f.data.len(), "got datagram frame");
+                Frame::Datagram(_f) => {
+                    trace!(len = _f.data.len(), "got datagram frame");
                 }
-                f => {
-                    trace!("got frame {:?}", f);
+                _f => {
+                    trace!("got frame {:?}", _f);
                 }
             }
 
@@ -3339,10 +3339,10 @@ impl Connection {
                     } else if let Some(nat_traversal) = &mut self.nat_traversal {
                         // Check if this is a response to NAT traversal PATH_CHALLENGE
                         match nat_traversal.handle_validation_success(remote, token, now) {
-                            Ok(sequence) => {
+                            Ok(_sequence) => {
                                 trace!(
                                     "NAT traversal candidate {} validated for sequence {}",
-                                    remote, sequence
+                                    remote, _sequence
                                 );
 
                                 // Check if this was part of a coordination round
@@ -3368,12 +3368,12 @@ impl Connection {
                                                     "NAT traversal found better path, initiating migration"
                                                 );
                                                 // Trigger migration to the better NAT-traversed path
-                                                if let Err(e) =
+                                                if let Err(_e) =
                                                     self.migrate_to_nat_traversal_path(now)
                                                 {
                                                     warn!(
                                                         "Failed to migrate to NAT traversal path: {:?}",
-                                                        e
+                                                        _e
                                                     );
                                                 }
                                             }
@@ -3392,8 +3392,8 @@ impl Connection {
                                     remote
                                 );
                             }
-                            Err(e) => {
-                                debug!("NAT traversal validation error: {}", e);
+                            Err(_e) => {
+                                debug!("NAT traversal validation error: {}", _e);
                             }
                         }
                     } else {
@@ -3414,10 +3414,13 @@ impl Connection {
                         self.spaces[SpaceId::Data].pending.max_data = true;
                     }
                 }
-                Frame::DataBlocked { offset } => {
-                    debug!(offset, "peer claims to be blocked at connection level");
+                Frame::DataBlocked { offset: _offset } => {
+                    debug!(_offset, "peer claims to be blocked at connection level");
                 }
-                Frame::StreamDataBlocked { id, offset } => {
+                Frame::StreamDataBlocked {
+                    id,
+                    offset: _offset,
+                } => {
                     if id.initiator() == self.side.side() && id.dir() == Dir::Uni {
                         debug!("got STREAM_DATA_BLOCKED on send-only {}", id);
                         return Err(TransportError::STREAM_STATE_ERROR(
@@ -3426,18 +3429,21 @@ impl Connection {
                     }
                     debug!(
                         stream = %id,
-                        offset, "peer claims to be blocked at stream level"
+                        _offset, "peer claims to be blocked at stream level"
                     );
                 }
-                Frame::StreamsBlocked { dir, limit } => {
-                    if limit > MAX_STREAM_COUNT {
+                Frame::StreamsBlocked {
+                    dir: _dir,
+                    limit: _limit,
+                } => {
+                    if _limit > MAX_STREAM_COUNT {
                         return Err(TransportError::FRAME_ENCODING_ERROR(
                             "unrepresentable stream limit",
                         ));
                     }
                     debug!(
                         "peer claims to be blocked opening more than {} {} streams",
-                        limit, dir
+                        _limit, _dir
                     );
                 }
                 Frame::StopSending(frame::StopSending { id, error_code }) => {
@@ -3780,8 +3786,8 @@ impl Connection {
         self.peer_params.stateless_reset_token = Some(reset_token);
     }
 
-    fn handle_encode_error(&mut self, now: Instant, context: &'static str) {
-        tracing::error!("VarInt overflow while encoding {context}");
+    fn handle_encode_error(&mut self, now: Instant, _context: &'static str) {
+        crate::error!("VarInt overflow while encoding {_context}");
         self.close_inner(
             now,
             Close::from(TransportError::INTERNAL_ERROR(
@@ -4110,8 +4116,8 @@ impl Connection {
                 &mut self.rng,
             ) {
                 Ok(token) => token,
-                Err(err) => {
-                    error!(?err, "failed to encode validation token");
+                Err(_err) => {
+                    error!(?_err, "failed to encode validation token");
                     continue;
                 }
             };
@@ -4411,8 +4417,8 @@ impl Connection {
                     self.initiate_nat_traversal_process();
                 }
             }
-            Err(e) => {
-                warn!("NAT traversal capability negotiation failed: {}", e);
+            Err(_e) => {
+                warn!("NAT traversal capability negotiation failed: {}", _e);
                 self.emit_nat_traversal_capability_event(false);
                 self.set_nat_traversal_compatibility_mode(false);
             }
@@ -4543,8 +4549,8 @@ impl Connection {
                         Instant::now() + Duration::from_millis(100),
                     );
                 }
-                Err(e) => {
-                    warn!("Failed to initiate NAT traversal process: {}", e);
+                Err(_e) => {
+                    warn!("Failed to initiate NAT traversal process: {}", _e);
                 }
             }
         }
@@ -4591,8 +4597,8 @@ impl Connection {
                         nat_traversal::TimeoutAction::RetryDiscovery => {
                             debug!("NAT traversal timeout: retrying candidate discovery");
                             if let Some(nat_state) = &mut self.nat_traversal {
-                                if let Err(e) = nat_state.start_candidate_discovery() {
-                                    warn!("Failed to retry candidate discovery: {}", e);
+                                if let Err(_e) = nat_state.start_candidate_discovery() {
+                                    warn!("Failed to retry candidate discovery: {}", _e);
                                 }
                             }
                         }
@@ -4619,8 +4625,8 @@ impl Connection {
                     }
                 }
             }
-            Err(e) => {
-                warn!("NAT traversal timeout handling failed: {}", e);
+            Err(_e) => {
+                warn!("NAT traversal timeout handling failed: {}", _e);
                 self.handle_nat_traversal_failure();
             }
         }
@@ -4632,7 +4638,7 @@ impl Connection {
             // Get candidate pairs that need validation
             let pairs = nat_state.get_next_validation_pairs(3);
 
-            for pair in pairs {
+            for _pair in pairs {
                 // Send PATH_CHALLENGE to validate the path
                 let challenge = self.rng.r#gen();
                 self.path.challenge = Some(challenge);
@@ -4640,7 +4646,7 @@ impl Connection {
 
                 debug!(
                     "Starting path validation for NAT traversal candidate: {}",
-                    pair.remote_addr
+                    _pair.remote_addr
                 );
             }
 
@@ -4782,8 +4788,8 @@ impl Connection {
                 // Silently ignore duplicates (peer may resend)
                 Ok(())
             }
-            Err(e) => {
-                warn!("Failed to add remote candidate: {}", e);
+            Err(_e) => {
+                warn!("Failed to add remote candidate: {}", _e);
                 Ok(()) // Don't terminate connection for non-critical errors
             }
         }
@@ -4842,8 +4848,8 @@ impl Connection {
                         trace!("Coordination completed or no action needed");
                         return Ok(());
                     }
-                    Err(e) => {
-                        warn!("Coordination failed: {}", e);
+                    Err(_e) => {
+                        warn!("Coordination failed: {}", _e);
                         return Ok(());
                     }
                 }
@@ -4923,7 +4929,7 @@ impl Connection {
         observed_address: &crate::frame::ObservedAddress,
         now: Instant,
     ) -> Result<(), TransportError> {
-        tracing::info!(
+        crate::info!(
             address = %observed_address.address,
             sequence = %observed_address.sequence_number,
             "handle_observed_address_frame: RECEIVED OBSERVED_ADDRESS from peer"
@@ -5912,20 +5918,20 @@ impl Connection {
 
         // Now process candidates with mutable access
         if let Some(nat_state) = &mut self.nat_traversal {
-            for (seq, address) in candidates {
+            for (seq, _address) in candidates {
                 // Generate a random challenge token
                 let challenge: u64 = self.rng.r#gen();
 
                 // Start validation for this candidate
-                if let Err(e) = nat_state.start_validation(seq, challenge, now) {
-                    debug!("Failed to start validation for candidate {}: {}", seq, e);
+                if let Err(_e) = nat_state.start_validation(seq, challenge, now) {
+                    debug!("Failed to start validation for candidate {}: {}", seq, _e);
                     continue;
                 }
 
                 // NAT traversal PATH_CHALLENGE frames are sent via send_nat_traversal_challenge()
                 trace!(
                     "Started NAT validation for {} with token {:08x}",
-                    address, challenge
+                    _address, challenge
                 );
             }
         }
@@ -6602,13 +6608,13 @@ impl AddressDiscoveryState {
     ) -> Option<frame::ObservedAddress> {
         // Check if address discovery is enabled
         if !self.enabled {
-            tracing::debug!("queue_observed_address_frame: BLOCKED - address discovery disabled");
+            crate::debug!("queue_observed_address_frame: BLOCKED - address discovery disabled");
             return None;
         }
 
         // Check path restrictions
         if !self.observe_all_paths && path_id != 0 {
-            tracing::debug!(
+            crate::debug!(
                 "queue_observed_address_frame: BLOCKED - path {} not allowed (observe_all_paths={})",
                 path_id,
                 self.observe_all_paths
@@ -6619,7 +6625,7 @@ impl AddressDiscoveryState {
         // Check if this path has already been notified
         if let Some(info) = self.sent_observations.get(&path_id) {
             if info.notified {
-                tracing::trace!(
+                crate::trace!(
                     "queue_observed_address_frame: BLOCKED - path {} already notified",
                     path_id
                 );
@@ -6629,14 +6635,14 @@ impl AddressDiscoveryState {
 
         // Check rate limiting
         if self.rate_limiter.tokens < 1.0 {
-            tracing::debug!(
+            crate::debug!(
                 "queue_observed_address_frame: BLOCKED - rate limited (tokens={})",
                 self.rate_limiter.tokens
             );
             return None;
         }
 
-        tracing::info!(
+        crate::info!(
             "queue_observed_address_frame: SENDING OBSERVED_ADDRESS to {} for path {}",
             address,
             path_id
@@ -6653,7 +6659,7 @@ impl AddressDiscoveryState {
         info.observed_address = Some(address);
         info.notified = true;
 
-        tracing::trace!(
+        crate::trace!(
             path_id = ?path_id,
             address = %address,
             "queue_observed_address_frame: queuing frame"

--- a/src/connection/mtud.rs
+++ b/src/connection/mtud.rs
@@ -5,9 +5,9 @@
 //
 // Full details available at https://saorsalabs.com/licenses
 
+use crate::trace;
 use crate::{Instant, MAX_UDP_PAYLOAD, MtuDiscoveryConfig, packet::SpaceId};
 use std::cmp;
-use tracing::trace;
 
 /// Implements Datagram Packetization Layer Path Maximum Transmission Unit Discovery
 ///

--- a/src/connection/nat_traversal.rs
+++ b/src/connection/nat_traversal.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 use crate::shared::ConnectionId;
-use tracing::{debug, info, trace, warn};
+use crate::{debug, info, trace, warn};
 
 use super::{PortPredictor, PortPredictorConfig};
 use crate::{Instant, VarInt};
@@ -1490,10 +1490,10 @@ impl ResourceCleanupCoordinator {
             let is_failed = coord.state == CoordinationPhase::Failed;
 
             if is_expired || is_failed {
-                let round = coord.round;
+                let _round = coord.round;
                 *coordination = None;
                 cleaned += 1;
-                trace!("Cleaned up old coordination state for round {}", round);
+                trace!("Cleaned up old coordination state for round {}", _round);
             }
         }
 
@@ -3341,12 +3341,12 @@ impl NatTraversalState {
     /// This confirms that the source address can reach us.
     pub(super) fn record_successful_callback_probe(
         &mut self,
-        request_id: VarInt,
-        source_address: SocketAddr,
+        _request_id: VarInt,
+        _source_address: SocketAddr,
     ) {
         debug!(
             "Recording successful callback probe: request_id={}, source={}",
-            request_id, source_address
+            _request_id, _source_address
         );
         // Update statistics
         self.stats.callback_probes_received += 1;
@@ -3361,12 +3361,12 @@ impl NatTraversalState {
     /// Called when we receive a TryConnectToResponse indicating failure.
     pub(super) fn record_failed_callback_probe(
         &mut self,
-        request_id: VarInt,
-        error_code: Option<crate::frame::TryConnectError>,
+        _request_id: VarInt,
+        _error_code: Option<crate::frame::TryConnectError>,
     ) {
         debug!(
             "Recording failed callback probe: request_id={}, error={:?}",
-            request_id, error_code
+            _request_id, _error_code
         );
         // Update statistics
         self.stats.callback_probes_received += 1;
@@ -3717,24 +3717,24 @@ impl BootstrapCoordinator {
         // Enhanced address validation with amplification protection
         self.security_validator
             .enhanced_address_validation(frame.address, source_addr, now)
-            .inspect_err(|&e| {
+            .inspect_err(|&_e| {
                 self.stats.security_rejections += 1;
                 debug!(
                     "PUNCH_ME_NOW frame address validation failed from peer {:?}: {:?}",
                     hex::encode(&from_peer[..8]),
-                    e
+                    _e
                 );
             })?;
 
         // Comprehensive security validation
         self.security_validator
             .validate_punch_me_now_frame(frame, source_addr, from_peer, now)
-            .inspect_err(|&e| {
+            .inspect_err(|&_e| {
                 self.stats.security_rejections += 1;
                 debug!(
                     "PUNCH_ME_NOW frame validation failed from peer {:?}: {:?}",
                     hex::encode(&from_peer[..8]),
-                    e
+                    _e
                 );
             })?;
 

--- a/src/connection/pacing.rs
+++ b/src/connection/pacing.rs
@@ -9,7 +9,7 @@
 
 use crate::{Duration, Instant};
 
-use tracing::warn;
+use crate::warn;
 
 /// A simple token-bucket pacer
 ///

--- a/src/connection/packet_builder.rs
+++ b/src/connection/packet_builder.rs
@@ -5,9 +5,9 @@
 //
 // Full details available at https://saorsalabs.com/licenses
 
+use crate::{debug, trace, trace_span};
 use bytes::Bytes;
 use rand::Rng;
-use tracing::{debug, trace, trace_span};
 
 use super::{Connection, SentFrames, spaces::SentPacket};
 use crate::{

--- a/src/connection/packet_crypto.rs
+++ b/src/connection/packet_crypto.rs
@@ -5,7 +5,7 @@
 //
 // Full details available at https://saorsalabs.com/licenses
 
-use tracing::{debug, trace};
+use crate::{debug, trace};
 
 use crate::Instant;
 use crate::connection::spaces::PacketSpace;
@@ -57,8 +57,8 @@ pub(super) fn unprotect_header(
             packet: None,
             stateless_reset: true,
         }),
-        Err(e) => {
-            trace!("unable to complete packet decoding: {}", e);
+        Err(_e) => {
+            trace!("unable to complete packet decoding: {}", _e);
             None
         }
     }

--- a/src/connection/paths.rs
+++ b/src/connection/paths.rs
@@ -7,7 +7,7 @@
 
 use std::{cmp, net::SocketAddr};
 
-use tracing::trace;
+use crate::trace;
 
 use super::{
     mtud::MtuDiscovery,

--- a/src/connection/spaces.rs
+++ b/src/connection/spaces.rs
@@ -12,9 +12,9 @@ use std::{
     ops::{Bound, Index, IndexMut},
 };
 
+use crate::trace;
 use rand::Rng;
 use rustc_hash::FxHashSet;
-use tracing::trace;
 
 use super::assembler::Assembler;
 use crate::{

--- a/src/connection/streams/mod.rs
+++ b/src/connection/streams/mod.rs
@@ -10,9 +10,9 @@ use std::{
     io,
 };
 
+use crate::{trace, warn};
 use bytes::Bytes;
 use thiserror::Error;
-use tracing::{trace, warn};
 
 use super::spaces::{Retransmits, ThinRetransmits};
 use crate::{

--- a/src/connection/streams/recv.rs
+++ b/src/connection/streams/recv.rs
@@ -8,8 +8,8 @@
 use std::collections::hash_map::Entry;
 use std::mem;
 
+use crate::debug;
 use thiserror::Error;
-use tracing::debug;
 
 use super::state::get_or_insert_recv;
 use super::{ClosedStream, Retransmits, ShouldTransmit, StreamId, StreamsState};

--- a/src/connection/streams/state.rs
+++ b/src/connection/streams/state.rs
@@ -11,9 +11,9 @@ use std::{
     mem,
 };
 
+use crate::{debug, trace};
 use bytes::BufMut;
 use rustc_hash::FxHashMap;
-use tracing::{debug, trace};
 
 use super::{
     PendingStreamsQueue, Recv, Retransmits, Send, SendState, ShouldTransmit, StreamEvent,

--- a/src/connection_router.rs
+++ b/src/connection_router.rs
@@ -422,7 +422,7 @@ impl RoutedConnection {
                 handle,
                 ..
             } => {
-                tracing::debug!(
+                crate::debug!(
                     connection_id = connection_id.0,
                     reason_code,
                     "closing constrained connection with reason"
@@ -945,7 +945,7 @@ impl ConnectionRouter {
             ProtocolEngine::Constrained => self.stats.constrained_selections += 1,
         }
 
-        tracing::debug!(
+        crate::debug!(
             engine = ?engine,
             reason = %reason,
             supports_quic = supports_quic,
@@ -980,7 +980,7 @@ impl ConnectionRouter {
             ProtocolEngine::Quic if constrained_available => {
                 // Fall back to constrained
                 self.stats.fallback_selections += 1;
-                tracing::warn!(
+                crate::warn!(
                     preferred = "QUIC",
                     fallback = "Constrained",
                     "preferred engine unavailable, using fallback"
@@ -1001,7 +1001,7 @@ impl ConnectionRouter {
             ProtocolEngine::Constrained if quic_available && capabilities.supports_full_quic() => {
                 // Fall back to QUIC (only if transport supports it)
                 self.stats.fallback_selections += 1;
-                tracing::warn!(
+                crate::warn!(
                     preferred = "Constrained",
                     fallback = "QUIC",
                     "preferred engine unavailable, using fallback"
@@ -1018,7 +1018,7 @@ impl ConnectionRouter {
             }
             _ => {
                 // No suitable engine available
-                tracing::error!(
+                crate::error!(
                     quic_available,
                     constrained_available,
                     "no suitable engine available"
@@ -1175,7 +1175,7 @@ impl ConnectionRouter {
         self.next_quic_id += 1;
         self.stats.quic_connections += 1;
 
-        tracing::info!(
+        crate::info!(
             connection_id,
             remote = %socket_addr,
             "QUIC connection established via router"
@@ -1305,7 +1305,7 @@ impl ConnectionRouter {
         self.next_quic_id += 1;
         self.stats.quic_connections += 1;
 
-        tracing::info!(
+        crate::info!(
             connection_id,
             remote = %remote_addr,
             "Accepted incoming QUIC connection via router"

--- a/src/constrained/connection.rs
+++ b/src/constrained/connection.rs
@@ -375,8 +375,8 @@ impl ConstrainedConnection {
             ConnectionState::Established => {
                 // Process ACK
                 if header.is_ack() {
-                    let acked = self.send_window.acknowledge(header.ack);
-                    tracing::trace!(acked, ack = header.ack.value(), "Processed ACK");
+                    let _acked = self.send_window.acknowledge(header.ack);
+                    crate::trace!(_acked, ack = header.ack.value(), "Processed ACK");
                 }
 
                 // Process DATA

--- a/src/constrained/state.rs
+++ b/src/constrained/state.rs
@@ -201,7 +201,7 @@ impl StateMachine {
         self.state = new_state;
         self.state_entered = Instant::now();
 
-        tracing::trace!(
+        crate::trace!(
             from = %old_state,
             event = %event,
             to = %new_state,

--- a/src/crypto/certificate_negotiation.rs
+++ b/src/crypto/certificate_negotiation.rs
@@ -21,7 +21,8 @@ use std::{
 
 use parking_lot::{Mutex, RwLock};
 
-use tracing::{Level, debug, info, span, warn};
+use crate::{debug, info, warn};
+use tracing::{Level, span};
 
 use super::tls_extensions::{
     CertificateTypeList, CertificateTypePreferences, NegotiationResult, TlsExtensionError,
@@ -469,7 +470,7 @@ impl CertificateNegotiationManager {
         let mut sessions = self.sessions.write();
         let cutoff = Instant::now() - max_age;
 
-        sessions.retain(|id, state| {
+        sessions.retain(|_id, state| {
             let should_retain = match state {
                 NegotiationState::Completed { completed_at, .. } => *completed_at > cutoff,
                 NegotiationState::Failed { failed_at, .. } => *failed_at > cutoff,
@@ -478,7 +479,7 @@ impl CertificateNegotiationManager {
             };
 
             if !should_retain {
-                debug!("Cleaned up old negotiation session: {:?}", id);
+                debug!("Cleaned up old negotiation session: {:?}", _id);
             }
 
             should_retain

--- a/src/crypto/pqc/negotiation.rs
+++ b/src/crypto/pqc/negotiation.rs
@@ -20,8 +20,8 @@ use crate::crypto::pqc::{
     config::PqcConfig,
     tls_extensions::{NamedGroup, SignatureScheme},
 };
+use crate::{debug, info, trace, warn};
 use std::collections::HashSet;
-use tracing::{debug, info, trace, warn};
 
 /// Result of algorithm negotiation
 #[derive(Debug, Clone, PartialEq)]

--- a/src/crypto/pqc/packet_handler.rs
+++ b/src/crypto/pqc/packet_handler.rs
@@ -18,8 +18,8 @@
 //! - Coalescing logic aware of PQC constraints
 
 use crate::{MAX_UDP_PAYLOAD, MtuDiscoveryConfig, frame::Crypto, packet::SpaceId};
+use crate::{debug, trace};
 use std::cmp;
-use tracing::{debug, trace};
 
 /// Size constants for PQC algorithms
 pub const ML_KEM_768_HANDSHAKE_OVERHEAD: u16 = 1184 + 1088; // Public key + ciphertext
@@ -229,9 +229,9 @@ impl PqcPacketHandler {
     }
 
     /// Update statistics after packet sent
-    pub fn on_packet_sent(&mut self, space: SpaceId, size: u16) {
+    pub fn on_packet_sent(&mut self, space: SpaceId, _size: u16) {
         if self.pqc_detected && matches!(space, SpaceId::Initial | SpaceId::Handshake) {
-            trace!("PQC packet sent in {:?}: {} bytes", space, size);
+            trace!("PQC packet sent in {:?}: {} bytes", space, _size);
         }
     }
 

--- a/src/crypto/pqc/tls_integration.rs
+++ b/src/crypto/pqc/tls_integration.rs
@@ -20,8 +20,8 @@ use crate::crypto::pqc::{
     tls_extensions::{NamedGroup, SignatureScheme},
     types::*,
 };
+use crate::{debug, info, warn};
 use std::sync::Arc;
-use tracing::{debug, info, warn};
 
 /// TLS handshake extension for pure PQC negotiation
 ///

--- a/src/crypto/raw_public_keys.rs
+++ b/src/crypto/raw_public_keys.rs
@@ -30,7 +30,7 @@ use rustls::{
 
 use super::tls_extension_simulation::{Rfc7250ClientConfig, Rfc7250ServerConfig};
 
-use tracing::{debug, info, warn};
+use crate::{debug, info, warn};
 
 // Re-export Pure PQC types from pqc module
 pub use pqc::{

--- a/src/crypto/rustls.rs
+++ b/src/crypto/rustls.rs
@@ -707,10 +707,10 @@ pub fn configured_provider_with_pqc(
     // Use the PQC crypto provider factory
     match crate::crypto::pqc::create_crypto_provider(pqc_config) {
         Ok(provider) => provider,
-        Err(e) => {
-            tracing::warn!(
+        Err(_e) => {
+            crate::warn!(
                 "Failed to create PQC provider: {:?}, falling back to default",
-                e
+                _e
             );
             configured_provider()
         }

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -16,13 +16,13 @@ use std::{
 
 use indexmap::IndexMap;
 
+use crate::{debug, error, trace, warn};
 use bytes::{BufMut, Bytes, BytesMut};
 use rand::{Rng, RngCore, SeedableRng, rngs::StdRng};
 use rustc_hash::FxHashMap;
 use rustls;
 use slab::Slab;
 use thiserror::Error;
-use tracing::{debug, error, trace, warn};
 
 use crate::{
     Duration, INITIAL_MTU, Instant, MAX_CID_SIZE, MIN_INITIAL_SIZE, RESET_TOKEN_SIZE, ResetToken,
@@ -241,11 +241,11 @@ impl RelayQueue {
 
         // Remove expired items
         for key in expired_keys {
-            if let Some(expired) = self.pending.shift_remove(&key) {
+            if let Some(_expired) = self.pending.shift_remove(&key) {
                 debug!(
                     "Relay request for peer {:?} timed out after {:?}",
-                    expired.target_peer_id,
-                    now.saturating_duration_since(expired.created_at)
+                    _expired.target_peer_id,
+                    now.saturating_duration_since(_expired.created_at)
                 );
             }
         }
@@ -396,10 +396,10 @@ impl Endpoint {
 
     /// Unregister a peer ID from the connection mapping
     pub fn unregister_peer(&mut self, peer_id: &PeerId) {
-        if let Some(handle) = self.peer_connections.remove(peer_id) {
+        if let Some(_handle) = self.peer_connections.remove(peer_id) {
             trace!(
                 "Unregistered peer {:?} from connection {:?}",
-                peer_id, handle
+                peer_id, _handle
             );
         }
     }
@@ -469,11 +469,11 @@ impl Endpoint {
         if self.connections.get(ch.0).is_some() {
             // Store the event to be processed by the high-level layer
             // The high-level endpoint will drain these and send to the appropriate connections
-            tracing::info!("Queueing PUNCH_ME_NOW relay event for connection {:?}", ch);
+            crate::info!("Queueing PUNCH_ME_NOW relay event for connection {:?}", ch);
             self.pending_relay_events.push((ch, event));
             true
         } else {
-            tracing::warn!("Cannot relay PUNCH_ME_NOW: connection {:?} not found", ch);
+            crate::warn!("Cannot relay PUNCH_ME_NOW: connection {:?} not found", ch);
             false
         }
     }
@@ -670,23 +670,26 @@ impl Endpoint {
                     add_address_frame,
                 )));
             }
-            NatCandidateValidated { address, challenge } => {
+            NatCandidateValidated {
+                address: _address,
+                challenge: _challenge,
+            } => {
                 // Handle successful NAT traversal candidate validation
                 trace!(
                     "NAT candidate validation succeeded for {} with challenge {:016x}",
-                    address, challenge
+                    _address, _challenge
                 );
 
                 // The validation success is primarily handled by the connection-level state machine
                 // This event serves as notification to the endpoint for potential coordination
                 // with other components or logging/metrics collection
-                debug!("NAT candidate {} validated successfully", address);
+                debug!("NAT candidate {} validated successfully", _address);
             }
             TryConnectTo {
-                request_id,
-                target_address,
-                timeout_ms,
-                requester_connection,
+                request_id: _request_id,
+                target_address: _target_address,
+                timeout_ms: _timeout_ms,
+                requester_connection: _requester_connection,
                 requested_at: _,
             } => {
                 // Handle TryConnectTo request from a peer
@@ -694,7 +697,7 @@ impl Endpoint {
                 // to a target to verify connectivity
                 trace!(
                     "TryConnectTo request received: request_id={}, target={}, timeout={}ms, from={}",
-                    request_id, target_address, timeout_ms, requester_connection
+                    _request_id, _target_address, _timeout_ms, _requester_connection
                 );
 
                 // Since the endpoint is synchronous and we can't spawn async tasks here,
@@ -703,7 +706,7 @@ impl Endpoint {
                 // For now, we queue a "not implemented" response to acknowledge the request.
                 debug!(
                     "TryConnectTo: endpoint received callback request for {}",
-                    target_address
+                    _target_address
                 );
 
                 // TODO: In the async wrapper (high_level/mod.rs), implement the actual
@@ -787,8 +790,8 @@ impl Endpoint {
                     src_ip: local_ip,
                 }));
             }
-            Err(e) => {
-                trace!("malformed header: {}", e);
+            Err(_e) => {
+                trace!("malformed header: {}", _e);
                 return None;
             }
         };
@@ -1067,8 +1070,8 @@ impl Endpoint {
 
         let packet = match event.first_decode.finish(Some(&*crypto.header.remote)) {
             Ok(packet) => packet,
-            Err(e) => {
-                trace!("unable to decode initial packet: {}", e);
+            Err(_e) => {
+                trace!("unable to decode initial packet: {}", _e);
                 return None;
             }
         };
@@ -1382,8 +1385,8 @@ impl Endpoint {
             &mut self.rng,
         ) {
             Ok(token) => token,
-            Err(err) => {
-                error!(?err, "failed to encode retry token");
+            Err(_err) => {
+                error!(?_err, "failed to encode retry token");
                 return Err(RetryError::incoming(incoming));
             }
         };

--- a/src/error_handling.rs
+++ b/src/error_handling.rs
@@ -72,7 +72,7 @@ pub type Result<T> = std::result::Result<T, SaorsaTransportError>;
 /// Error handling utilities
 pub mod utils {
     use super::*;
-    use tracing::{error, warn, info, debug};
+    use crate::{debug, error, info, warn};
 
     /// Log an error with appropriate level based on severity
     pub fn log_error<E: std::error::Error>(error: &E, context: &str) {

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -25,7 +25,7 @@ use crate::{
 };
 
 fn log_encode_overflow(context: &'static str) {
-    tracing::error!("VarInt overflow while encoding {context}");
+    crate::error!("VarInt overflow while encoding {context}");
     debug_assert!(false, "VarInt overflow while encoding {context}");
 }
 
@@ -513,7 +513,7 @@ impl Ack {
         let first = match rest.next() {
             Some(first) => first,
             None => {
-                tracing::error!("ACK ranges should have at least one range");
+                crate::error!("ACK ranges should have at least one range");
                 return Err(VarIntBoundsExceeded);
             }
         };

--- a/src/frame/nat_traversal_unified.rs
+++ b/src/frame/nat_traversal_unified.rs
@@ -25,7 +25,7 @@ use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 pub const TRANSPORT_PARAM_RFC_NAT_TRAVERSAL: u64 = 0x3d7e9f0bca12fea8;
 
 fn log_encode_overflow(context: &'static str) {
-    tracing::error!("VarInt overflow while encoding {context}");
+    crate::error!("VarInt overflow while encoding {context}");
     debug_assert!(false, "VarInt overflow while encoding {context}");
 }
 

--- a/src/happy_eyeballs.rs
+++ b/src/happy_eyeballs.rs
@@ -44,9 +44,9 @@ use std::future::Future;
 use std::net::SocketAddr;
 use std::time::Duration;
 
+use crate::{debug, info, warn};
 use thiserror::Error;
 use tokio::task::JoinHandle;
-use tracing::{debug, info, warn};
 
 /// Which address family to prefer when interleaving connection attempts.
 ///
@@ -234,7 +234,7 @@ enum AttemptResult<C> {
 /// The task sends its result (success or failure) through the provided channel sender.
 fn spawn_attempt<F, Fut, C, E>(
     addr: SocketAddr,
-    attempt_num: usize,
+    _attempt_num: usize,
     connect_fn: &F,
     tx: &tokio::sync::mpsc::UnboundedSender<AttemptResult<C>>,
 ) -> JoinHandle<()>
@@ -244,7 +244,7 @@ where
     C: Send + 'static,
     E: std::fmt::Display + Send + 'static,
 {
-    debug!(addr = %addr, attempt = attempt_num, "Starting connection attempt");
+    debug!(addr = %addr, attempt = _attempt_num, "Starting connection attempt");
     let fut = connect_fn(addr);
     let tx_clone = tx.clone();
     tokio::spawn(async move {

--- a/src/high_level/connection.rs
+++ b/src/high_level/connection.rs
@@ -17,12 +17,13 @@ use std::{
     task::{Context, Poll, Waker, ready},
 };
 
+use crate::{debug_span, error};
 use bytes::Bytes;
 use pin_project_lite::pin_project;
 use rustc_hash::FxHashMap;
 use thiserror::Error;
 use tokio::sync::{Notify, futures::Notified, mpsc, oneshot};
-use tracing::{Instrument, Span, debug_span, error};
+use tracing::{Instrument, Span};
 
 use super::{
     ConnectionEvent,
@@ -70,8 +71,8 @@ impl Connecting {
         let driver = ConnectionDriver(conn.clone());
         runtime.spawn(Box::pin(
             async {
-                if let Err(e) = driver.await {
-                    tracing::error!("I/O error: {e}");
+                if let Err(_e) = driver.await {
+                    crate::error!("I/O error: {_e}");
                 }
             }
             .instrument(Span::current()),
@@ -145,7 +146,7 @@ impl Connecting {
             match self.conn.take() {
                 Some(conn) => Ok((Connection(conn), ZeroRttAccepted(self.connected))),
                 None => {
-                    tracing::error!("Connection state missing during 0-RTT acceptance");
+                    crate::error!("Connection state missing during 0-RTT acceptance");
                     Err(self)
                 }
             }
@@ -168,7 +169,7 @@ impl Connecting {
             let _ = x.await;
         }
         let conn = self.conn.as_ref().ok_or_else(|| {
-            tracing::error!("Connection state missing while retrieving handshake data");
+            crate::error!("Connection state missing while retrieving handshake data");
             ConnectionError::LocallyClosed
         })?;
         let inner = conn.state.lock("handshake");
@@ -1378,7 +1379,7 @@ impl State {
                 }
                 DatagramDropped(drop) => {
                     // Buffer overflow - surface to application via dedicated queue and notify
-                    tracing::debug!(
+                    crate::debug!(
                         datagrams = drop.datagrams,
                         bytes = drop.bytes,
                         "datagrams dropped due to receive buffer overflow"

--- a/src/high_level/endpoint.rs
+++ b/src/high_level/endpoint.rs
@@ -26,6 +26,7 @@ use super::{
     udp_transmit,
 };
 use crate::Instant;
+use crate::error;
 use crate::{
     ClientConfig, ConnectError, ConnectionError, ConnectionHandle, DatagramEvent, EndpointEvent,
     ServerConfig,
@@ -37,7 +38,6 @@ use rustc_hash::FxHashMap;
 #[cfg(all(not(wasm_browser), feature = "network-discovery"))]
 use socket2::{Domain, Protocol, Socket, Type};
 use tokio::sync::{Notify, futures::Notified, mpsc};
-use tracing::error;
 use tracing::{Instrument, Span};
 
 use super::{
@@ -88,8 +88,8 @@ impl Endpoint {
     pub fn client(addr: SocketAddr) -> io::Result<Self> {
         let socket = Socket::new(Domain::for_address(addr), Type::DGRAM, Some(Protocol::UDP))?;
         if addr.is_ipv6() {
-            if let Err(e) = socket.set_only_v6(false) {
-                tracing::debug!(%e, "unable to make socket dual-stack");
+            if let Err(_e) = socket.set_only_v6(false) {
+                crate::debug!(%_e, "unable to make socket dual-stack");
             }
         }
 
@@ -97,11 +97,11 @@ impl Endpoint {
         // and ensure reliable QUIC connections, especially with PQC
         use crate::config::buffer_defaults;
         let buffer_size = buffer_defaults::PLATFORM_DEFAULT;
-        if let Err(e) = socket.set_send_buffer_size(buffer_size) {
-            tracing::debug!(%e, "unable to set send buffer size to {}", buffer_size);
+        if let Err(_e) = socket.set_send_buffer_size(buffer_size) {
+            crate::debug!(%_e, "unable to set send buffer size to {}", buffer_size);
         }
-        if let Err(e) = socket.set_recv_buffer_size(buffer_size) {
-            tracing::debug!(%e, "unable to set recv buffer size to {}", buffer_size);
+        if let Err(_e) = socket.set_recv_buffer_size(buffer_size) {
+            crate::debug!(%_e, "unable to set recv buffer size to {}", buffer_size);
         }
 
         socket.bind(&addr.into())?;
@@ -142,8 +142,8 @@ impl Endpoint {
 
         // Enable dual-stack for IPv6 sockets (consistent with client() behavior)
         if addr.is_ipv6() {
-            if let Err(e) = socket.set_only_v6(false) {
-                tracing::debug!(%e, "unable to make server socket dual-stack");
+            if let Err(_e) = socket.set_only_v6(false) {
+                crate::debug!(%_e, "unable to make server socket dual-stack");
             }
         }
 
@@ -153,11 +153,11 @@ impl Endpoint {
         // and ensure reliable QUIC connections, especially with PQC
         use crate::config::buffer_defaults;
         let buffer_size = buffer_defaults::PLATFORM_DEFAULT;
-        if let Err(e) = socket.set_send_buffer_size(buffer_size) {
-            tracing::debug!(%e, "unable to set send buffer size to {}", buffer_size);
+        if let Err(_e) = socket.set_send_buffer_size(buffer_size) {
+            crate::debug!(%_e, "unable to set send buffer size to {}", buffer_size);
         }
-        if let Err(e) = socket.set_recv_buffer_size(buffer_size) {
-            tracing::debug!(%e, "unable to set recv buffer size to {}", buffer_size);
+        if let Err(_e) = socket.set_recv_buffer_size(buffer_size) {
+            crate::debug!(%_e, "unable to set recv buffer size to {}", buffer_size);
         }
 
         socket.bind(&addr.into())?;
@@ -224,8 +224,8 @@ impl Endpoint {
         let driver = EndpointDriver(rc.clone());
         runtime.spawn(Box::pin(
             async {
-                if let Err(e) = driver.await {
-                    tracing::error!("I/O error: {}", e);
+                if let Err(_e) = driver.await {
+                    crate::error!("I/O error: {}", _e);
                 }
             }
             .instrument(Span::current()),
@@ -677,10 +677,10 @@ impl State {
         for (ch, event) in self.inner.drain_relay_events() {
             did_work = true;
             if let Some(sender) = self.recv_state.connections.senders.get_mut(&ch) {
-                tracing::debug!("Sending relay event to connection {:?}", ch);
+                crate::debug!("Sending relay event to connection {:?}", ch);
                 let _ = sender.send(ConnectionEvent::Proto(event));
             } else {
-                tracing::warn!(
+                crate::warn!(
                     "Cannot send relay event: connection {:?} not found in senders",
                     ch
                 );

--- a/src/high_level/incoming.rs
+++ b/src/high_level/incoming.rs
@@ -13,9 +13,9 @@ use std::{
     task::{Context, Poll},
 };
 
+use crate::error;
 use crate::{ConnectionError, ConnectionId, ServerConfig};
 use thiserror::Error;
-use tracing::error;
 
 use super::{
     connection::{Connecting, Connection},

--- a/src/high_level/mutex.rs
+++ b/src/high_level/mutex.rs
@@ -15,9 +15,9 @@ use std::{
 #[cfg(feature = "lock_tracking")]
 mod tracking {
     use super::*;
+    use crate::warn;
     use crate::{Duration, Instant};
     use std::collections::VecDeque;
-    use tracing::warn;
 
     #[derive(Debug)]
     struct Inner<T> {

--- a/src/high_level/runtime.rs
+++ b/src/high_level/runtime.rs
@@ -15,8 +15,8 @@ use std::{
     task::{Context, Poll},
 };
 
+use crate::error;
 use quinn_udp::{RecvMeta, Transmit};
-use tracing::error;
 
 use crate::Instant;
 

--- a/src/high_level/work_limiter.rs
+++ b/src/high_level/work_limiter.rs
@@ -5,8 +5,8 @@
 //
 // Full details available at https://saorsalabs.com/licenses
 
+use crate::error;
 use crate::{Duration, Instant};
-use tracing::error;
 
 /// Limits the amount of time spent on a certain type of work in a cycle
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,7 @@
 #![allow(non_snake_case)]
 #![allow(clippy::unnecessary_literal_unwrap)]
 #![allow(clippy::assertions_on_constants)]
+pub(crate) mod logging_macros;
 
 use std::{
     fmt,

--- a/src/link_transport_impl.rs
+++ b/src/link_transport_impl.rs
@@ -40,10 +40,10 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::{Arc, RwLock};
 
+use crate::{debug, error, info, warn};
 use bytes::Bytes;
 use futures_util::StreamExt;
 use tokio::sync::{RwLock as TokioRwLock, broadcast};
-use tracing::{debug, error, info, warn};
 
 use crate::high_level::{
     Connection as HighLevelConnection, RecvStream as HighLevelRecvStream,
@@ -556,8 +556,8 @@ impl P2pLinkTransport {
                         }
                     }
                 }
-                Err(broadcast::error::RecvError::Lagged(n)) => {
-                    warn!("Event forwarder lagged by {} events", n);
+                Err(broadcast::error::RecvError::Lagged(_n)) => {
+                    warn!("Event forwarder lagged by {} events", _n);
                 }
                 Err(broadcast::error::RecvError::Closed) => {
                     debug!("Event forwarder channel closed");
@@ -1010,14 +1010,14 @@ where
             let handlers = self.handlers.read().await;
             let mut seen = std::collections::HashSet::new();
 
-            for (stream_type, handler) in handlers.iter() {
+            for (_stream_type, handler) in handlers.iter() {
                 let ptr = Arc::as_ptr(handler) as usize;
                 if seen.insert(ptr) {
-                    if let Err(e) = handler.shutdown().await {
+                    if let Err(_e) = handler.shutdown().await {
                         error!(
                             handler = %handler.name(),
-                            stream_type = %stream_type,
-                            error = %e,
+                            stream_type = %_stream_type,
+                            error = %_e,
                             "Handler shutdown error"
                         );
                     }
@@ -1028,9 +1028,9 @@ where
         // Close all connections
         {
             let connections = self.connections.read().await;
-            for (addr, conn) in connections.iter() {
+            for (_addr, conn) in connections.iter() {
                 conn.close(0, "transport shutdown");
-                debug!(addr = %addr, "Closed connection");
+                debug!(addr = %_addr, "Closed connection");
             }
         }
 
@@ -1201,8 +1201,8 @@ where
                                 ).await;
                             });
                         }
-                        Some(Err(e)) => {
-                            warn!(error = %e, "Error accepting connection");
+                        Some(Err(_e)) => {
+                            warn!(error = %_e, "Error accepting connection");
                         }
                         None => {
                             debug!("Incoming connection stream ended");
@@ -1279,8 +1279,8 @@ where
                                 ).await;
                             });
                         }
-                        Some(Err(e)) => {
-                            warn!(addr = %addr, error = %e, "Error accepting stream");
+                        Some(Err(_e)) => {
+                            warn!(addr = %addr, error = %_e, "Error accepting stream");
                         }
                         None => {
                             debug!(addr = %addr, "Connection closed");
@@ -1316,8 +1316,8 @@ where
         // Read incoming data
         let data = match recv.read_to_end(max_message_size).await {
             Ok(data) => Bytes::from(data),
-            Err(e) => {
-                warn!(addr = %addr, error = %e, "Failed to read stream");
+            Err(_e) => {
+                warn!(addr = %addr, error = %_e, "Failed to read stream");
                 return;
             }
         };
@@ -1342,16 +1342,16 @@ where
             .await
         {
             Ok(Some(response)) => {
-                if let Err(e) = send.write_all(&response).await {
-                    warn!(addr = %addr, error = %e, "Failed to send response");
+                if let Err(_e) = send.write_all(&response).await {
+                    warn!(addr = %addr, error = %_e, "Failed to send response");
                 }
                 let _ = send.finish();
             }
             Ok(None) => {
                 let _ = send.finish();
             }
-            Err(e) => {
-                error!(addr = %addr, error = %e, "Handler error");
+            Err(_e) => {
+                error!(addr = %addr, error = %_e, "Handler error");
                 let _ = send.finish();
             }
         }

--- a/src/logging/components.rs
+++ b/src/logging/components.rs
@@ -5,11 +5,11 @@
 //
 // Full details available at https://saorsalabs.com/licenses
 
+use crate::{debug, trace};
 /// Component-specific logging functions
 ///
 /// Provides specialized logging for different components of the QUIC stack
 use std::collections::HashMap;
-use tracing::{debug, trace};
 
 use crate::{ConnectionId, Frame};
 
@@ -276,49 +276,49 @@ pub fn log_error_with_context(error: &dyn std::error::Error, context: super::Err
 
 /// Log detailed frame information
 #[allow(dead_code)]
-pub(crate) fn log_frame_details(frame: &Frame, direction: &str, conn_id: &ConnectionId) {
+pub(crate) fn log_frame_details(_frame: &Frame, _direction: &str, _conn_id: &ConnectionId) {
     trace!(
         target: "saorsa_transport::frame::details",
-        conn_id = ?conn_id,
-        direction = direction,
-        frame_type = ?frame.ty(),
+        conn_id = ?_conn_id,
+        direction = _direction,
+        frame_type = ?_frame.ty(),
         "Processing frame"
     );
 
-    match frame {
-        Frame::ObservedAddress(addr) => {
+    match _frame {
+        Frame::ObservedAddress(_addr) => {
             debug!(
                 target: "saorsa_transport::frame::observed_address",
-                conn_id = ?conn_id,
-                sequence_number = addr.sequence_number.0,
-                address = ?addr.address,
+                conn_id = ?_conn_id,
+                sequence_number = _addr.sequence_number.0,
+                address = ?_addr.address,
                 "OBSERVED_ADDRESS frame"
             );
         }
-        Frame::AddAddress(addr) => {
+        Frame::AddAddress(_addr) => {
             debug!(
                 target: "saorsa_transport::frame::add_address",
-                conn_id = ?conn_id,
-                sequence = addr.sequence.0,
-                address = ?addr.address,
-                priority = addr.priority.0,
+                conn_id = ?_conn_id,
+                sequence = _addr.sequence.0,
+                address = ?_addr.address,
+                priority = _addr.priority.0,
                 "ADD_ADDRESS frame"
             );
         }
-        Frame::PunchMeNow(punch) => {
+        Frame::PunchMeNow(_punch) => {
             debug!(
                 target: "saorsa_transport::frame::punch_me_now",
-                conn_id = ?conn_id,
-                paired_with_sequence_number = punch.paired_with_sequence_number.0,
-                round = punch.round.0,
+                conn_id = ?_conn_id,
+                paired_with_sequence_number = _punch.paired_with_sequence_number.0,
+                round = _punch.round.0,
                 "PUNCH_ME_NOW frame"
             );
         }
         _ => {
             trace!(
                 target: "saorsa_transport::frame::other",
-                conn_id = ?conn_id,
-                frame_type = ?frame.ty(),
+                conn_id = ?_conn_id,
+                frame_type = ?_frame.ty(),
                 "Standard QUIC frame"
             );
         }

--- a/src/logging/lifecycle.rs
+++ b/src/logging/lifecycle.rs
@@ -5,11 +5,12 @@
 //
 // Full details available at https://saorsalabs.com/licenses
 
+use crate::{debug, info, warn};
 /// Connection lifecycle logging
 ///
 /// Tracks and logs the complete lifecycle of QUIC connections
 use std::collections::HashMap;
-use tracing::{Span, debug, info, warn};
+use tracing::Span;
 
 use super::{ConnectionRole, LogEvent, logger};
 use crate::{ConnectionId, Duration, Instant};
@@ -216,55 +217,55 @@ impl ConnectionLifecycle {
 
 /// Log connection lifecycle events
 pub fn log_connection_initiated(
-    conn_id: &ConnectionId,
-    role: ConnectionRole,
-    remote_addr: std::net::SocketAddr,
+    _conn_id: &ConnectionId,
+    _role: ConnectionRole,
+    _remote_addr: std::net::SocketAddr,
 ) {
     info!(
         target: "saorsa_transport::connection::lifecycle",
-        conn_id = ?conn_id,
-        role = ?role,
-        remote_addr = %remote_addr,
+        conn_id = ?_conn_id,
+        role = ?_role,
+        remote_addr = %_remote_addr,
         "Connection initiated"
     );
 }
 
 /// Log when a handshake process starts for a connection
-pub fn log_handshake_started(conn_id: &ConnectionId) {
+pub fn log_handshake_started(_conn_id: &ConnectionId) {
     debug!(
         target: "saorsa_transport::connection::lifecycle",
-        conn_id = ?conn_id,
+        conn_id = ?_conn_id,
         "Handshake started"
     );
 }
 
 /// Log successful handshake completion and its duration
-pub fn log_handshake_completed(conn_id: &ConnectionId, duration: Duration) {
+pub fn log_handshake_completed(_conn_id: &ConnectionId, _duration: Duration) {
     info!(
         target: "saorsa_transport::connection::lifecycle",
-        conn_id = ?conn_id,
-        duration_ms = duration.as_millis(),
+        conn_id = ?_conn_id,
+        duration_ms = _duration.as_millis(),
         "Handshake completed"
     );
 }
 
 /// Log connection established event including QUIC version info
-pub fn log_connection_established(conn_id: &ConnectionId, negotiated_version: u32) {
+pub fn log_connection_established(_conn_id: &ConnectionId, _negotiated_version: u32) {
     info!(
         target: "saorsa_transport::connection::lifecycle",
-        conn_id = ?conn_id,
-        negotiated_version = format!("0x{:08x}", negotiated_version),
+        conn_id = ?_conn_id,
+        negotiated_version = format!("0x{:08x}", _negotiated_version),
         "Connection established"
     );
 }
 
 /// Log a connection migration from one path to another
-pub fn log_connection_migration(conn_id: &ConnectionId, old_path: &str, new_path: &str) {
+pub fn log_connection_migration(_conn_id: &ConnectionId, _old_path: &str, _new_path: &str) {
     info!(
         target: "saorsa_transport::connection::lifecycle",
-        conn_id = ?conn_id,
-        old_path = old_path,
-        new_path = new_path,
+        conn_id = ?_conn_id,
+        old_path = _old_path,
+        new_path = _new_path,
         "Connection migrated to new path"
     );
 }
@@ -290,11 +291,11 @@ pub fn log_connection_closed(conn_id: &ConnectionId, reason: &str, error_code: O
 }
 
 /// Log a connection lost event caused by unexpected conditions
-pub fn log_connection_lost(conn_id: &ConnectionId, reason: &str) {
+pub fn log_connection_lost(_conn_id: &ConnectionId, _reason: &str) {
     warn!(
         target: "saorsa_transport::connection::lifecycle",
-        conn_id = ?conn_id,
-        reason = reason,
+        conn_id = ?_conn_id,
+        reason = _reason,
         "Connection lost"
     );
 }

--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -15,7 +15,8 @@ use std::net::SocketAddr;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
-use tracing::{Level, Span, debug, error, info, trace, warn};
+use crate::{debug, error, info, trace, warn};
+use tracing::{Level, Span};
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
 
 use crate::{

--- a/src/logging_macros.rs
+++ b/src/logging_macros.rs
@@ -1,0 +1,83 @@
+//! Conditional logging macros that compile to nothing in release builds.
+//!
+//! These macros wrap `tracing` and are gated behind `cfg(debug_assertions)`,
+//! ensuring that no tracing callsite metadata (module paths, file paths,
+//! field names) is present in release binaries.
+
+/// Emit a TRACE-level event (debug builds only).
+#[macro_export]
+macro_rules! trace {
+    ($($arg:tt)*) => {{
+        #[cfg(debug_assertions)]
+        { tracing::trace!($($arg)*) }
+    }};
+}
+
+/// Emit a DEBUG-level event (debug builds only).
+#[macro_export]
+macro_rules! debug {
+    ($($arg:tt)*) => {{
+        #[cfg(debug_assertions)]
+        { tracing::debug!($($arg)*) }
+    }};
+}
+
+/// Emit an INFO-level event (debug builds only).
+#[macro_export]
+macro_rules! info {
+    ($($arg:tt)*) => {{
+        #[cfg(debug_assertions)]
+        { tracing::info!($($arg)*) }
+    }};
+}
+
+/// Emit a WARN-level event (debug builds only).
+#[macro_export]
+macro_rules! warn {
+    ($($arg:tt)*) => {{
+        #[cfg(debug_assertions)]
+        { tracing::warn!($($arg)*) }
+    }};
+}
+
+/// Emit an ERROR-level event (debug builds only).
+#[macro_export]
+macro_rules! error {
+    ($($arg:tt)*) => {{
+        #[cfg(debug_assertions)]
+        { tracing::error!($($arg)*) }
+    }};
+}
+
+/// Create a TRACE-level span (debug builds only).
+#[macro_export]
+macro_rules! trace_span {
+    ($($arg:tt)*) => {{
+        #[cfg(debug_assertions)]
+        { tracing::trace_span!($($arg)*) }
+        #[cfg(not(debug_assertions))]
+        { tracing::Span::none() }
+    }};
+}
+
+/// Create a DEBUG-level span (debug builds only).
+#[macro_export]
+macro_rules! debug_span {
+    ($($arg:tt)*) => {{
+        #[cfg(debug_assertions)]
+        { tracing::debug_span!($($arg)*) }
+        #[cfg(not(debug_assertions))]
+        { tracing::Span::none() }
+    }};
+}
+
+/// Create an INFO-level span (debug builds only).
+#[macro_export]
+macro_rules! info_span {
+    ($($arg:tt)*) => {{
+        #[cfg(debug_assertions)]
+        { tracing::info_span!($($arg)*) }
+        #[cfg(not(debug_assertions))]
+        { tracing::Span::none() }
+    }};
+}

--- a/src/masque/integration.rs
+++ b/src/masque/integration.rs
@@ -331,7 +331,7 @@ impl RelayManager {
         let mut relays = self.relays.write().await;
         if !relays.contains_key(&address) && relays.len() < self.config.max_relays {
             relays.insert(address, RelayNodeInfo::new(address));
-            tracing::debug!(relay = %address, "Added relay node");
+            crate::debug!(relay = %address, "Added relay node");
         }
     }
 
@@ -344,7 +344,7 @@ impl RelayManager {
         let mut relays = self.relays.write().await;
         if !relays.contains_key(&primary) && relays.len() < self.config.max_relays {
             relays.insert(primary, RelayNodeInfo::new_dual_stack(primary, secondary));
-            tracing::debug!(
+            crate::debug!(
                 primary = %primary,
                 secondary = %secondary,
                 "Added dual-stack relay node"
@@ -405,7 +405,7 @@ impl RelayManager {
             if info.client.is_some() {
                 self.stats.record_disconnect();
             }
-            tracing::debug!(relay = %address, "Removed relay node");
+            crate::debug!(relay = %address, "Removed relay node");
         }
     }
 
@@ -477,7 +477,7 @@ impl RelayManager {
 
         self.stats.record_attempt(true);
 
-        tracing::info!(
+        crate::info!(
             relay = %relay,
             public_addr = ?public_addr,
             "Relay connection established"
@@ -534,7 +534,7 @@ impl RelayManager {
 
         self.stats.record_sent(payload.len() as u64);
 
-        tracing::trace!(
+        crate::trace!(
             relay = %relay,
             target = %target,
             bytes = payload.len(),
@@ -561,7 +561,7 @@ impl RelayManager {
             info.client = None;
         }
 
-        tracing::info!("Closed all relay connections");
+        crate::info!("Closed all relay connections");
     }
 
     /// Get number of active relay connections
@@ -659,7 +659,7 @@ impl RelayManager {
                     self.stats.record_disconnect();
                     disconnected += 1;
 
-                    tracing::warn!(
+                    crate::warn!(
                         relay = %info.address,
                         "Health check: relay disconnected"
                     );
@@ -704,7 +704,7 @@ impl RelayManager {
 
                 let disconnected = manager.health_check_relays().await;
                 if disconnected > 0 {
-                    tracing::info!(disconnected, "Keepalive: detected disconnected relays");
+                    crate::info!(disconnected, "Keepalive: detected disconnected relays");
                 }
             }
         })

--- a/src/masque/migration.rs
+++ b/src/masque/migration.rs
@@ -357,7 +357,7 @@ impl MigrationCoordinator {
             },
         );
 
-        tracing::debug!(peer = %peer, "Scheduled migration probe");
+        crate::debug!(peer = %peer, "Scheduled migration probe");
     }
 
     /// Poll migration progress - should be called periodically
@@ -429,7 +429,7 @@ impl MigrationCoordinator {
             self.stats.record_probe();
         }
 
-        tracing::info!(
+        crate::info!(
             peer = %peer,
             candidates = probe_candidates.len(),
             "Started probing candidate paths"
@@ -457,7 +457,7 @@ impl MigrationCoordinator {
             );
             self.stats
                 .record_attempt(false, self.config.validation_timeout);
-            tracing::warn!(peer = %peer, "Migration failed after {} attempts", attempts);
+            crate::warn!(peer = %peer, "Migration failed after {} attempts", attempts);
         } else {
             // Schedule another attempt
             states.insert(
@@ -466,7 +466,7 @@ impl MigrationCoordinator {
                     probe_at: Instant::now() + self.config.probe_interval,
                 },
             );
-            tracing::debug!(peer = %peer, "Scheduling retry after probe timeout");
+            crate::debug!(peer = %peer, "Scheduling retry after probe timeout");
         }
     }
 
@@ -497,7 +497,7 @@ impl MigrationCoordinator {
                 },
             );
 
-            tracing::info!(
+            crate::info!(
                 peer = %peer,
                 path = %path,
                 rtt_ms = rtt.as_millis(),
@@ -522,7 +522,7 @@ impl MigrationCoordinator {
                 },
             );
 
-            tracing::info!(peer = %peer, path = %path, "Migration completed - direct path active");
+            crate::info!(peer = %peer, path = %path, "Migration completed - direct path active");
         }
     }
 
@@ -545,7 +545,7 @@ impl MigrationCoordinator {
             },
         );
 
-        tracing::warn!(peer = %peer, reason = reason, "Forced fallback to relay");
+        crate::warn!(peer = %peer, reason = reason, "Forced fallback to relay");
     }
 
     /// Reset migration state for a peer

--- a/src/masque/relay_client.rs
+++ b/src/masque/relay_client.rs
@@ -248,7 +248,7 @@ impl MasqueRelayClient {
         // Store public address if provided
         if let Some(addr) = response.proxy_public_address {
             *self.public_address.write().await = Some(addr);
-            tracing::info!(
+            crate::info!(
                 relay = %self.relay_address,
                 public_addr = %addr,
                 "MASQUE relay session established"
@@ -267,9 +267,12 @@ impl MasqueRelayClient {
             Capsule::CompressionAck(ack) => self.handle_ack(ack).await,
             Capsule::CompressionClose(close) => self.handle_close(close).await,
             Capsule::CompressionAssign(assign) => self.handle_assign(assign).await,
-            Capsule::Unknown { capsule_type, .. } => {
-                tracing::debug!(
-                    capsule_type = capsule_type.into_inner(),
+            Capsule::Unknown {
+                capsule_type: _capsule_type,
+                ..
+            } => {
+                crate::debug!(
+                    capsule_type = _capsule_type.into_inner(),
                     "Ignoring unknown capsule from relay"
                 );
                 Ok(None)
@@ -287,7 +290,7 @@ impl MasqueRelayClient {
         match result {
             Ok(_) => {
                 self.stats.record_context();
-                tracing::debug!(
+                crate::debug!(
                     context_id = ack.context_id.into_inner(),
                     "Context acknowledged by relay"
                 );
@@ -295,7 +298,7 @@ impl MasqueRelayClient {
                 // Flush pending datagrams for this context - payloads can be re-sent
                 let flushed_payloads = self.flush_pending_for_context(ack.context_id).await;
                 if !flushed_payloads.is_empty() {
-                    tracing::debug!(
+                    crate::debug!(
                         context_id = ack.context_id.into_inner(),
                         count = flushed_payloads.len(),
                         "Flushed pending datagrams for acknowledged context"
@@ -303,10 +306,10 @@ impl MasqueRelayClient {
                 }
                 Ok(None)
             }
-            Err(e) => {
-                tracing::warn!(
+            Err(_e) => {
+                crate::warn!(
                     context_id = ack.context_id.into_inner(),
-                    error = %e,
+                    error = %_e,
                     "Unexpected ACK from relay"
                 );
                 Ok(None)
@@ -330,7 +333,7 @@ impl MasqueRelayClient {
         let mut mgr = self.context_manager.write().await;
         let _ = mgr.close(close.context_id);
 
-        tracing::debug!(
+        crate::debug!(
             context_id = close.context_id.into_inner(),
             "Context closed by relay"
         );
@@ -345,10 +348,10 @@ impl MasqueRelayClient {
         // Register the remote context
         {
             let mut mgr = self.context_manager.write().await;
-            if let Err(e) = mgr.register_remote(assign.context_id, target) {
-                tracing::warn!(
+            if let Err(_e) = mgr.register_remote(assign.context_id, target) {
+                crate::warn!(
                     context_id = assign.context_id.into_inner(),
-                    error = %e,
+                    error = %_e,
                     "Failed to register remote context"
                 );
                 // Send CLOSE to reject
@@ -551,7 +554,7 @@ impl MasqueRelayClient {
         self.target_to_context.write().await.clear();
         self.pending_datagrams.write().await.clear();
 
-        tracing::info!(
+        crate::info!(
             relay = %self.relay_address,
             "MASQUE relay client closed"
         );

--- a/src/masque/relay_server.rs
+++ b/src/masque/relay_server.rs
@@ -427,7 +427,7 @@ impl MasqueRelayServer {
             self.record_bridged_connection();
         }
 
-        tracing::info!(
+        crate::info!(
             session_id = session_id,
             client = %client_addr,
             public_addr = %advertised_address,
@@ -635,7 +635,7 @@ impl MasqueRelayServer {
 
         self.stats.record_session_terminated();
 
-        tracing::info!(session_id = session_id, "MASQUE relay session closed");
+        crate::info!(session_id = session_id, "MASQUE relay session closed");
 
         Ok(())
     }
@@ -671,17 +671,17 @@ impl MasqueRelayServer {
 
         let count = expired_ids.len();
         for session_id in expired_ids {
-            if let Err(e) = self.close_session(session_id).await {
-                tracing::warn!(
+            if let Err(_e) = self.close_session(session_id).await {
+                crate::warn!(
                     session_id = session_id,
-                    error = %e,
+                    error = %_e,
                     "Failed to close expired session"
                 );
             }
         }
 
         if count > 0 {
-            tracing::debug!(count = count, "Cleaned up expired MASQUE sessions");
+            crate::debug!(count = count, "Cleaned up expired MASQUE sessions");
         }
 
         count

--- a/src/masque/relay_session.rs
+++ b/src/masque/relay_session.rs
@@ -330,11 +330,14 @@ impl RelaySession {
             Capsule::CompressionAssign(assign) => self.handle_compression_assign(assign),
             Capsule::CompressionAck(ack) => self.handle_compression_ack(ack),
             Capsule::CompressionClose(close) => self.handle_compression_close(close),
-            Capsule::Unknown { capsule_type, .. } => {
+            Capsule::Unknown {
+                capsule_type: _capsule_type,
+                ..
+            } => {
                 // Unknown capsules should be ignored per spec
-                tracing::debug!(
+                crate::debug!(
                     session_id = self.session_id,
-                    capsule_type = capsule_type.into_inner(),
+                    capsule_type = _capsule_type.into_inner(),
                     "Ignoring unknown capsule type"
                 );
                 Ok(None)
@@ -385,11 +388,11 @@ impl RelaySession {
                     assign.context_id,
                 ))))
             }
-            Err(e) => {
-                tracing::warn!(
+            Err(_e) => {
+                crate::warn!(
                     session_id = self.session_id,
                     context_id = assign.context_id.into_inner(),
-                    error = %e,
+                    error = %_e,
                     "Failed to register context"
                 );
                 // Send CLOSE on error
@@ -404,11 +407,11 @@ impl RelaySession {
     fn handle_compression_ack(&mut self, ack: CompressionAck) -> RelayResult<Option<Capsule>> {
         match self.context_manager.handle_ack(ack.context_id) {
             Ok(_) => Ok(None),
-            Err(e) => {
-                tracing::warn!(
+            Err(_e) => {
+                crate::warn!(
                     session_id = self.session_id,
                     context_id = ack.context_id.into_inner(),
-                    error = %e,
+                    error = %_e,
                     "Unexpected ACK for unknown context"
                 );
                 Ok(None)
@@ -429,11 +432,11 @@ impl RelaySession {
         // Close the context
         match self.context_manager.close(close.context_id) {
             Ok(_) | Err(ContextError::UnknownContext) => Ok(None),
-            Err(e) => {
-                tracing::warn!(
+            Err(_e) => {
+                crate::warn!(
                     session_id = self.session_id,
                     context_id = close.context_id.into_inner(),
-                    error = %e,
+                    error = %_e,
                     "Error closing context"
                 );
                 Ok(None)

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -79,17 +79,17 @@ fn broadcast_address_to_peers(
     priority: u32,
 ) {
     for mut entry in connections.iter_mut() {
-        let remote_addr = *entry.key();
+        let _remote_addr = *entry.key();
         let conn = entry.value_mut();
         match conn.send_nat_address_advertisement(address, priority) {
-            Ok(seq) => {
+            Ok(_seq) => {
                 info!(
                     "Sent ADD_ADDRESS to {}: addr={}, seq={}",
-                    remote_addr, address, seq
+                    _remote_addr, address, _seq
                 );
             }
-            Err(e) => {
-                debug!("Failed to send ADD_ADDRESS to {}: {:?}", remote_addr, e);
+            Err(_e) => {
+                debug!("Failed to send ADD_ADDRESS to {}: {:?}", _remote_addr, _e);
             }
         }
     }
@@ -168,7 +168,7 @@ impl TransportCandidate {
     }
 }
 
-use tracing::{debug, error, info, trace, warn};
+use crate::{debug, error, info, trace, warn};
 
 use std::sync::atomic::{AtomicBool, Ordering};
 // Use parking_lot for faster, non-poisoning locks that work better with async code
@@ -1360,7 +1360,7 @@ impl NatTraversalEndpoint {
             let transport_count = online_providers.len();
 
             if transport_count > 0 {
-                let transport_names: Vec<_> = online_providers
+                let _transport_names: Vec<_> = online_providers
                     .iter()
                     .map(|p| format!("{}({})", p.name(), p.transport_type()))
                     .collect();
@@ -1368,20 +1368,20 @@ impl NatTraversalEndpoint {
                 debug!(
                     "Listening on {} transports: {}",
                     transport_count,
-                    transport_names.join(", ")
+                    _transport_names.join(", ")
                 );
 
                 let mut handles = Vec::new();
 
                 for provider in online_providers {
                     let transport_type = provider.transport_type();
-                    let transport_name = provider.name().to_string();
+                    let _transport_name = provider.name().to_string();
 
                     // Skip UDP transports since they're already handled by the QUIC endpoint
                     if transport_type == crate::transport::TransportType::Udp {
                         debug!(
                             "Skipping UDP transport '{}' (already handled by QUIC endpoint)",
-                            transport_name
+                            _transport_name
                         );
                         continue;
                     }
@@ -1395,21 +1395,24 @@ impl NatTraversalEndpoint {
                     let event_tx_clone = endpoint.constrained_event_tx.clone();
 
                     let handle = tokio::spawn(async move {
-                        debug!("Started listening on transport '{}'", transport_name);
+                        debug!("Started listening on transport '{}'", _transport_name);
 
                         loop {
                             // Fallback shutdown check: notify_waiters() can be missed
                             // if no task is awaiting .notified() at the moment shutdown()
                             // fires, so we check the AtomicBool on each iteration.
                             if shutdown_flag_clone.load(std::sync::atomic::Ordering::Relaxed) {
-                                debug!("Shutting down transport listener for '{}'", transport_name);
+                                debug!(
+                                    "Shutting down transport listener for '{}'",
+                                    _transport_name
+                                );
                                 break;
                             }
 
                             tokio::select! {
                                 // Instant shutdown via Notify
                                 _ = shutdown_notify_clone.notified() => {
-                                    debug!("Shutting down transport listener for '{}'", transport_name);
+                                    debug!("Shutting down transport listener for '{}'", _transport_name);
                                     break;
                                 }
 
@@ -1421,7 +1424,7 @@ impl NatTraversalEndpoint {
                                                 "Received {} bytes from {} on transport '{}' ({})",
                                                 datagram.data.len(),
                                                 datagram.source,
-                                                transport_name,
+                                                _transport_name,
                                                 transport_type
                                             );
 
@@ -1434,10 +1437,10 @@ impl NatTraversalEndpoint {
                                                 let mut engine = engine_clone.lock();
                                                 match engine.process_incoming(remote_addr, &datagram.data) {
                                                     Ok(responses) => responses,
-                                                    Err(e) => {
+                                                    Err(_e) => {
                                                         debug!(
                                                             "Constrained engine error processing packet from {}: {:?}",
-                                                            datagram.source, e
+                                                            datagram.source, _e
                                                         );
                                                         Vec::new()
                                                     }
@@ -1449,10 +1452,10 @@ impl NatTraversalEndpoint {
                                                 if let Some(registry) = &registry_clone {
                                                     for (_dest_addr, response_data) in responses {
                                                         // Send response back to the source transport address
-                                                        if let Err(e) = registry.send(&response_data, &datagram.source).await {
+                                                        if let Err(_e) = registry.send(&response_data, &datagram.source).await {
                                                             debug!(
                                                                 "Failed to send constrained response to {}: {:?}",
-                                                                datagram.source, e
+                                                                datagram.source, _e
                                                             );
                                                         }
                                                     }
@@ -1471,14 +1474,14 @@ impl NatTraversalEndpoint {
                                                         event,
                                                         remote_addr: source_addr.clone(),
                                                     };
-                                                    if let Err(e) = event_tx_clone.send(event_with_addr) {
-                                                        debug!("Failed to forward constrained event: {}", e);
+                                                    if let Err(_e) = event_tx_clone.send(event_with_addr) {
+                                                        debug!("Failed to forward constrained event: {}", _e);
                                                     }
                                                 }
                                             }
                                         }
                                         None => {
-                                            debug!("Transport '{}' inbound channel closed", transport_name);
+                                            debug!("Transport '{}' inbound channel closed", _transport_name);
                                             break;
                                         }
                                     }
@@ -1486,7 +1489,7 @@ impl NatTraversalEndpoint {
                             }
                         }
 
-                        debug!("Transport listener for '{}' terminated", transport_name);
+                        debug!("Transport listener for '{}' terminated", _transport_name);
                     });
 
                     handles.push(handle);
@@ -1758,7 +1761,7 @@ impl NatTraversalEndpoint {
             let transport_count = online_providers.len();
 
             if transport_count > 0 {
-                let transport_names: Vec<_> = online_providers
+                let _transport_names: Vec<_> = online_providers
                     .iter()
                     .map(|p| format!("{}({})", p.name(), p.transport_type()))
                     .collect();
@@ -1766,20 +1769,20 @@ impl NatTraversalEndpoint {
                 debug!(
                     "Listening on {} transports: {}",
                     transport_count,
-                    transport_names.join(", ")
+                    _transport_names.join(", ")
                 );
 
                 let mut handles = Vec::new();
 
                 for provider in online_providers {
                     let transport_type = provider.transport_type();
-                    let transport_name = provider.name().to_string();
+                    let _transport_name = provider.name().to_string();
 
                     // Skip UDP transports since they're already handled by the QUIC endpoint
                     if transport_type == crate::transport::TransportType::Udp {
                         debug!(
                             "Skipping UDP transport '{}' (already handled by QUIC endpoint)",
-                            transport_name
+                            _transport_name
                         );
                         continue;
                     }
@@ -1793,21 +1796,24 @@ impl NatTraversalEndpoint {
                     let event_tx_clone = endpoint.constrained_event_tx.clone();
 
                     let handle = tokio::spawn(async move {
-                        debug!("Started listening on transport '{}'", transport_name);
+                        debug!("Started listening on transport '{}'", _transport_name);
 
                         loop {
                             // Fallback shutdown check: notify_waiters() can be missed
                             // if no task is awaiting .notified() at the moment shutdown()
                             // fires, so we check the AtomicBool on each iteration.
                             if shutdown_flag_clone.load(std::sync::atomic::Ordering::Relaxed) {
-                                debug!("Shutting down transport listener for '{}'", transport_name);
+                                debug!(
+                                    "Shutting down transport listener for '{}'",
+                                    _transport_name
+                                );
                                 break;
                             }
 
                             tokio::select! {
                                 // Instant shutdown via Notify
                                 _ = shutdown_notify_clone.notified() => {
-                                    debug!("Shutting down transport listener for '{}'", transport_name);
+                                    debug!("Shutting down transport listener for '{}'", _transport_name);
                                     break;
                                 }
 
@@ -1819,7 +1825,7 @@ impl NatTraversalEndpoint {
                                                 "Received {} bytes from {} on transport '{}' ({})",
                                                 datagram.data.len(),
                                                 datagram.source,
-                                                transport_name,
+                                                _transport_name,
                                                 transport_type
                                             );
 
@@ -1832,10 +1838,10 @@ impl NatTraversalEndpoint {
                                                 let mut engine = engine_clone.lock();
                                                 match engine.process_incoming(remote_addr, &datagram.data) {
                                                     Ok(responses) => responses,
-                                                    Err(e) => {
+                                                    Err(_e) => {
                                                         debug!(
                                                             "Constrained engine error processing packet from {}: {:?}",
-                                                            datagram.source, e
+                                                            datagram.source, _e
                                                         );
                                                         Vec::new()
                                                     }
@@ -1847,10 +1853,10 @@ impl NatTraversalEndpoint {
                                                 if let Some(registry) = &registry_clone {
                                                     for (_dest_addr, response_data) in responses {
                                                         // Send response back to the source transport address
-                                                        if let Err(e) = registry.send(&response_data, &datagram.source).await {
+                                                        if let Err(_e) = registry.send(&response_data, &datagram.source).await {
                                                             debug!(
                                                                 "Failed to send constrained response to {}: {:?}",
-                                                                datagram.source, e
+                                                                datagram.source, _e
                                                             );
                                                         }
                                                     }
@@ -1869,14 +1875,14 @@ impl NatTraversalEndpoint {
                                                         event,
                                                         remote_addr: source_addr.clone(),
                                                     };
-                                                    if let Err(e) = event_tx_clone.send(event_with_addr) {
-                                                        debug!("Failed to forward constrained event: {}", e);
+                                                    if let Err(_e) = event_tx_clone.send(event_with_addr) {
+                                                        debug!("Failed to forward constrained event: {}", _e);
                                                     }
                                                 }
                                             }
                                         }
                                         None => {
-                                            debug!("Transport '{}' inbound channel closed", transport_name);
+                                            debug!("Transport '{}' inbound channel closed", _transport_name);
                                             break;
                                         }
                                     }
@@ -1884,7 +1890,7 @@ impl NatTraversalEndpoint {
                             }
                         }
 
-                        debug!("Transport listener for '{}' terminated", transport_name);
+                        debug!("Transport listener for '{}' terminated", _transport_name);
                     });
 
                     handles.push(handle);
@@ -2352,7 +2358,7 @@ impl NatTraversalEndpoint {
                             if let Some(mut session) = sessions.get_mut(&addr) {
                                 session.session_state.state = ConnectionState::Closed;
                                 session.session_state.last_transition = std::time::Instant::now();
-                                tracing::warn!("Connection to {} timed out", addr);
+                                crate::warn!("Connection to {} timed out", addr);
                             }
                         }
                         SessionUpdate::Disconnected => {
@@ -2360,7 +2366,7 @@ impl NatTraversalEndpoint {
                                 session.session_state.state = ConnectionState::Closed;
                                 session.session_state.last_transition = std::time::Instant::now();
                                 session.session_state.connection = None;
-                                tracing::info!("Connection to {} closed", addr);
+                                crate::info!("Connection to {} closed", addr);
                             }
                         }
                         SessionUpdate::UpdateMetrics => {
@@ -2379,7 +2385,7 @@ impl NatTraversalEndpoint {
                             if let Some(mut session) = sessions.get_mut(&addr) {
                                 session.session_state.state = ConnectionState::Closed;
                                 session.session_state.last_transition = std::time::Instant::now();
-                                tracing::error!("Session {} in invalid state", addr);
+                                crate::error!("Session {} in invalid state", addr);
                             }
                         }
                         SessionUpdate::Retry => {
@@ -2387,7 +2393,7 @@ impl NatTraversalEndpoint {
                                 session.session_state.state = ConnectionState::Connecting;
                                 session.session_state.last_transition = std::time::Instant::now();
                                 session.attempt += 1;
-                                tracing::info!(
+                                crate::info!(
                                     "Retrying connection to {} (attempt {})",
                                     addr,
                                     session.attempt
@@ -2398,12 +2404,12 @@ impl NatTraversalEndpoint {
                             if let Some(mut session) = sessions.get_mut(&addr) {
                                 session.session_state.state = ConnectionState::Closed;
                                 session.session_state.last_transition = std::time::Instant::now();
-                                tracing::warn!("Migration timeout for {}", addr);
+                                crate::warn!("Migration timeout for {}", addr);
                             }
                         }
                         SessionUpdate::Remove => {
                             sessions.remove(&addr);
-                            tracing::debug!("Removed old session for {}", addr);
+                            crate::debug!("Removed old session for {}", addr);
                         }
                     }
                 }
@@ -2637,11 +2643,11 @@ impl NatTraversalEndpoint {
         // Priority: 1) quinn_socket parameter, 2) transport registry address, 3) create new
         let std_socket = if let Some(socket) = quinn_socket {
             // Use pre-bound socket (preferred for socket sharing with transport registry)
-            let socket_addr = socket
+            let _socket_addr = socket
                 .local_addr()
                 .map(|addr| addr.to_string())
                 .unwrap_or_else(|_| "unknown".to_string());
-            info!("Using pre-bound UDP socket at {}", socket_addr);
+            info!("Using pre-bound UDP socket at {}", _socket_addr);
             socket
         } else if let Some(registry_addr) = transport_registry.get_udp_local_addr() {
             // Transport registry has UDP - bind new socket on same interface
@@ -2815,8 +2821,8 @@ impl NatTraversalEndpoint {
                                 // Handle connection streams
                                 Self::handle_connection(remote_address, connection, event_tx).await;
                             }
-                            Err(e) => {
-                                debug!("Connection failed: {}", e);
+                            Err(_e) => {
+                                debug!("Connection failed: {}", _e);
                             }
                         }
                     });
@@ -2871,18 +2877,18 @@ impl NatTraversalEndpoint {
 
                                                 // Send the response
                                                 let response_bytes = response.encode();
-                                                if let Err(e) =
+                                                if let Err(_e) =
                                                     send_stream.write_all(&response_bytes).await
                                                 {
                                                     warn!(
                                                         "Failed to send relay response to {}: {}",
-                                                        addr, e
+                                                        addr, _e
                                                     );
                                                 }
-                                                if let Err(e) = send_stream.finish() {
+                                                if let Err(_e) = send_stream.finish() {
                                                     warn!(
                                                         "Failed to finish relay stream to {}: {}",
-                                                        addr, e
+                                                        addr, _e
                                                     );
                                                 }
                                             }
@@ -2902,26 +2908,26 @@ impl NatTraversalEndpoint {
                                             }
                                         }
                                     }
-                                    Err(e) => {
+                                    Err(_e) => {
                                         // Not a CONNECT-UDP request, ignore
                                         debug!(
                                             "Stream from {} is not a CONNECT-UDP request: {}",
-                                            addr, e
+                                            addr, _e
                                         );
                                     }
                                 }
                             }
-                            Err(e) => {
-                                debug!("Failed to read relay request from {}: {}", addr, e);
+                            Err(_e) => {
+                                debug!("Failed to read relay request from {}: {}", addr, _e);
                             }
                         }
                     });
                 }
-                Err(e) => {
+                Err(_e) => {
                     // Connection closed or error
                     debug!(
                         "Relay handler stopping for {} - accept_bi error: {}",
-                        client_addr, e
+                        client_addr, _e
                     );
                     break;
                 }
@@ -2953,7 +2959,7 @@ impl NatTraversalEndpoint {
 
             // 1. Check active connections for observed addresses and feed them to discovery
             // DashMap allows concurrent iteration without blocking
-            tracing::trace!(
+            crate::trace!(
                 "poll_discovery_task: checking {} connections for observed addresses",
                 connections.len()
             );
@@ -2961,7 +2967,7 @@ impl NatTraversalEndpoint {
                 let remote_addr = *entry.key();
                 let conn = entry.value();
                 let observed = conn.observed_address();
-                tracing::trace!(
+                crate::trace!(
                     "poll_discovery_task: remote {} observed_address={:?}",
                     remote_addr,
                     observed
@@ -3154,10 +3160,10 @@ impl NatTraversalEndpoint {
                 info!("Direct connection to {} succeeded", remote_addr);
                 return Ok(conn);
             }
-            Err(e) => {
+            Err(_e) => {
                 info!(
                     "Direct connection to {} failed ({:?}), trying hole punching",
-                    remote_addr, e
+                    remote_addr, _e
                 );
             }
         }
@@ -3183,18 +3189,18 @@ impl NatTraversalEndpoint {
                         info!("Connection via hole punching to {} succeeded", remote_addr);
                         return Ok(conn);
                     }
-                    Err(e) => {
+                    Err(_e) => {
                         info!(
                             "Connection after hole punching failed ({:?}), trying relay",
-                            e
+                            _e
                         );
                     }
                 }
             }
-            Err(e) => {
+            Err(_e) => {
                 info!(
                     "Hole punching for {} failed ({:?}), trying relay",
-                    remote_addr, e
+                    remote_addr, _e
                 );
             }
         }
@@ -3245,10 +3251,10 @@ impl NatTraversalEndpoint {
 
             // Establish relay session (CONNECT-UDP Bind)
             match self.establish_relay_session(relay_addr).await {
-                Ok(public_addr) => {
+                Ok(_public_addr) => {
                     info!(
                         "Relay session established via {} with public address {:?}",
-                        relay_addr, public_addr
+                        relay_addr, _public_addr
                     );
 
                     // Now attempt the connection through the relay
@@ -3261,7 +3267,7 @@ impl NatTraversalEndpoint {
                         Ok(conn) => {
                             info!(
                                 "Connected to {} via relay {} (public addr: {:?})",
-                                remote_addr, relay_addr, public_addr
+                                remote_addr, relay_addr, _public_addr
                             );
                             return Ok(conn);
                         }
@@ -3447,12 +3453,12 @@ impl NatTraversalEndpoint {
                     match event_rx.try_recv() {
                         Ok(NatTraversalEvent::ConnectionEstablished {
                             remote_address,
-                            side,
+                            side: _side,
                             ..
                         }) => {
                             info!(
                                 "Received ConnectionEstablished event for {} (side: {:?})",
-                                remote_address, side
+                                remote_address, _side
                             );
                             let connection = self
                                 .connections
@@ -3467,10 +3473,10 @@ impl NatTraversalEndpoint {
                             info!("Retrieved accepted connection from {}", remote_address);
                             return Ok((remote_address, connection));
                         }
-                        Ok(event) => {
+                        Ok(_event) => {
                             debug!(
                                 "Ignoring non-connection event while waiting for accept: {:?}",
-                                event
+                                _event
                             );
                         }
                         Err(mpsc::error::TryRecvError::Empty) => break,
@@ -3535,8 +3541,8 @@ impl NatTraversalEndpoint {
         addr: SocketAddr,
         connection: InnerConnection,
     ) -> Result<(), NatTraversalError> {
-        let observed = connection.observed_address();
-        info!("add_connection: {} observed_address={:?}", addr, observed);
+        let _observed = connection.observed_address();
+        info!("add_connection: {} observed_address={:?}", addr, _observed);
         // DashMap provides lock-free .insert()
         self.connections.insert(addr, connection);
         info!(
@@ -3718,7 +3724,7 @@ impl NatTraversalEndpoint {
 
         // For non-UDP transports, we need to store the transport candidate
         // and advertise it via the extended ADD_ADDRESS frames
-        let candidate = TransportCandidate {
+        let _candidate = TransportCandidate {
             address: address.clone(),
             priority,
             source: CandidateSource::Local,
@@ -3728,7 +3734,7 @@ impl NatTraversalEndpoint {
 
         info!(
             "Advertising {:?} transport address with priority {} (capabilities: {:?})",
-            candidate.transport_type(),
+            _candidate.transport_type(),
             priority,
             capabilities
         );
@@ -4108,8 +4114,8 @@ impl NatTraversalEndpoint {
             );
             match tokio::time::timeout(SHUTDOWN_DRAIN_TIMEOUT, async {
                 for handle in handles {
-                    if let Err(e) = handle.await {
-                        warn!("Transport listener task failed during shutdown: {e}");
+                    if let Err(_e) = handle.await {
+                        warn!("Transport listener task failed during shutdown: {_e}");
                     }
                 }
             })
@@ -4165,8 +4171,8 @@ impl NatTraversalEndpoint {
                         // Send ADD_ADDRESS frame to advertise this candidate to the target
                         self.send_candidate_advertisement(target_addr, &candidate)
                             .await
-                            .unwrap_or_else(|e| {
-                                debug!("Failed to send candidate advertisement: {}", e)
+                            .unwrap_or_else(|_e| {
+                                debug!("Failed to send candidate advertisement: {}", _e)
                             });
                     }
                     DiscoveryEvent::ServerReflexiveCandidateDiscovered { candidate, .. } => {
@@ -4175,8 +4181,8 @@ impl NatTraversalEndpoint {
                         // Send ADD_ADDRESS frame to advertise this candidate to the target
                         self.send_candidate_advertisement(target_addr, &candidate)
                             .await
-                            .unwrap_or_else(|e| {
-                                debug!("Failed to send candidate advertisement: {}", e)
+                            .unwrap_or_else(|_e| {
+                                debug!("Failed to send candidate advertisement: {}", _e)
                             });
                     }
                     // Prediction events removed in minimal flow
@@ -4421,10 +4427,10 @@ impl NatTraversalEndpoint {
 
             // Send the packet to the remote candidate address
             match local_socket.send_to(&path_challenge_packet, pair.remote_candidate.address) {
-                Ok(bytes_sent) => {
+                Ok(_bytes_sent) => {
                     debug!(
                         "Sent {} bytes for hole punch from {} to {}",
-                        bytes_sent, pair.local_candidate.address, pair.remote_candidate.address
+                        _bytes_sent, pair.local_candidate.address, pair.remote_candidate.address
                     );
 
                     // Set a short timeout for response
@@ -4462,13 +4468,13 @@ impl NatTraversalEndpoint {
                         {
                             debug!("No response received for hole punch attempt");
                         }
-                        Err(e) => {
-                            debug!("Error receiving hole punch response: {}", e);
+                        Err(_e) => {
+                            debug!("Error receiving hole punch response: {}", _e);
                         }
                     }
                 }
-                Err(e) => {
-                    debug!("Failed to send hole punch packet: {}", e);
+                Err(_e) => {
+                    debug!("Failed to send hole punch packet: {}", _e);
                 }
             }
         }
@@ -4586,7 +4592,7 @@ impl NatTraversalEndpoint {
                         let event_tx = event_tx.clone();
                         let connections = self.connections.clone();
                         let incoming_notify = self.incoming_notify.clone();
-                        let address = candidate.address;
+                        let _address = candidate.address;
 
                         tokio::spawn(async move {
                             match connecting.await {
@@ -4596,14 +4602,14 @@ impl NatTraversalEndpoint {
                                     if connections.contains_key(&remote) {
                                         debug!(
                                             "Connection already exists for {}, discarding duplicate from {}",
-                                            remote, address
+                                            remote, _address
                                         );
                                         // Close the duplicate connection to free resources
                                         connection.close(0u32.into(), b"duplicate connection");
                                         return;
                                     }
 
-                                    info!("Successfully connected to {} for {}", address, remote);
+                                    info!("Successfully connected to {} for {}", _address, remote);
 
                                     let public_key =
                                         Self::extract_public_key_from_connection(&connection);
@@ -4624,8 +4630,8 @@ impl NatTraversalEndpoint {
                                     // Handle the connection
                                     Self::handle_connection(remote, connection, event_tx).await;
                                 }
-                                Err(e) => {
-                                    warn!("Connection to {} failed: {}", address, e);
+                                Err(_e) => {
+                                    warn!("Connection to {} failed: {}", _address, _e);
                                 }
                             }
                         });
@@ -4764,10 +4770,10 @@ impl NatTraversalEndpoint {
                             // Retry discovery with exponential backoff
                             session.attempt += 1;
                             session.started_at = now;
-                            let backoff_duration = self.calculate_backoff(session.attempt);
+                            let _backoff_duration = self.calculate_backoff(session.attempt);
                             warn!(
                                 "Discovery timeout for {}, retrying (attempt {}), backoff: {:?}",
-                                target_addr, session.attempt, backoff_duration
+                                target_addr, session.attempt, _backoff_duration
                             );
                         } else {
                             // Max attempts reached, fail
@@ -5035,10 +5041,10 @@ impl NatTraversalEndpoint {
             // Retry with backoff
             session.attempt += 1;
             session.started_at = now;
-            let backoff = self.calculate_backoff(session.attempt);
+            let _backoff = self.calculate_backoff(session.attempt);
             warn!(
                 "Phase {:?} failed for {:?}: {:?}, retrying (attempt {}) after {:?}",
-                session.phase, session.target_addr, error, session.attempt, backoff
+                session.phase, session.target_addr, error, session.attempt, _backoff
             );
         } else {
             // Max attempts reached
@@ -5196,16 +5202,16 @@ impl NatTraversalEndpoint {
                                             coordinator, target_addr
                                         );
                                     }
-                                    Err(e) => {
+                                    Err(_e) => {
                                         warn!(
                                             "Failed to send PUNCH_ME_NOW after connecting: {:?}",
-                                            e
+                                            _e
                                         );
                                     }
                                 }
                             }
-                            Ok(Err(e)) => {
-                                warn!("Failed to connect to coordinator {}: {}", coordinator, e);
+                            Ok(Err(_e)) => {
+                                warn!("Failed to connect to coordinator {}: {}", coordinator, _e);
                             }
                             Err(_) => {
                                 warn!(
@@ -5325,10 +5331,10 @@ impl NatTraversalEndpoint {
                             candidate.address
                         );
                     }
-                    Err(e) => {
+                    Err(_e) => {
                         warn!(
                             "Failed to initiate connection to {}: {:?}",
-                            candidate.address, e
+                            candidate.address, _e
                         );
                     }
                 }
@@ -5558,10 +5564,13 @@ impl NatTraversalEndpoint {
         event: crate::shared::EndpointEventInner,
     ) -> Result<(), NatTraversalError> {
         match event {
-            crate::shared::EndpointEventInner::NatCandidateValidated { address, challenge } => {
+            crate::shared::EndpointEventInner::NatCandidateValidated {
+                address,
+                challenge: _challenge,
+            } => {
                 info!(
                     "NAT candidate validation succeeded for {} with challenge {:016x}",
-                    address, challenge
+                    address, _challenge
                 );
 
                 // Find and update the active session with validated candidate
@@ -5690,7 +5699,7 @@ impl NatTraversalEndpoint {
                     .map(|entry| (*entry.key(), entry.value().clone()))
                     .collect();
 
-                for (addr, connection) in connections_snapshot {
+                for (_addr, connection) in connections_snapshot {
                     // Send AddAddress frame via unidirectional stream
                     let mut send_stream = connection.open_uni().await.map_err(|e| {
                         NatTraversalError::NetworkError(format!("Failed to open stream: {e}"))
@@ -5706,7 +5715,7 @@ impl NatTraversalEndpoint {
 
                     let _ = send_stream.finish();
 
-                    debug!("Sent AddAddress frame to {}", addr);
+                    debug!("Sent AddAddress frame to {}", _addr);
                 }
 
                 Ok(())
@@ -5808,10 +5817,10 @@ impl NatTraversalEndpoint {
             let conn = entry.value_mut();
             // Use the connection's API to enqueue a proper NAT traversal frame
             match conn.send_nat_address_advertisement(candidate.address, candidate.priority) {
-                Ok(seq) => {
+                Ok(_seq) => {
                     info!(
                         "Queued ADD_ADDRESS via connection API: addr={}, candidate={}, priority={}, seq={}",
-                        addr, candidate.address, candidate.priority, seq
+                        addr, candidate.address, candidate.priority, _seq
                     );
                     Ok(())
                 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -48,8 +48,8 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use crate::crypto::pqc::types::{MlDsaPublicKey, MlDsaSecretKey};
+use crate::info;
 use tokio::sync::broadcast;
-use tracing::info;
 
 use crate::host_identity::HostIdentity;
 use crate::node_config::NodeConfig;
@@ -310,9 +310,9 @@ impl Node {
                         // Channel closed, endpoint shutting down
                         break;
                     }
-                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                    Err(broadcast::error::RecvError::Lagged(_n)) => {
                         // Subscriber lagged behind, log and continue
-                        tracing::warn!("Event bridge lagged by {} events", n);
+                        crate::warn!("Event bridge lagged by {} events", _n);
                     }
                 }
             }

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -54,10 +54,10 @@ use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use crate::{debug, error, info, warn};
 use tokio::sync::{RwLock, broadcast, mpsc};
 use tokio::time::timeout;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info, warn};
 
 use crate::Side;
 use crate::bootstrap_cache::{BootstrapCache, BootstrapTokenStore};
@@ -1188,11 +1188,11 @@ impl P2pEndpoint {
 
         // Handle all possible outcomes
         match (ipv4_result, ipv6_result) {
-            (Some(v4_conn), Some(v6_conn)) => {
+            (Some(_v4_conn), Some(v6_conn)) => {
                 // 🎉 BEST CASE: Both IPv4 AND IPv6 work - keep both!
                 info!(
                     "✓✓ Dual-stack success! IPv4: {}, IPv6: {} (maintaining both connections)",
-                    v4_conn.remote_addr, v6_conn.remote_addr
+                    _v4_conn.remote_addr, v6_conn.remote_addr
                 );
 
                 // Both connections already stored by try_connect_family
@@ -1233,41 +1233,41 @@ impl P2pEndpoint {
     async fn try_connect_family(
         &self,
         addresses: &[SocketAddr],
-        family_name: &str,
+        _family_name: &str,
     ) -> Option<PeerConnection> {
         if addresses.is_empty() {
-            debug!("{}: No addresses to try", family_name);
+            debug!("{}: No addresses to try", _family_name);
             return None;
         }
 
-        debug!("Trying {} {} addresses", addresses.len(), family_name);
+        debug!("Trying {} {} addresses", addresses.len(), _family_name);
 
-        for (idx, addr) in addresses.iter().enumerate() {
+        for (_idx, addr) in addresses.iter().enumerate() {
             debug!(
                 "  {} attempt {}/{}: {}",
-                family_name,
-                idx + 1,
+                _family_name,
+                _idx + 1,
                 addresses.len(),
                 addr
             );
 
             match timeout(Duration::from_secs(5), self.connect(*addr)).await {
                 Ok(Ok(peer_conn)) => {
-                    info!("✓ {} connection successful to {}", family_name, addr);
+                    info!("✓ {} connection successful to {}", _family_name, addr);
                     return Some(peer_conn);
                 }
-                Ok(Err(e)) => {
-                    debug!("  {} to {} failed: {}", family_name, addr, e);
+                Ok(Err(_e)) => {
+                    debug!("  {} to {} failed: {}", _family_name, addr, _e);
                     // Try next address
                 }
                 Err(_) => {
-                    debug!("  {} to {} timed out (5s)", family_name, addr);
+                    debug!("  {} to {} timed out (5s)", _family_name, addr);
                     // Try next address
                 }
             }
         }
 
-        debug!("{}: All {} addresses failed", family_name, addresses.len());
+        debug!("{}: All {} addresses failed", _family_name, addresses.len());
         None
     }
 
@@ -1754,7 +1754,7 @@ impl P2pEndpoint {
             target, relay_addr
         );
 
-        let public_addr = self
+        let _public_addr = self
             .inner
             .establish_relay_session(relay_addr)
             .await
@@ -1762,14 +1762,14 @@ impl P2pEndpoint {
 
         info!(
             "MASQUE relay session established via {} (public addr: {:?})",
-            relay_addr, public_addr
+            relay_addr, _public_addr
         );
 
         let conn = self.connect(target).await?;
 
         info!(
             "MASQUE relay connection succeeded to {} via {} (our relay addr: {:?})",
-            target, relay_addr, public_addr
+            target, relay_addr, _public_addr
         );
 
         Ok(conn)
@@ -1803,11 +1803,11 @@ impl P2pEndpoint {
                 let remote_public_key = extract_public_key_bytes_from_connection(&connection);
 
                 // They initiated the connection to us = Server side
-                if let Err(e) =
+                if let Err(_e) =
                     self.inner
                         .spawn_connection_handler(remote_addr, connection, Side::Server)
                 {
-                    error!("Failed to spawn connection handler: {}", e);
+                    error!("Failed to spawn connection handler: {}", _e);
                     return None;
                 }
 
@@ -1848,8 +1848,8 @@ impl P2pEndpoint {
 
                 Some(peer_conn)
             }
-            Err(e) => {
-                debug!("Accept failed: {}", e);
+            Err(_e) => {
+                debug!("Accept failed: {}", _e);
                 None
             }
         }
@@ -2140,8 +2140,8 @@ impl P2pEndpoint {
                     connected += 1;
                     info!("Connected to known peer {}", addr);
                 }
-                Err(e) => {
-                    warn!("Failed to connect to known peer {}: {}", addr, e);
+                Err(_e) => {
+                    warn!("Failed to connect to known peer {}: {}", addr, _e);
                 }
             }
         }
@@ -2211,7 +2211,7 @@ impl P2pEndpoint {
         // Bounded timeout prevents blocking when the remote peer is unresponsive.
         match timeout(SHUTDOWN_DRAIN_TIMEOUT, self.inner.shutdown()).await {
             Err(_) => warn!("Inner endpoint shutdown timed out, proceeding"),
-            Ok(Err(e)) => warn!("Inner endpoint shutdown error: {e}"),
+            Ok(Err(_e)) => warn!("Inner endpoint shutdown error: {_e}"),
             Ok(Ok(())) => {}
         }
     }
@@ -2243,8 +2243,8 @@ impl P2pEndpoint {
                 // Accept the next unidirectional stream
                 let mut recv_stream = match connection.accept_uni().await {
                     Ok(stream) => stream,
-                    Err(e) => {
-                        debug!("Reader task for {} ending: accept_uni error: {}", addr, e);
+                    Err(_e) => {
+                        debug!("Reader task for {} ending: accept_uni error: {}", addr, _e);
                         break;
                     }
                 };
@@ -2252,14 +2252,14 @@ impl P2pEndpoint {
                 let data = match recv_stream.read_to_end(max_read_bytes).await {
                     Ok(data) if data.is_empty() => continue,
                     Ok(data) => data,
-                    Err(e) => {
-                        debug!("Reader task for {}: read_to_end error: {}", addr, e);
+                    Err(_e) => {
+                        debug!("Reader task for {}: read_to_end error: {}", addr, _e);
                         break;
                     }
                 };
 
                 let data_len = data.len();
-                tracing::trace!("Reader task: {} bytes from {}", data_len, addr);
+                crate::trace!("Reader task: {} bytes from {}", data_len, addr);
 
                 // Update last_activity
                 if let Some(peer_conn) = connected_peers.write().await.get_mut(&addr) {
@@ -2272,7 +2272,7 @@ impl P2pEndpoint {
                 if data.len() == 2 && data[0] == HEALTH_CHECK_PREFIX {
                     if data[1] == HEALTH_PING[1] {
                         // Received PING — respond with PONG
-                        tracing::trace!("Health PING from {}, sending PONG", addr);
+                        crate::trace!("Health PING from {}, sending PONG", addr);
                         if let Ok(mut send) = connection.open_uni().await {
                             let _ = send.write_all(&HEALTH_PONG).await;
                             let _ = send.finish();
@@ -2280,7 +2280,7 @@ impl P2pEndpoint {
                         continue;
                     } else if data[1] == HEALTH_PONG[1] {
                         // Received PONG — update health timestamp
-                        tracing::trace!("Health PONG from {}", addr);
+                        crate::trace!("Health PONG from {}", addr);
                         if let Some(peer_conn) = connected_peers.write().await.get_mut(&addr) {
                             peer_conn.last_health_pong_received = Some(Instant::now());
                         }
@@ -2389,7 +2389,7 @@ impl P2pEndpoint {
                             .unwrap_or_else(|| wrapper.remote_addr.to_synthetic_socket_addr());
 
                         let data_len = data.len();
-                        tracing::trace!(
+                        crate::trace!(
                             "Constrained poller: {} bytes from {}",
                             data_len,
                             synthetic_addr
@@ -2462,13 +2462,13 @@ impl P2pEndpoint {
                         }
                     }
                     EngineEvent::ConnectionError {
-                        connection_id,
-                        error,
+                        connection_id: _connection_id,
+                        error: _error,
                     } => {
                         warn!(
                             "Constrained poller: conn_id={}, error={}",
-                            connection_id.value(),
-                            error
+                            _connection_id.value(),
+                            _error
                         );
                     }
                     EngineEvent::Transmit { .. } => {}
@@ -2607,11 +2607,11 @@ impl P2pEndpoint {
                                     if let Some(pc) = connected_peers.write().await.get_mut(addr) {
                                         pc.last_health_ping_sent = Some(Instant::now());
                                     }
-                                    tracing::trace!("Health PING sent to {}", addr);
+                                    crate::trace!("Health PING sent to {}", addr);
                                 }
                             }
-                            Err(e) => {
-                                debug!("Health check: failed to open stream to {}: {}", addr, e);
+                            Err(_e) => {
+                                debug!("Health check: failed to open stream to {}: {}", addr, _e);
                             }
                         }
                     }

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -312,7 +312,7 @@ impl Header {
         match self.try_encode(w) {
             Ok(encode) => encode,
             Err(_) => {
-                tracing::error!("VarInt overflow while encoding Header");
+                crate::error!("VarInt overflow while encoding Header");
                 debug_assert!(false, "VarInt overflow while encoding Header");
                 PartialEncode {
                     start: w.len(),

--- a/src/path_selection.rs
+++ b/src/path_selection.rs
@@ -363,7 +363,7 @@ impl PathManager {
             }
         }
 
-        tracing::debug!(
+        crate::debug!(
             closed = to_close.len(),
             remaining = self.direct_path_count(),
             "Closed redundant paths"

--- a/src/relay/authenticator.rs
+++ b/src/relay/authenticator.rs
@@ -228,7 +228,7 @@ impl RelayAuthenticator {
         let mut used_nonces = match self.used_nonces.lock() {
             Ok(guard) => guard,
             Err(_poisoned) => {
-                tracing::error!(
+                crate::error!(
                     "Mutex poisoned in relay authenticator - potential security compromise, \
                      failing authentication to prevent replay attacks"
                 );

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -17,11 +17,11 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use crate::{debug, info, warn};
 use tokio::sync::Notify;
 use tokio::task::JoinHandle;
 use tokio::time::timeout;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info, warn};
 
 /// Default timeout for graceful shutdown
 pub const DEFAULT_SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(500);

--- a/src/structured_events.rs
+++ b/src/structured_events.rs
@@ -217,7 +217,7 @@ impl StructuredEvent {
     pub fn log(&self) {
         match self.severity {
             EventSeverity::Trace => {
-                tracing::trace!(
+                crate::trace!(
                     component = %self.component,
                     kind = %self.kind,
                     peer_id = ?self.peer_id,
@@ -229,7 +229,7 @@ impl StructuredEvent {
                 );
             }
             EventSeverity::Debug => {
-                tracing::debug!(
+                crate::debug!(
                     component = %self.component,
                     kind = %self.kind,
                     peer_id = ?self.peer_id,
@@ -241,7 +241,7 @@ impl StructuredEvent {
                 );
             }
             EventSeverity::Info => {
-                tracing::info!(
+                crate::info!(
                     component = %self.component,
                     kind = %self.kind,
                     peer_id = ?self.peer_id,
@@ -253,7 +253,7 @@ impl StructuredEvent {
                 );
             }
             EventSeverity::Warn => {
-                tracing::warn!(
+                crate::warn!(
                     component = %self.component,
                     kind = %self.kind,
                     peer_id = ?self.peer_id,
@@ -265,7 +265,7 @@ impl StructuredEvent {
                 );
             }
             EventSeverity::Error => {
-                tracing::error!(
+                crate::error!(
                     component = %self.component,
                     kind = %self.kind,
                     peer_id = ?self.peer_id,

--- a/src/token_memory_cache.rs
+++ b/src/token_memory_cache.rs
@@ -12,9 +12,9 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use crate::{error, trace};
 use bytes::Bytes;
 use lru_slab::LruSlab;
-use tracing::{error, trace};
 
 use crate::token::TokenStore;
 
@@ -38,8 +38,8 @@ impl TokenStore for TokenMemoryCache {
         trace!(%server_name, "storing token");
         let mut state = match self.0.lock() {
             Ok(state) => state,
-            Err(e) => {
-                error!("Token cache mutex poisoned: {}", e);
+            Err(_e) => {
+                error!("Token cache mutex poisoned: {}", _e);
                 return;
             }
         };
@@ -49,8 +49,8 @@ impl TokenStore for TokenMemoryCache {
     fn take(&self, server_name: &str) -> Option<Bytes> {
         let mut state = match self.0.lock() {
             Ok(state) => state,
-            Err(e) => {
-                error!("Token cache mutex poisoned: {}", e);
+            Err(_e) => {
+                error!("Token cache mutex poisoned: {}", _e);
                 return None;
             }
         };

--- a/src/transport/ble.rs
+++ b/src/transport/ble.rs
@@ -328,7 +328,7 @@ impl BlePacketFragmenter {
         if total_fragments > 255 {
             // Data too large - would need more than 255 fragments
             // In practice, this is ~61KB with 244-byte MTU
-            tracing::warn!(
+            crate::warn!(
                 data_len = data.len(),
                 max_fragments = 255,
                 "Data exceeds maximum fragment count"
@@ -898,7 +898,7 @@ impl Drop for BleConnection {
     fn drop(&mut self) {
         // Attempt graceful disconnect on drop
         // We can't do async operations in Drop, so we just log
-        tracing::debug!(
+        crate::debug!(
             device_id = ?self.device_id,
             "BleConnection dropped"
         );
@@ -1424,7 +1424,7 @@ impl BleTransport {
         // Load persisted sessions from disk if configured
         if transport.config.session_persist_path.is_some() {
             if let Err(e) = transport.load_sessions_from_disk().await {
-                tracing::warn!(error = %e, "Failed to load session cache from disk");
+                crate::warn!(error = %e, "Failed to load session cache from disk");
             }
         }
 
@@ -1485,7 +1485,7 @@ impl BleTransport {
         // Set locally administered bit to indicate this is derived, not actual MAC
         device_id[0] |= 0x02;
 
-        tracing::info!(
+        crate::info!(
             adapter = %adapter_info,
             device_id = ?device_id,
             "BLE adapter initialized"
@@ -1614,7 +1614,7 @@ impl BleTransport {
 
         self.cache_session(device_id, session_key, session_id).await;
 
-        tracing::debug!(
+        crate::debug!(
             device_id = ?device_id,
             session_id,
             "Cached session for future resumption"
@@ -1661,7 +1661,7 @@ impl BleTransport {
 
         let total_removed = expired_removed + lru_removed;
         if total_removed > 0 {
-            tracing::debug!(
+            crate::debug!(
                 expired = expired_removed,
                 lru = lru_removed,
                 remaining = cache.len(),
@@ -1690,7 +1690,7 @@ impl BleTransport {
         cache.drain(0..count);
         let removed = before - cache.len();
 
-        tracing::debug!(removed, remaining = cache.len(), "Evicted LRU sessions");
+        crate::debug!(removed, remaining = cache.len(), "Evicted LRU sessions");
         removed
     }
 
@@ -1699,7 +1699,7 @@ impl BleTransport {
         let mut cache = self.session_cache.write().await;
         let count = cache.len();
         cache.clear();
-        tracing::debug!(count, "Cleared session cache");
+        crate::debug!(count, "Cleared session cache");
     }
 
     /// Save session cache to disk for persistence across restarts
@@ -1726,7 +1726,7 @@ impl BleTransport {
             message: format!("Failed to save session cache to {}: {}", path.display(), e),
         })?;
 
-        tracing::info!(
+        crate::info!(
             path = %path.display(),
             sessions = cache.len(),
             "Saved session cache to disk"
@@ -1747,7 +1747,7 @@ impl BleTransport {
 
         // Check if file exists
         if !path.exists() {
-            tracing::debug!(path = %path.display(), "Session cache file does not exist");
+            crate::debug!(path = %path.display(), "Session cache file does not exist");
             return Ok(0);
         }
 
@@ -1764,7 +1764,7 @@ impl BleTransport {
         let file = match SessionCacheFile::from_bytes(&bytes) {
             Some(f) => f,
             None => {
-                tracing::warn!(
+                crate::warn!(
                     path = %path.display(),
                     "Invalid or corrupted session cache file, ignoring"
                 );
@@ -1781,7 +1781,7 @@ impl BleTransport {
         // key to still be in memory. Future enhancement: store encrypted
         // session keys with a master key.
 
-        tracing::info!(
+        crate::info!(
             path = %path.display(),
             sessions = file.sessions.len(),
             "Loaded session cache metadata from disk (keys not restored)"
@@ -1810,19 +1810,19 @@ impl BleTransport {
                 // Prune expired sessions
                 let pruned = transport.prune_expired_sessions().await;
                 if pruned > 0 {
-                    tracing::debug!(pruned, "Periodic session cleanup completed");
+                    crate::debug!(pruned, "Periodic session cleanup completed");
                 }
 
                 // Prune stale reassembly buffers
                 let stale = transport.prune_stale_reassemblies().await;
                 if stale > 0 {
-                    tracing::debug!(stale, "Pruned stale reassembly buffers");
+                    crate::debug!(stale, "Pruned stale reassembly buffers");
                 }
 
                 // Save to disk if persistence is configured
                 if transport.config.session_persist_path.is_some() {
                     if let Err(e) = transport.save_sessions_to_disk().await {
-                        tracing::warn!(error = %e, "Failed to persist session cache");
+                        crate::warn!(error = %e, "Failed to persist session cache");
                     }
                 }
             }
@@ -1907,7 +1907,7 @@ impl BleTransport {
 
         *state = ScanState::Scanning;
 
-        tracing::info!(
+        crate::info!(
             service_uuid = ?self.config.service_uuid,
             platform = %Self::platform_name(),
             "Starting BLE scan"
@@ -1938,7 +1938,7 @@ impl BleTransport {
             let mut events = match adapter.events().await {
                 Ok(events) => events,
                 Err(e) => {
-                    tracing::error!(error = %e, "Failed to get adapter events stream");
+                    crate::error!(error = %e, "Failed to get adapter events stream");
                     return;
                 }
             };
@@ -1978,7 +1978,7 @@ impl BleTransport {
                                 let is_new = !devices.contains_key(&device_id);
                                 devices.insert(device_id, device.clone());
 
-                                tracing::debug!(
+                                crate::debug!(
                                     device_id = ?device_id,
                                     local_name = ?device.local_name,
                                     rssi = ?device.rssi,
@@ -1990,7 +1990,7 @@ impl BleTransport {
                                 // Send scan event
                                 let event = ScanEvent { device, is_new };
                                 if scan_event_tx.send(event).await.is_err() {
-                                    tracing::debug!("Scan event receiver dropped");
+                                    crate::debug!("Scan event receiver dropped");
                                 }
                             }
                         }
@@ -2013,7 +2013,7 @@ impl BleTransport {
                                         device.has_service = true;
                                     }
 
-                                    tracing::trace!(
+                                    crate::trace!(
                                         device_id = ?device_id,
                                         rssi = ?device.rssi,
                                         "Updated BLE device"
@@ -2024,7 +2024,7 @@ impl BleTransport {
                     }
                     CentralEvent::DeviceDisconnected(id) => {
                         let device_id = Self::peripheral_id_to_device_id(&id.to_string());
-                        tracing::debug!(device_id = ?device_id, "BLE device disconnected");
+                        crate::debug!(device_id = ?device_id, "BLE device disconnected");
                     }
                     _ => {
                         // Ignore other events
@@ -2032,7 +2032,7 @@ impl BleTransport {
                 }
             }
 
-            tracing::info!("BLE scan event processing stopped");
+            crate::info!("BLE scan event processing stopped");
         });
 
         Ok(())
@@ -2073,7 +2073,7 @@ impl BleTransport {
 
         *state = ScanState::Stopping;
 
-        tracing::info!(
+        crate::info!(
             platform = %Self::platform_name(),
             "Stopping BLE scan"
         );
@@ -2144,7 +2144,7 @@ impl BleTransport {
         // Send scan event
         let event = ScanEvent { device, is_new };
         if self.scan_event_tx.send(event).await.is_err() {
-            tracing::debug!("Scan event receiver dropped");
+            crate::debug!("Scan event receiver dropped");
         }
 
         is_new
@@ -2231,18 +2231,18 @@ impl BleTransport {
         let using_session_resumption = resume_token.is_some();
 
         if using_session_resumption {
-            tracing::info!(
+            crate::info!(
                 device_id = ?device_id,
                 "Found cached session - using fast handshake (32 bytes vs ~8KB)"
             );
         } else {
-            tracing::info!(
+            crate::info!(
                 device_id = ?device_id,
                 "No cached session - will perform full PQC handshake"
             );
         }
 
-        tracing::info!(
+        crate::info!(
             device_id = ?device_id,
             btleplug_id = %btleplug_id_str,
             platform = %Self::platform_name(),
@@ -2311,7 +2311,7 @@ impl BleTransport {
                 message: "RX characteristic not found".to_string(),
             })?;
 
-        tracing::debug!(
+        crate::debug!(
             tx_uuid = %tx_char.uuid,
             rx_uuid = %rx_char.uuid,
             "Found saorsa-transport characteristics"
@@ -2325,7 +2325,7 @@ impl BleTransport {
                 message: format!("Failed to subscribe to RX notifications: {e}"),
             })?;
 
-        tracing::debug!(
+        crate::debug!(
             device_id = ?device_id,
             "Subscribed to RX notifications"
         );
@@ -2359,7 +2359,7 @@ impl BleTransport {
             let mut notifications = match peripheral_arc.notifications().await {
                 Ok(stream) => stream,
                 Err(e) => {
-                    tracing::error!(
+                    crate::error!(
                         device_id = ?device_id,
                         error = %e,
                         "Failed to get notification stream"
@@ -2368,7 +2368,7 @@ impl BleTransport {
                 }
             };
 
-            tracing::info!(
+            crate::info!(
                 device_id = ?device_id,
                 "Started notification handler"
             );
@@ -2393,14 +2393,14 @@ impl BleTransport {
 
                     // Send to inbound channel
                     if inbound_tx.send(datagram).await.is_err() {
-                        tracing::debug!(
+                        crate::debug!(
                             device_id = ?device_id,
                             "Inbound channel closed, stopping notification handler"
                         );
                         break;
                     }
 
-                    tracing::trace!(
+                    crate::trace!(
                         device_id = ?device_id,
                         data_len,
                         "Received BLE notification"
@@ -2408,13 +2408,13 @@ impl BleTransport {
                 }
             }
 
-            tracing::info!(
+            crate::info!(
                 device_id = ?device_id,
                 "Notification handler stopped"
             );
         });
 
-        tracing::info!(
+        crate::info!(
             device_id = ?device_id,
             session_resumed = using_session_resumption,
             "BLE device connected"
@@ -2426,7 +2426,7 @@ impl BleTransport {
         if !using_session_resumption {
             // Generate a session ID from the connection timestamp
             let session_id = (Instant::now().elapsed().as_millis() & 0xFFFF) as u16;
-            tracing::debug!(
+            crate::debug!(
                 device_id = ?device_id,
                 session_id,
                 "New connection - session can be cached after PQC handshake"
@@ -2519,7 +2519,7 @@ impl BleTransport {
             .await
             .insert(device_id, connection.clone());
 
-        tracing::debug!(
+        crate::debug!(
             device_id = ?device_id,
             "Created simulated BLE connection (test mode)"
         );
@@ -2536,7 +2536,7 @@ impl BleTransport {
         if let Some(conn) = connections.remove(device_id) {
             let conn = conn.read().await;
             conn.start_disconnect().await?;
-            tracing::info!(
+            crate::info!(
                 device_id = ?device_id,
                 "BLE device disconnected"
             );
@@ -2585,7 +2585,7 @@ impl BleTransport {
         for (device_id, conn) in connections.drain() {
             let conn = conn.read().await;
             if let Err(e) = conn.start_disconnect().await {
-                tracing::warn!(
+                crate::warn!(
                     device_id = ?device_id,
                     error = %e,
                     "Error disconnecting device"
@@ -2593,7 +2593,7 @@ impl BleTransport {
             }
         }
 
-        tracing::info!(count, "Disconnected all BLE devices");
+        crate::info!(count, "Disconnected all BLE devices");
         count
     }
 
@@ -2615,7 +2615,7 @@ impl BleTransport {
             match self.connect_to_device(device_id).await {
                 Ok(conn) => return Ok(conn),
                 Err(e) if attempts >= max_attempts => {
-                    tracing::error!(
+                    crate::error!(
                         device_id = ?device_id,
                         attempts,
                         error = %e,
@@ -2624,7 +2624,7 @@ impl BleTransport {
                     return Err(e);
                 }
                 Err(e) => {
-                    tracing::warn!(
+                    crate::warn!(
                         device_id = ?device_id,
                         attempt = attempts,
                         max_attempts,
@@ -2713,7 +2713,7 @@ impl BleTransport {
         let complete_data = match complete_data {
             Some(data) => data,
             None => {
-                tracing::trace!(
+                crate::trace!(
                     device_id = ?device_id,
                     fragment_len,
                     "BLE fragment received, waiting for more"
@@ -2754,7 +2754,7 @@ impl BleTransport {
         // Touch session cache entry to keep it fresh
         self.touch_session(&device_id).await;
 
-        tracing::trace!(
+        crate::trace!(
             device_id = ?device_id,
             data_len,
             "Processed complete BLE message"
@@ -2834,7 +2834,7 @@ impl BleTransport {
             return Err(TransportError::Offline);
         }
 
-        tracing::info!(
+        crate::info!(
             service_uuid = ?self.config.service_uuid,
             platform = %Self::platform_name(),
             "Starting BLE advertising (peripheral mode - stub)"
@@ -2866,7 +2866,7 @@ impl BleTransport {
 
     /// Stop advertising as a BLE peripheral
     pub async fn stop_advertising(&self) -> Result<(), TransportError> {
-        tracing::info!(
+        crate::info!(
             platform = %Self::platform_name(),
             "Stopping BLE advertising"
         );
@@ -2957,13 +2957,13 @@ impl BleTransport {
         if let Some(device_id) = lru_device {
             if let Some(conn) = connections.remove(&device_id) {
                 if let Err(e) = conn.read().await.start_disconnect().await {
-                    tracing::warn!(
+                    crate::warn!(
                         device_id = ?device_id,
                         error = %e,
                         "Error during LRU eviction"
                     );
                 }
-                tracing::info!(
+                crate::info!(
                     device_id = ?device_id,
                     idle_secs = max_idle.as_secs(),
                     "Evicted LRU connection"
@@ -2998,7 +2998,7 @@ impl BleTransport {
         }
 
         if !to_evict.is_empty() {
-            tracing::info!(
+            crate::info!(
                 count = to_evict.len(),
                 threshold_secs = idle_threshold.as_secs(),
                 "Evicted idle connections"
@@ -3033,7 +3033,7 @@ impl BleTransport {
         }
 
         if !to_remove.is_empty() {
-            tracing::debug!(
+            crate::debug!(
                 removed = to_remove.len(),
                 remaining = connections.len(),
                 "Pool maintenance: removed disconnected connections"
@@ -3234,7 +3234,7 @@ impl TransportProvider for BleTransport {
                 // Simulated connection - skip actual btleplug write
                 #[cfg(test)]
                 {
-                    tracing::debug!(
+                    crate::debug!(
                         device_id = ?device_id,
                         data_len = data.len(),
                         fragments = fragment_count,
@@ -3285,7 +3285,7 @@ impl TransportProvider for BleTransport {
                         })?;
                 }
 
-                tracing::debug!(
+                crate::debug!(
                     device_id = ?device_id,
                     data_len = data.len(),
                     fragments = fragment_count,
@@ -3298,7 +3298,7 @@ impl TransportProvider for BleTransport {
         #[cfg(not(feature = "ble"))]
         {
             let _ = &fragments; // Silence unused variable warning
-            tracing::debug!(
+            crate::debug!(
                 device_id = ?device_id,
                 data_len = data.len(),
                 fragments = fragment_count,
@@ -3372,7 +3372,7 @@ impl TransportProvider for BleTransport {
         }
 
         // In a full implementation, this would set up BLE advertising with the data
-        tracing::debug!(
+        crate::debug!(
             data_len = data.len(),
             platform = %Self::platform_name(),
             "BLE broadcast (simulated)"

--- a/src/transport_error.rs
+++ b/src/transport_error.rs
@@ -67,7 +67,7 @@ impl coding::Codec for Code {
     }
     fn encode<B: BufMut>(&self, buf: &mut B) {
         if buf.write_var(self.0).is_err() {
-            tracing::error!("VarInt overflow while encoding TransportErrorCode");
+            crate::error!("VarInt overflow while encoding TransportErrorCode");
             debug_assert!(false, "VarInt overflow while encoding TransportErrorCode");
         }
     }

--- a/src/transport_parameters.rs
+++ b/src/transport_parameters.rs
@@ -216,7 +216,7 @@ impl TransportParameters {
                 let micros = TIMER_GRANULARITY.as_micros();
                 // TIMER_GRANULARITY should always fit in u64 and be less than 2^62
                 let micros_u64 = u64::try_from(micros).unwrap_or_else(|_| {
-                    tracing::error!("Timer granularity {} micros exceeds u64::MAX", micros);
+                    crate::error!("Timer granularity {} micros exceeds u64::MAX", micros);
                     1_000_000 // Default to 1 second
                 });
                 VarInt::from_u64_bounded(micros_u64)
@@ -871,18 +871,23 @@ impl TransportParameters {
             match (side, nat_config) {
                 // Traditional: Server receives ClientSupport from client
                 (Side::Server, NatTraversalConfig::ClientSupport) => {
-                    tracing::debug!("Server received valid ClientSupport NAT traversal parameter");
+                    crate::debug!("Server received valid ClientSupport NAT traversal parameter");
                 }
                 // Traditional: Client receives ServerSupport from server
-                (Side::Client, NatTraversalConfig::ServerSupport { concurrency_limit }) => {
-                    tracing::debug!(
+                (
+                    Side::Client,
+                    NatTraversalConfig::ServerSupport {
+                        concurrency_limit: _concurrency_limit,
+                    },
+                ) => {
+                    crate::debug!(
                         "Client received valid ServerSupport with concurrency_limit: {}",
-                        concurrency_limit
+                        _concurrency_limit
                     );
                 }
                 // P2P: Server receives ServerSupport from peer (symmetric P2P)
                 (Side::Server, NatTraversalConfig::ServerSupport { concurrency_limit }) => {
-                    tracing::debug!(
+                    crate::debug!(
                         "P2P: Server received ServerSupport with concurrency_limit: {} (symmetric P2P)",
                         concurrency_limit
                     );
@@ -899,7 +904,7 @@ impl TransportParameters {
                 }
                 // P2P: Client receives ClientSupport from peer (symmetric P2P)
                 (Side::Client, NatTraversalConfig::ClientSupport) => {
-                    tracing::debug!("P2P: Client received ClientSupport (symmetric P2P)");
+                    crate::debug!("P2P: Client received ClientSupport (symmetric P2P)");
                     // Valid for P2P - both peers have client capabilities
                 }
             }

--- a/src/transport_parameters/error_handling.rs
+++ b/src/transport_parameters/error_handling.rs
@@ -7,9 +7,9 @@
 
 use crate::TransportError;
 use crate::VarInt;
+use crate::error;
 use crate::frame;
 use crate::transport_parameters::{Side, TransportParameters};
-use tracing::error;
 
 /// Enhanced error handling for transport parameter validation
 pub(crate) struct TransportParameterErrorHandler;
@@ -17,25 +17,25 @@ pub(crate) struct TransportParameterErrorHandler;
 impl TransportParameterErrorHandler {
     /// Log specific validation failures with RFC references
     pub(super) fn log_validation_failure(
-        param_name: &str,
-        value: u64,
-        expected: &str,
-        rfc_ref: &str,
+        _param_name: &str,
+        _value: u64,
+        _expected: &str,
+        _rfc_ref: &str,
     ) {
         error!(
-            param_name = param_name,
-            value = value,
-            expected = expected,
-            rfc_ref = rfc_ref,
+            param_name = _param_name,
+            value = _value,
+            expected = _expected,
+            rfc_ref = _rfc_ref,
             "Transport parameter validation failed"
         );
     }
 
     /// Log semantic validation errors
-    pub(super) fn log_semantic_error(error_desc: &str, context: &str) {
+    pub(super) fn log_semantic_error(_error_desc: &str, _context: &str) {
         error!(
-            error = error_desc,
-            context = context,
+            error = _error_desc,
+            context = _context,
             compliance = "RFC 9000 Section 18",
             "Transport parameter semantic validation failed"
         );
@@ -44,11 +44,11 @@ impl TransportParameterErrorHandler {
     /// Log NAT traversal parameter errors
     /// (Not currently used - kept for potential future diagnostic needs)
     #[allow(dead_code)]
-    pub(super) fn log_nat_traversal_error(side: Side, received_variant: &str, expected: &str) {
+    pub(super) fn log_nat_traversal_error(_side: Side, _received_variant: &str, _expected: &str) {
         error!(
-            side = ?side,
-            received = received_variant,
-            expected = expected,
+            side = ?_side,
+            received = _received_variant,
+            expected = _expected,
             compliance = "draft-seemann-quic-nat-traversal-02",
             "NAT traversal parameter role mismatch"
         );

--- a/src/varint.rs
+++ b/src/varint.rs
@@ -216,7 +216,7 @@ impl Codec for VarInt {
 
     fn encode<B: BufMut>(&self, w: &mut B) {
         if let Err(_) = Self::encode_checked(self.0, w) {
-            tracing::error!("VarInt overflow: {} exceeds maximum", self.0);
+            crate::error!("VarInt overflow: {} exceeds maximum", self.0);
             debug_assert!(false, "VarInt overflow: {}", self.0);
         }
     }


### PR DESCRIPTION
## Summary
- Add `logging_macros.rs` module with `cfg(debug_assertions)`-gated wrapper macros for events and spans
- Replace `use tracing::{...}` with `use crate::{...}` across ~60 source files (~1,593 macro calls)
- Span macros (`debug_span!`, `trace_span!`) return `Span::none()` in release builds
- Add `cfg_attr(not(debug_assertions), allow(unused_variables))` for release builds

Logging macros compile to nothing in release builds, ensuring zero tracing callsite metadata in production binaries. Debug builds retain full logging.

Part of [V2-124](https://linear.app/autonominetwork/issue/V2-124).

## Test plan
- [x] `cargo build` (debug) — passes
- [x] `cargo build --release` — passes
- [x] `cargo test --lib` — 1,458 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)