### PR TITLE
ci: remove security audit from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,17 +139,6 @@ jobs:
     needs: validate
     uses: ./.github/workflows/quick-checks.yml
 
-  security-check:
-    name: Security Audit
-    needs: validate
-    permissions:
-      contents: read
-      pull-requests: write
-      security-events: write
-      id-token: write
-      actions: read
-    uses: ./.github/workflows/security.yml
-
   build:
     name: Build ${{ matrix.target }}
     needs: [validate, test]


### PR DESCRIPTION
## Summary
- Remove the `security-check` job from the release workflow so publishing to crates.io is not coupled to the security audit
- The security audit continues to run independently via its own workflow triggers
- No other release jobs depended on `security-check`, so this is a safe removal

## Test plan
- [ ] Verify release workflow YAML is valid (no broken `needs` references)
- [ ] Confirm security workflow still triggers independently on its own events

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the `security-check` job from the release workflow so that publishing to crates.io is no longer blocked by the security audit — the security workflow continues to run independently via `push`, `pull_request`, `schedule`, and `workflow_dispatch` triggers. Alongside the CI change, the PR includes a sizeable set of unrelated updates: a version bump from 0.23.0 to 0.29.0, dependency upgrades (`reqwest` 0.12 → 0.13, `quinn-udp` 0.5 → 0.6), removal of the `external/devp2p` submodule, and widespread Rust refactoring (new `DiscoverySessionId` enum, BLE/LoRa struct field renames, etc.).

Key observations:
- The `security-check` removal is clean — no dangling `needs` references remain.
- The `publish-crate` dependency change from `build` to `test` is a silent behavioural shift: crates.io publication now proceeds once the single-platform `quick-checks` workflow passes, without waiting for or requiring cross-platform binary builds to succeed. This may be intentional decoupling, but it is not called out in the PR description.
- The scope of changes goes well beyond the stated CI goal — many Rust source and test files are modified with API-breaking field/type renames that are unrelated to the security-audit decoupling.

<h3>Confidence Score: 4/5</h3>

Safe to merge after confirming the `publish-crate` dependency change is intentional.

The CI-only change is straightforward and the security workflow still fires independently. The one concern worth confirming is that `publish-crate` now no longer waits for cross-platform builds — a silent behavioural change not described in the PR. Everything else (code refactors, dependency upgrades) looks mechanical and consistent.

`.github/workflows/release.yml` — specifically the `publish-crate` needs change from `build` to `test`.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Removes `security-check` job and changes `publish-crate` dependency from `build` to `test`, decoupling crate publishing from cross-platform binary builds. |
| Cargo.toml | Version bumped from 0.23.0 to 0.29.0; `reqwest` upgraded from 0.12 to 0.13, `quinn-udp` from 0.5 to 0.6 with updated feature flags. |
| Cargo.lock | Lock file updated to reflect `reqwest` 0.13.2, `quinn-udp` 0.6.0, removal of `webpki-roots`/`serde_urlencoded`, and addition of `rustls-platform-verifier`/`aws-lc-rs`. |
| src/candidate_discovery.rs | Replaces `PeerId` map key with a new `DiscoverySessionId` enum (`Local`/`Remote(SocketAddr)`) and adds `allow_loopback` field to `DiscoveryConfig`. |
| src/transport/addr.rs | Renames BLE struct fields (`device_id`→`mac`, `service_uuid`→`psm`) and LoRa fields (`device_addr`→`dev_addr`, `params`→`freq_hz`) for clearer naming. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    validate([validate])
    changelog([changelog])
    test([test / quick-checks])
    build([build — multi-platform])
    build_docker([build-docker])
    publish_crate([publish-crate])
    release([release — GitHub Release])
    notify([notify])

    validate --> changelog
    validate --> test
    validate --> build_docker
    test --> build
    build --> release
    changelog --> release
    release --> notify

    validate --> publish_crate
    test --> publish_crate
    changelog --> publish_crate

    style publish_crate fill:#ffe0b2,stroke:#f57c00
    style build fill:#e3f2fd,stroke:#1976d2

    subgraph removed [" Removed from release.yml "]
        security_check["security-check\n(was: needs validate)"]
    end

    validate -.->|removed| security_check

    subgraph independent [" security.yml — runs independently "]
        sec_push["on: push to master"]
        sec_pr["on: pull_request"]
        sec_schedule["on: schedule (daily 2 AM)"]
        sec_dispatch["on: workflow_dispatch"]
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/release.yml
Line: 380

Comment:
**`publish-crate` no longer waits for cross-platform builds**

The dependency was changed from `[validate, build, changelog]` to `[validate, test, changelog]`. In the original setup, `publish-crate` transitively required all multi-platform `build` jobs to succeed (since `build` depends on `test`). Now crates.io publication proceeds as soon as `test` (i.e., `quick-checks.yml`, which runs on a single platform) passes, without waiting for or requiring cross-compilation to succeed.

This means a crate could be published to crates.io even if it fails to compile on one of the supported targets (ARM, musl, Windows, etc.). The PR description only mentions removing `security-check` and does not explicitly call out this change in gating behaviour. If the intent is to decouple crates.io publishing from binary builds, this is fine — but it is worth confirming that is deliberate.

```suggestion
    needs: [validate, build, test, changelog]
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: remove security audit job from relea..."](https://github.com/saorsa-labs/saorsa-transport/commit/0e80932878451b4f8bba97fd90eb6dc8409dfb6d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26694091)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->