### PR TITLE
chore: bump version to 0.30.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2934,7 +2934,7 @@ dependencies = [
 
 [[package]]
 name = "saorsa-transport"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "saorsa-transport"
-version = "0.30.0"
+version = "0.30.1"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary
- Patch version bump from 0.30.0 to 0.30.1
- Tag `v0.30.1` created

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR performs a minimal patch version bump of `saorsa-transport` from `0.30.0` to `0.30.1`, updating both `Cargo.toml` and `Cargo.lock` consistently.

- `Cargo.toml`: `version` field updated from `0.30.0` → `0.30.1`
- `Cargo.lock`: Lock file entry for `saorsa-transport` updated to match the new version
- No functional code changes; this is a pure release-plumbing commit

<h3>Confidence Score: 5/5</h3>

Safe to merge — only version metadata changed, no logic or dependencies affected.

The diff is two single-line version string updates (Cargo.toml and Cargo.lock) that are consistent with each other. No code, dependencies, or behaviour changed. No issues found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Cargo.toml | Patch version bumped from 0.30.0 to 0.30.1; no other changes. |
| Cargo.lock | Lock file updated to reflect the new 0.30.1 version of saorsa-transport; consistent with Cargo.toml change. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([Cargo.toml\nversion = 0.30.0]) -->|bump patch| B([Cargo.toml\nversion = 0.30.1])
    C([Cargo.lock\nsaorsa-transport 0.30.0]) -->|regenerated| D([Cargo.lock\nsaorsa-transport 0.30.1])
    B --> E([Tag v0.30.1 created])
    D --> E
```

<sub>Reviews (1): Last reviewed commit: ["chore: bump version to 0.30.1"](https://github.com/saorsa-labs/saorsa-transport/commit/3c7c9d11ee3a41a5dd7c063315ef627853f8b89e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26705449)</sub>

<!-- /greptile_comment -->