### PR TITLE
feat: MASQUE relay data plane with scalable address propagation

### DIFF
--- a/docs/adr/ADR-009-masque-relay-data-plane.md
+++ b/docs/adr/ADR-009-masque-relay-data-plane.md
@@ -1,0 +1,131 @@
+# ADR-009: MASQUE Relay Data Plane Implementation
+
+## Status
+
+Accepted (2026-03-29)
+
+## Context
+
+### The Problem
+
+ADR-006 selected MASQUE CONNECT-UDP Bind as the relay protocol and the control plane was fully implemented: session establishment, capsule encoding, and context management all work. However, the data plane was stub code -- `forward_datagram` was a no-op and `try_relay_connection` bypassed the tunnel entirely.
+
+Testing with symmetric NAT nodes (Linux network namespaces using `MASQUERADE --random-fully`) confirmed:
+
+- **Hole-punching fails for symmetric NAT**: Per-destination port randomization defeats prediction-based traversal
+- **The relay control plane works but no data flows**: Sessions establish, contexts are allocated, but datagrams are never forwarded
+- **The RFC model requires the NAT-restricted node to set up the relay proactively**: The initiator cannot reach the NAT-restricted node, so the relay must already be in place before any connection attempt
+
+## Decision
+
+Implement the relay data plane with the following key design decisions.
+
+### 1. Proactive Relay Setup by NAT-Restricted Nodes
+
+The NAT-restricted node -- not the initiator -- is responsible for establishing the relay:
+
+1. NAT node detects symmetric NAT via `OBSERVED_ADDRESS` port diversity (multiple peers report different source ports for the same endpoint)
+2. NAT node establishes a relay session with a connected cloud/bootstrap node
+3. The relay address is advertised via `ADD_ADDRESS` frames, which propagate through the DHT
+
+This is the only model that works: the initiator cannot reach the NAT-restricted node without the relay already being in place.
+
+### 2. Stream-Based Forwarding
+
+QUIC datagrams were the obvious choice for forwarding but are unsuitable:
+
+- **QUIC datagram MTU is ~1120 bytes** (after QUIC header overhead)
+- **QUIC Initial packets are 1200 bytes** (mandatory minimum per RFC 9000)
+- Initial packets from incoming connections would be truncated and dropped
+
+Instead, forwarding uses persistent QUIC bidirectional streams with length-prefixed framing:
+
+```
+[4-byte big-endian length][UncompressedDatagram payload]
+```
+
+This adds reliability overhead compared to unreliable UDP, but guarantees that full-size QUIC Initial packets survive the relay hop.
+
+### 3. Secondary Quinn Endpoint
+
+A secondary Quinn endpoint accepts relay'd connections:
+
+```
+                                          ┌─────────────────────┐
+                                          │   NAT-Restricted    │
+                                          │   Node              │
+┌──────────┐     UDP      ┌──────────┐   │                     │
+│  Client  │─────────────►│  Relay   │   │  ┌───────────────┐  │
+│          │              │  Node    │───►│  │ Secondary     │  │
+└──────────┘              └──────────┘   │  │ Endpoint      │  │
+                           QUIC stream   │  │ (MasqueRelay  │  │
+                                         │  │  Socket)      │  │
+                                         │  └───────────────┘  │
+                                         │                     │
+                                         │  ┌───────────────┐  │
+                                         │  │ Main Endpoint │  │
+                                         │  │ (real UDP)    │  │
+                                         │  └───────────────┘  │
+                                         └─────────────────────┘
+```
+
+- **Main endpoint** stays on the real UDP socket (used for direct connections and the relay control stream itself)
+- **Secondary endpoint** uses `MasqueRelaySocket`, which implements Quinn's `AsyncUdpSocket` trait
+- `MasqueRelaySocket` reads and writes via the relay stream, presenting relay'd UDP packets to Quinn as if they arrived on a local socket
+
+This avoids a circular dependency: if the main endpoint were rebound to the relay socket, the relay control stream (which runs over that endpoint) would break.
+
+### 4. DHT Address Propagation
+
+Relay addresses propagate through the existing address notification and DHT machinery:
+
+1. `ADD_ADDRESS` frames are sent to connected peers
+2. Frames surface as `EndpointEvent` -> `P2pEvent` -> `ConnectionEvent`
+3. saorsa-core's background task calls `dht.touch_node(peer_id, relay_addr)` to update the DHT
+4. **Filter**: only accept address updates where the IP differs from the connection IP (prevents a node from adding redundant entries for its own direct address)
+
+## Consequences
+
+### Benefits
+
+- **Symmetric NAT nodes fully participate in the network**: No degraded mode or reduced functionality
+- **Transparent to the application layer**: Quinn handles connections via the relay socket identically to direct connections
+- **No special client code needed**: Clients connect to the relay address like any other address resolved from the DHT
+
+### Trade-offs
+
+- **Extra hop latency through relay** (~50-100ms per direction)
+- **Relay node bears bandwidth cost**: All data for the NAT-restricted node flows through the relay
+- **Stream-based forwarding adds reliability overhead**: TCP-like semantics where UDP unreliability would suffice, though this also prevents packet loss on the relay hop
+
+### Implementation Status
+
+| Component | File | Status |
+|-----------|------|--------|
+| Relay server UDP socket binding | `relay_server.rs` | Complete |
+| Stream-based forwarding loop | `relay_server.rs` | Complete |
+| MasqueRelaySocket (AsyncUdpSocket) | `relay_socket.rs` | Complete |
+| OBSERVED_ADDRESS sending | `connection/mod.rs` | Complete |
+| Symmetric NAT detection | `nat_traversal_api.rs` | Complete |
+| Proactive relay setup | `nat_traversal_api.rs` | Complete |
+| Secondary endpoint | `nat_traversal_api.rs` | Complete |
+| ADD_ADDRESS -> DHT bridge | saorsa-core `network.rs` | Complete |
+| Address suppression after relay | `nat_traversal_api.rs` | Complete |
+
+## Alternatives Considered
+
+1. **QUIC datagrams for forwarding**
+   - Rejected: MTU limitation (~1120 bytes) truncates QUIC Initial packets (1200 bytes minimum)
+
+2. **Endpoint rebind to relay socket**
+   - Rejected: Circular dependency -- the relay control stream runs over the main endpoint, so rebinding it to the relay socket would sever the control path
+
+3. **Initiator-side relay**
+   - Rejected: Does not work for symmetric NAT targets -- the initiator has no way to reach the target without the relay already being established by the target
+
+## References
+
+- **ADR-006**: MASQUE CONNECT-UDP Bind Relay
+- **ADR-005**: Native QUIC NAT Traversal
+- **RFC draft-ietf-masque-connect-udp-listen-10**: MASQUE CONNECT-UDP Bind specification
+- **RFC 9000**: QUIC Transport Protocol (1200-byte Initial packet minimum)

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -4783,11 +4783,12 @@ impl Connection {
                 );
 
                 // Notify the endpoint so the DHT routing table can be updated
-                self.endpoint_events
-                    .push_back(crate::shared::EndpointEventInner::PeerAddressAdvertised {
+                self.endpoint_events.push_back(
+                    crate::shared::EndpointEventInner::PeerAddressAdvertised {
                         peer_addr: self.path.remote,
                         advertised_addr: normalized_addr,
-                    });
+                    },
+                );
 
                 // Trigger validation of this new candidate
                 self.trigger_candidate_validation(normalized_addr, now)?;
@@ -5244,6 +5245,12 @@ impl Connection {
 
         // Check if address discovery is enabled
         if !state.enabled {
+            return;
+        }
+
+        // Only send if the peer negotiated address discovery support.
+        // Sending to a peer that didn't negotiate causes PROTOCOL_VIOLATION.
+        if self.peer_params.address_discovery.is_none() {
             return;
         }
 

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -609,7 +609,18 @@ impl Connection {
             if nat_traversal.check_coordination_timeout(now) {
                 trace!("NAT traversal coordination timed out, may retry");
             }
+            // Clean up expired validations so slots are freed for new candidates
+            let expired = nat_traversal.check_validation_timeouts(now);
+            if !expired.is_empty() {
+                debug!(
+                    "Cleaned up {} expired NAT traversal validations",
+                    expired.len()
+                );
+            }
         }
+
+        // Send OBSERVED_ADDRESS frames to tell peers their external address
+        self.check_for_address_observations(now);
 
         // First priority: NAT traversal PATH_CHALLENGE packets (includes coordination)
         if let Some(challenge) = self.send_nat_traversal_challenge(now, buf) {
@@ -4770,6 +4781,13 @@ impl Connection {
                     "Added remote candidate: {} (seq={}, priority={})",
                     normalized_addr, add_address.sequence, add_address.priority
                 );
+
+                // Notify the endpoint so the DHT routing table can be updated
+                self.endpoint_events
+                    .push_back(crate::shared::EndpointEventInner::PeerAddressAdvertised {
+                        peer_addr: self.path.remote,
+                        advertised_addr: normalized_addr,
+                    });
 
                 // Trigger validation of this new candidate
                 self.trigger_candidate_validation(normalized_addr, now)?;

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -369,7 +369,8 @@ impl Endpoint {
             } => {
                 tracing::info!(
                     "Peer {} advertised new address {}",
-                    peer_addr, advertised_addr
+                    peer_addr,
+                    advertised_addr
                 );
                 self.pending_peer_address_updates
                     .push((peer_addr, advertised_addr));

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -113,6 +113,9 @@ pub struct Endpoint {
     /// Pending hole-punch connection attempts to initiate
     /// These are generated when a target node receives a relayed PUNCH_ME_NOW
     pending_hole_punch_addrs: Vec<SocketAddr>,
+    /// Pending peer address updates from ADD_ADDRESS frames.
+    /// Each entry is (peer_connection_addr, new_advertised_addr).
+    pending_peer_address_updates: Vec<(SocketAddr, SocketAddr)>,
 }
 
 /// Deterministic 32-byte wire ID from a SocketAddr, used to correlate
@@ -158,6 +161,7 @@ impl Endpoint {
             address_change_callback: None,
             pending_relay_events: Vec::new(),
             pending_hole_punch_addrs: Vec::new(),
+            pending_peer_address_updates: Vec::new(),
         }
     }
 
@@ -230,6 +234,14 @@ impl Endpoint {
     /// Drain pending hole-punch addresses that need connection attempts.
     pub fn drain_hole_punch_addrs(&mut self) -> impl Iterator<Item = SocketAddr> + '_ {
         self.pending_hole_punch_addrs.drain(..)
+    }
+
+    /// Drain pending peer address updates from ADD_ADDRESS frames.
+    /// Returns (peer_connection_addr, advertised_addr) pairs.
+    pub fn drain_peer_address_updates(
+        &mut self,
+    ) -> impl Iterator<Item = (SocketAddr, SocketAddr)> + '_ {
+        self.pending_peer_address_updates.drain(..)
     }
 
     /// Set the peer ID for an existing connection
@@ -350,6 +362,17 @@ impl Endpoint {
                 // This event serves as notification to the endpoint for potential coordination
                 // with other components or logging/metrics collection
                 debug!("NAT candidate {} validated successfully", address);
+            }
+            PeerAddressAdvertised {
+                peer_addr,
+                advertised_addr,
+            } => {
+                tracing::info!(
+                    "Peer {} advertised new address {}",
+                    peer_addr, advertised_addr
+                );
+                self.pending_peer_address_updates
+                    .push((peer_addr, advertised_addr));
             }
             InitiateHolePunch { peer_address } => {
                 // Queue a hole-punch connection attempt as a relay event.

--- a/src/high_level/endpoint.rs
+++ b/src/high_level/endpoint.rs
@@ -271,10 +271,7 @@ impl Endpoint {
     }
 
     /// Set channel for peer address update events (ADD_ADDRESS → DHT bridge).
-    pub fn set_peer_address_update_tx(
-        &self,
-        tx: mpsc::UnboundedSender<(SocketAddr, SocketAddr)>,
-    ) {
+    pub fn set_peer_address_update_tx(&self, tx: mpsc::UnboundedSender<(SocketAddr, SocketAddr)>) {
         if let Ok(mut state) = self.inner.0.state.lock() {
             state.peer_address_update_tx = Some(tx);
         }

--- a/src/high_level/endpoint.rs
+++ b/src/high_level/endpoint.rs
@@ -270,6 +270,16 @@ impl Endpoint {
         }
     }
 
+    /// Set channel for peer address update events (ADD_ADDRESS → DHT bridge).
+    pub fn set_peer_address_update_tx(
+        &self,
+        tx: mpsc::UnboundedSender<(SocketAddr, SocketAddr)>,
+    ) {
+        if let Ok(mut state) = self.inner.0.state.lock() {
+            state.peer_address_update_tx = Some(tx);
+        }
+    }
+
     /// Connect to a remote endpoint
     ///
     /// `server_name` must be covered by the certificate presented by the server. This prevents a
@@ -629,6 +639,7 @@ pub(crate) struct State {
     /// Channel for forwarding hole-punch addresses to the NatTraversalEndpoint
     /// for full connection tracking instead of fire-and-forget.
     hole_punch_tx: Option<mpsc::UnboundedSender<SocketAddr>>,
+    peer_address_update_tx: Option<mpsc::UnboundedSender<(SocketAddr, SocketAddr)>>,
 }
 
 #[derive(Debug)]
@@ -759,6 +770,17 @@ impl State {
                         );
                     }
                 }
+            }
+        }
+
+        // Forward peer address updates from ADD_ADDRESS frames to the
+        // NatTraversalEndpoint so it can update the DHT routing table.
+        let address_updates: Vec<(SocketAddr, SocketAddr)> =
+            self.inner.drain_peer_address_updates().collect();
+        for (peer_addr, advertised_addr) in address_updates {
+            did_work = true;
+            if let Some(ref tx) = self.peer_address_update_tx {
+                let _ = tx.send((peer_addr, advertised_addr));
             }
         }
 
@@ -921,6 +943,7 @@ impl EndpointRef {
                 stats: EndpointStats::default(),
                 default_client_config: None,
                 hole_punch_tx: None,
+                peer_address_update_tx: None,
             }),
         }))
     }

--- a/src/masque/mod.rs
+++ b/src/masque/mod.rs
@@ -99,6 +99,7 @@ pub mod migration;
 pub mod relay_client;
 pub mod relay_server;
 pub mod relay_session;
+pub mod relay_socket;
 
 // Re-export primary types for convenience
 pub use capsule::{
@@ -123,3 +124,4 @@ pub use relay_server::{
     SessionInfo,
 };
 pub use relay_session::{RelaySession, RelaySessionConfig, RelaySessionState, RelaySessionStats};
+pub use relay_socket::MasqueRelaySocket;

--- a/src/masque/relay_server.rs
+++ b/src/masque/relay_server.rs
@@ -40,13 +40,13 @@ use std::time::{Duration, Instant};
 use tokio::net::UdpSocket;
 use tokio::sync::RwLock;
 
+use crate::VarInt;
 use crate::high_level::Connection as QuicConnection;
 use crate::masque::{
     Capsule, CompressedDatagram, ConnectUdpRequest, ConnectUdpResponse, Datagram, RelaySession,
     RelaySessionConfig, RelaySessionState, UncompressedDatagram,
 };
 use crate::relay::error::{RelayError, RelayResult, SessionErrorKind};
-use crate::VarInt;
 
 /// Configuration for the MASQUE relay server
 #[derive(Debug, Clone)]
@@ -411,16 +411,12 @@ impl MasqueRelayServer {
             if self.public_address.is_ipv4() {
                 self.public_address.ip()
             } else {
-                self.secondary_address
-                    .unwrap_or(self.public_address)
-                    .ip()
+                self.secondary_address.unwrap_or(self.public_address).ip()
             }
         } else if self.public_address.is_ipv6() {
             self.public_address.ip()
         } else {
-            self.secondary_address
-                .unwrap_or(self.public_address)
-                .ip()
+            self.secondary_address.unwrap_or(self.public_address).ip()
         };
 
         // Bind a real UDP socket for this session's data plane.
@@ -432,25 +428,27 @@ impl MasqueRelayServer {
             SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0)
         };
 
-        let udp_socket = UdpSocket::bind(bind_addr).await.map_err(|e| {
-            RelayError::SessionError {
-                session_id: None,
-                kind: SessionErrorKind::InvalidState {
-                    current_state: format!("UDP bind failed: {}", e),
-                    expected_state: "bound".into(),
-                },
-            }
-        })?;
+        let udp_socket =
+            UdpSocket::bind(bind_addr)
+                .await
+                .map_err(|e| RelayError::SessionError {
+                    session_id: None,
+                    kind: SessionErrorKind::InvalidState {
+                        current_state: format!("UDP bind failed: {}", e),
+                        expected_state: "bound".into(),
+                    },
+                })?;
 
-        let bound_port = udp_socket.local_addr().map_err(|e| {
-            RelayError::SessionError {
+        let bound_port = udp_socket
+            .local_addr()
+            .map_err(|e| RelayError::SessionError {
                 session_id: None,
                 kind: SessionErrorKind::InvalidState {
                     current_state: format!("Failed to get bound address: {}", e),
                     expected_state: "address available".into(),
                 },
-            }
-        })?.port();
+            })?
+            .port();
 
         let advertised_address = SocketAddr::new(public_ip, bound_port);
         let udp_socket = Arc::new(udp_socket);
@@ -882,7 +880,10 @@ impl MasqueRelayServer {
             match sessions.get(&session_id) {
                 Some(s) => s.udp_socket().cloned(),
                 None => {
-                    tracing::warn!(session_id, "Cannot start stream forwarding: session not found");
+                    tracing::warn!(
+                        session_id,
+                        "Cannot start stream forwarding: session not found"
+                    );
                     return;
                 }
             }

--- a/src/masque/relay_server.rs
+++ b/src/masque/relay_server.rs
@@ -33,17 +33,20 @@
 
 use bytes::Bytes;
 use std::collections::HashMap;
-use std::net::SocketAddr;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
+use tokio::net::UdpSocket;
 use tokio::sync::RwLock;
 
+use crate::high_level::Connection as QuicConnection;
 use crate::masque::{
-    Capsule, ConnectUdpRequest, ConnectUdpResponse, Datagram, RelaySession, RelaySessionConfig,
-    RelaySessionState,
+    Capsule, CompressedDatagram, ConnectUdpRequest, ConnectUdpResponse, Datagram, RelaySession,
+    RelaySessionConfig, RelaySessionState, UncompressedDatagram,
 };
 use crate::relay::error::{RelayError, RelayResult, SessionErrorKind};
+use crate::VarInt;
 
 /// Configuration for the MASQUE relay server
 #[derive(Debug, Clone)]
@@ -332,6 +335,24 @@ impl MasqueRelayServer {
         self.public_address
     }
 
+    /// Update the public address when the actual external address is discovered.
+    ///
+    /// The relay server is created with the bind address (e.g., `[::]:10000`),
+    /// but after OBSERVED_ADDRESS frames arrive, the real external IP is known.
+    pub fn set_public_address(&self, addr: SocketAddr) {
+        // Note: This only affects new sessions. Existing sessions keep their
+        // original advertised address.
+        // We use interior mutability via a separate atomic or by accepting
+        // that the field isn't mutable through &self.
+        // For now, log the update — the actual address propagation happens
+        // via the client's relay session response.
+        tracing::info!(
+            old = %self.public_address,
+            new = %addr,
+            "Relay server public address updated"
+        );
+    }
+
     /// Handle a CONNECT-UDP request (both bind and target modes)
     ///
     /// Creates a new session for the client and returns the response.
@@ -385,21 +406,56 @@ impl MasqueRelayServer {
             ));
         }
 
-        // Determine the public address to advertise based on client IP version
-        // For dual-stack: give client the address matching their IP version
-        let advertised_address = if client_addr.is_ipv4() {
+        // Determine the public IP to advertise based on client IP version
+        let public_ip = if client_addr.is_ipv4() {
             if self.public_address.is_ipv4() {
-                self.public_address
+                self.public_address.ip()
             } else {
-                self.secondary_address.unwrap_or(self.public_address)
+                self.secondary_address
+                    .unwrap_or(self.public_address)
+                    .ip()
             }
         } else if self.public_address.is_ipv6() {
-            self.public_address
+            self.public_address.ip()
         } else {
-            self.secondary_address.unwrap_or(self.public_address)
+            self.secondary_address
+                .unwrap_or(self.public_address)
+                .ip()
         };
 
-        // Create new session
+        // Bind a real UDP socket for this session's data plane.
+        // Bind to INADDR_ANY / IN6ADDR_ANY with OS-assigned port, then advertise
+        // our public IP with the bound port.
+        let bind_addr: SocketAddr = if client_addr.is_ipv4() {
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0)
+        } else {
+            SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0)
+        };
+
+        let udp_socket = UdpSocket::bind(bind_addr).await.map_err(|e| {
+            RelayError::SessionError {
+                session_id: None,
+                kind: SessionErrorKind::InvalidState {
+                    current_state: format!("UDP bind failed: {}", e),
+                    expected_state: "bound".into(),
+                },
+            }
+        })?;
+
+        let bound_port = udp_socket.local_addr().map_err(|e| {
+            RelayError::SessionError {
+                session_id: None,
+                kind: SessionErrorKind::InvalidState {
+                    current_state: format!("Failed to get bound address: {}", e),
+                    expected_state: "address available".into(),
+                },
+            }
+        })?.port();
+
+        let advertised_address = SocketAddr::new(public_ip, bound_port);
+        let udp_socket = Arc::new(udp_socket);
+
+        // Create new session with the bound socket
         let session_id = self.next_session_id.fetch_add(1, Ordering::SeqCst);
         let mut session = RelaySession::new(
             session_id,
@@ -407,6 +463,7 @@ impl MasqueRelayServer {
             advertised_address,
         );
         session.set_client_address(client_addr);
+        session.set_udp_socket(udp_socket);
         if requires_bridging {
             session.set_bridging(true);
         }
@@ -431,9 +488,10 @@ impl MasqueRelayServer {
             session_id = session_id,
             client = %client_addr,
             public_addr = %advertised_address,
+            bound_port = bound_port,
             bridging = requires_bridging,
             dual_stack = self.supports_dual_stack(),
-            "MASQUE relay session created"
+            "MASQUE relay session created with bound UDP socket"
         );
 
         Ok(ConnectUdpResponse::success(Some(advertised_address)))
@@ -605,6 +663,341 @@ impl MasqueRelayServer {
         self.stats.record_datagram();
 
         Ok((client_addr, encoded))
+    }
+
+    /// Run the bidirectional forwarding loop for a relay session.
+    ///
+    /// Bridges traffic between the QUIC connection to the client and the session's
+    /// bound UDP socket. Runs until the connection closes or an unrecoverable error occurs.
+    ///
+    /// - **QUIC → UDP**: Client sends HTTP Datagrams via QUIC; the relay decapsulates
+    ///   the target address and payload and sends raw UDP from the bound socket.
+    /// - **UDP → QUIC**: External peers send raw UDP to the bound socket; the relay
+    ///   encapsulates source address + payload as an HTTP Datagram and sends via QUIC.
+    pub async fn run_forwarding_loop(
+        self: &Arc<Self>,
+        session_id: u64,
+        connection: QuicConnection,
+    ) {
+        // Get the UDP socket for this session
+        let udp_socket = {
+            let sessions = self.sessions.read().await;
+            match sessions.get(&session_id) {
+                Some(s) => s.udp_socket().cloned(),
+                None => {
+                    tracing::warn!(session_id, "Cannot start forwarding: session not found");
+                    return;
+                }
+            }
+        };
+
+        let socket = match udp_socket {
+            Some(s) => s,
+            None => {
+                tracing::warn!(session_id, "Cannot start forwarding: no UDP socket bound");
+                return;
+            }
+        };
+
+        tracing::info!(
+            session_id,
+            bound_addr = %socket.local_addr().map(|a| a.to_string()).unwrap_or_default(),
+            "Starting relay forwarding loop"
+        );
+
+        let server = Arc::clone(self);
+        let server2 = Arc::clone(self);
+        let socket2 = Arc::clone(&socket);
+        let conn2 = connection.clone();
+
+        // Run both directions concurrently; exit when either side finishes.
+        tokio::select! {
+            // Direction 1: UDP → QUIC (target responses → relay → client)
+            _ = async {
+                let mut buf = vec![0u8; 65536];
+                loop {
+                    match socket.recv_from(&mut buf).await {
+                        Ok((len, source)) => {
+                            let payload = Bytes::copy_from_slice(&buf[..len]);
+                            tracing::trace!(
+                                session_id,
+                                source = %source,
+                                len,
+                                "Relay: received UDP from target"
+                            );
+
+                            // Encode as uncompressed datagram (includes source address
+                            // so client can decode without context registration)
+                            let datagram = UncompressedDatagram::new(
+                                VarInt::from_u32(0),
+                                source,
+                                payload.clone(),
+                            );
+                            let encoded = datagram.encode();
+
+                            // Record stats
+                            server.stats.record_bytes(encoded.len() as u64);
+                            server.stats.record_datagram();
+
+                            if let Err(e) = connection.send_datagram(encoded) {
+                                let err_str = e.to_string();
+                                if err_str.contains("too large") || err_str.contains("TooLarge") {
+                                    // Skip oversized datagrams (e.g., jumbo UDP from scanners)
+                                    tracing::trace!(
+                                        session_id,
+                                        len,
+                                        "Skipping oversized datagram for relay"
+                                    );
+                                    continue;
+                                } else {
+                                    tracing::debug!(
+                                        session_id,
+                                        error = %e,
+                                        "Fatal datagram send error, stopping UDP→QUIC"
+                                    );
+                                    break;
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            tracing::debug!(
+                                session_id,
+                                error = %e,
+                                "UDP socket recv error, stopping UDP→QUIC"
+                            );
+                            break;
+                        }
+                    }
+                }
+            } => {},
+
+            // Direction 2: QUIC → UDP (client requests → relay → target)
+            _ = async {
+                loop {
+                    match conn2.read_datagram().await {
+                        Ok(data) => {
+                            // Try to decode as uncompressed datagram (includes target address)
+                            let mut cursor = data.clone();
+                            match UncompressedDatagram::decode(&mut cursor) {
+                                Ok(datagram) => {
+                                    let target = datagram.target;
+                                    let payload = &datagram.payload;
+                                    tracing::trace!(
+                                        session_id,
+                                        target = %target,
+                                        len = payload.len(),
+                                        "Relay: forwarding to target via UDP"
+                                    );
+
+                                    // Record stats
+                                    server2.stats.record_bytes(payload.len() as u64);
+                                    server2.stats.record_datagram();
+
+                                    if let Err(e) = socket2.send_to(payload, target).await {
+                                        tracing::warn!(
+                                            session_id,
+                                            target = %target,
+                                            error = %e,
+                                            "Failed to send UDP to target"
+                                        );
+                                    }
+                                }
+                                Err(_) => {
+                                    // Try as compressed datagram — look up context in session
+                                    let mut cursor2 = data.clone();
+                                    if let Ok(compressed) = CompressedDatagram::decode(&mut cursor2) {
+                                        let client_addr = conn2.remote_address();
+                                        let datagram = Datagram::Compressed(compressed);
+                                        let payload_clone = datagram.payload().clone();
+                                        match server2.handle_client_datagram(
+                                            client_addr, datagram, payload_clone,
+                                        ).await {
+                                            DatagramResult::Forward(outbound) => {
+                                                server2.stats.record_bytes(outbound.payload.len() as u64);
+                                                server2.stats.record_datagram();
+                                                if let Err(e) = socket2.send_to(
+                                                    &outbound.payload, outbound.target,
+                                                ).await {
+                                                    tracing::warn!(
+                                                        session_id,
+                                                        target = %outbound.target,
+                                                        error = %e,
+                                                        "Failed to send UDP to target (compressed)"
+                                                    );
+                                                }
+                                            }
+                                            DatagramResult::Error(e) => {
+                                                tracing::debug!(
+                                                    session_id,
+                                                    error = %e,
+                                                    "Failed to process compressed datagram"
+                                                );
+                                            }
+                                            _ => {}
+                                        }
+                                    } else {
+                                        tracing::debug!(
+                                            session_id,
+                                            len = data.len(),
+                                            "Failed to decode relay datagram, skipping"
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            tracing::debug!(
+                                session_id,
+                                error = %e,
+                                "QUIC connection closed, stopping QUIC→UDP"
+                            );
+                            break;
+                        }
+                    }
+                }
+            } => {},
+        }
+
+        tracing::info!(session_id, "Relay forwarding loop ended");
+
+        // Clean up the session
+        if let Err(e) = self.close_session(session_id).await {
+            tracing::debug!(session_id, error = %e, "Error closing session after forwarding ended");
+        }
+    }
+
+    /// Stream-based forwarding loop — uses a persistent bidi QUIC stream instead
+    /// of unreliable QUIC datagrams. This avoids the MTU limitation that causes
+    /// "datagram too large" errors for QUIC Initial packets (1200+ bytes).
+    ///
+    /// Protocol: each forwarded packet is framed as [4-byte BE length][payload].
+    pub async fn run_stream_forwarding_loop(
+        self: &Arc<Self>,
+        session_id: u64,
+        mut send_stream: crate::high_level::SendStream,
+        mut recv_stream: crate::high_level::RecvStream,
+    ) {
+        let udp_socket = {
+            let sessions = self.sessions.read().await;
+            match sessions.get(&session_id) {
+                Some(s) => s.udp_socket().cloned(),
+                None => {
+                    tracing::warn!(session_id, "Cannot start stream forwarding: session not found");
+                    return;
+                }
+            }
+        };
+
+        let socket = match udp_socket {
+            Some(s) => s,
+            None => {
+                tracing::warn!(session_id, "Cannot start stream forwarding: no UDP socket");
+                return;
+            }
+        };
+
+        tracing::info!(
+            session_id,
+            bound_addr = %socket.local_addr().map(|a| a.to_string()).unwrap_or_default(),
+            "Starting stream-based relay forwarding loop"
+        );
+
+        let socket2 = Arc::clone(&socket);
+        let stats = self.stats();
+        let stats2 = self.stats();
+
+        tokio::select! {
+            // Direction 1: UDP → Stream (target → relay → client)
+            _ = async {
+                let mut buf = vec![0u8; 65536];
+                loop {
+                    match socket.recv_from(&mut buf).await {
+                        Ok((len, source)) => {
+                            let payload = Bytes::copy_from_slice(&buf[..len]);
+                            tracing::trace!(
+                                session_id, source = %source, len,
+                                "Stream relay: received UDP from target"
+                            );
+
+                            let datagram = UncompressedDatagram::new(
+                                VarInt::from_u32(0), source, payload,
+                            );
+                            let encoded = datagram.encode();
+
+                            // Write length-prefixed frame to stream
+                            let frame_len = encoded.len() as u32;
+                            if let Err(e) = send_stream.write_all(&frame_len.to_be_bytes()).await {
+                                tracing::debug!(session_id, error = %e, "Stream write error (length)");
+                                break;
+                            }
+                            if let Err(e) = send_stream.write_all(&encoded).await {
+                                tracing::debug!(session_id, error = %e, "Stream write error (data)");
+                                break;
+                            }
+
+                            stats.record_bytes(encoded.len() as u64);
+                            stats.record_datagram();
+                        }
+                        Err(e) => {
+                            tracing::debug!(session_id, error = %e, "UDP recv error");
+                            break;
+                        }
+                    }
+                }
+            } => {},
+
+            // Direction 2: Stream → UDP (client → relay → target)
+            _ = async {
+                loop {
+                    // Read 4-byte length prefix
+                    let mut len_buf = [0u8; 4];
+                    if let Err(e) = recv_stream.read_exact(&mut len_buf).await {
+                        tracing::debug!(session_id, error = %e, "Stream read error (length)");
+                        break;
+                    }
+                    let frame_len = u32::from_be_bytes(len_buf) as usize;
+                    if frame_len > 65536 {
+                        tracing::warn!(session_id, frame_len, "Oversized stream frame, dropping");
+                        break;
+                    }
+
+                    // Read frame data
+                    let mut frame_buf = vec![0u8; frame_len];
+                    if let Err(e) = recv_stream.read_exact(&mut frame_buf).await {
+                        tracing::debug!(session_id, error = %e, "Stream read error (data)");
+                        break;
+                    }
+
+                    // Decode and forward
+                    let mut cursor = Bytes::from(frame_buf);
+                    match UncompressedDatagram::decode(&mut cursor) {
+                        Ok(datagram) => {
+                            tracing::trace!(
+                                session_id, target = %datagram.target,
+                                len = datagram.payload.len(),
+                                "Stream relay: forwarding to target via UDP"
+                            );
+                            stats2.record_bytes(datagram.payload.len() as u64);
+                            stats2.record_datagram();
+                            if let Err(e) = socket2.send_to(&datagram.payload, datagram.target).await {
+                                tracing::warn!(
+                                    session_id, target = %datagram.target, error = %e,
+                                    "Failed to send UDP to target"
+                                );
+                            }
+                        }
+                        Err(_) => {
+                            tracing::debug!(session_id, "Failed to decode stream frame");
+                        }
+                    }
+                }
+            } => {},
+        }
+
+        tracing::info!(session_id, "Stream-based relay forwarding loop ended");
+        if let Err(e) = self.close_session(session_id).await {
+            tracing::debug!(session_id, error = %e, "Error closing session");
+        }
     }
 
     /// Close a specific session

--- a/src/masque/relay_session.rs
+++ b/src/masque/relay_session.rs
@@ -35,6 +35,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant, SystemTime};
+use tokio::net::UdpSocket;
 
 use crate::VarInt;
 use crate::masque::{
@@ -170,6 +171,8 @@ pub struct RelaySession {
     stats: Arc<RelaySessionStats>,
     /// Whether this session is bridging between IPv4 and IPv6
     is_bridging: bool,
+    /// Bound UDP socket for this session (relay data plane)
+    udp_socket: Option<Arc<UdpSocket>>,
     /// Bytes forwarded in current rate limit window
     bytes_in_window: AtomicU64,
     /// Rate limit window start time (epoch millis for atomic storage)
@@ -192,6 +195,7 @@ impl RelaySession {
             last_activity: now,
             stats: Arc::new(RelaySessionStats::new()),
             is_bridging: false,
+            udp_socket: None,
             bytes_in_window: AtomicU64::new(0),
             window_start_ms: AtomicU64::new(now_ms()),
         }
@@ -245,6 +249,21 @@ impl RelaySession {
     /// Get session configuration
     pub fn config(&self) -> &RelaySessionConfig {
         &self.config
+    }
+
+    /// Set the bound UDP socket for this session's data plane
+    pub fn set_udp_socket(&mut self, socket: Arc<UdpSocket>) {
+        self.udp_socket = Some(socket);
+    }
+
+    /// Get the bound UDP socket if available
+    pub fn udp_socket(&self) -> Option<&Arc<UdpSocket>> {
+        self.udp_socket.as_ref()
+    }
+
+    /// Update the public address (e.g., after binding a UDP socket)
+    pub fn set_public_address(&mut self, addr: SocketAddr) {
+        self.public_address = addr;
     }
 
     /// Set bridging flag for IPv4↔IPv6 sessions

--- a/src/masque/relay_socket.rs
+++ b/src/masque/relay_socket.rs
@@ -47,11 +47,7 @@ impl fmt::Debug for MasqueRelaySocket {
             .field("relay_public_addr", &self.relay_public_addr)
             .field(
                 "recv_queue_len",
-                &self
-                    .recv_queue
-                    .lock()
-                    .map(|q| q.len())
-                    .unwrap_or(0),
+                &self.recv_queue.lock().map(|q| q.len()).unwrap_or(0),
             )
             .finish()
     }

--- a/src/masque/relay_socket.rs
+++ b/src/masque/relay_socket.rs
@@ -1,0 +1,221 @@
+// Copyright 2024 Saorsa Labs Ltd.
+//
+// This Saorsa Network Software is licensed under the General Public License (GPL), version 3.
+// Please see the file LICENSE-GPL, or visit <http://www.gnu.org/licenses/> for the full text.
+//
+// Full details available at https://saorsalabs.com/licenses
+
+//! MASQUE Relay Socket
+//!
+//! A virtual UDP socket that routes QUIC packets through a MASQUE relay
+//! via a persistent QUIC stream (length-prefixed framing).
+//!
+//! Implements [`AsyncUdpSocket`] so it can be plugged into a Quinn endpoint
+//! as a transparent replacement for a real UDP socket.
+
+use bytes::Bytes;
+use std::collections::VecDeque;
+use std::fmt;
+use std::io::{self, IoSliceMut};
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll, Waker};
+
+use quinn_udp::{RecvMeta, Transmit};
+
+use crate::VarInt;
+use crate::high_level::{AsyncUdpSocket, UdpPoller};
+use crate::masque::UncompressedDatagram;
+
+/// A virtual UDP socket that tunnels packets through a MASQUE relay
+/// via a persistent QUIC stream with length-prefixed framing.
+pub struct MasqueRelaySocket {
+    /// The relay's public address (returned as our local address)
+    relay_public_addr: SocketAddr,
+    /// Queue of received packets (payload, source_addr)
+    recv_queue: std::sync::Mutex<VecDeque<(Vec<u8>, SocketAddr)>>,
+    /// Waker to notify when new packets arrive
+    recv_waker: std::sync::Mutex<Option<Waker>>,
+    /// Channel for outbound packets (written to the relay stream by background task)
+    send_tx: tokio::sync::mpsc::UnboundedSender<Bytes>,
+}
+
+impl fmt::Debug for MasqueRelaySocket {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MasqueRelaySocket")
+            .field("relay_public_addr", &self.relay_public_addr)
+            .field(
+                "recv_queue_len",
+                &self
+                    .recv_queue
+                    .lock()
+                    .map(|q| q.len())
+                    .unwrap_or(0),
+            )
+            .finish()
+    }
+}
+
+impl MasqueRelaySocket {
+    /// Create a new stream-based relay socket.
+    ///
+    /// Spawns two background tasks:
+    /// - Read from `recv_stream`, decode frames, queue for `poll_recv`
+    /// - Read from `send_tx` channel, write length-prefixed frames to `send_stream`
+    pub fn new(
+        mut send_stream: crate::high_level::SendStream,
+        mut recv_stream: crate::high_level::RecvStream,
+        relay_public_addr: SocketAddr,
+    ) -> Arc<Self> {
+        let (send_tx, mut send_rx) = tokio::sync::mpsc::unbounded_channel::<Bytes>();
+
+        let socket = Arc::new(Self {
+            relay_public_addr,
+            recv_queue: std::sync::Mutex::new(VecDeque::new()),
+            recv_waker: std::sync::Mutex::new(None),
+            send_tx,
+        });
+
+        // Background task: read length-prefixed frames from relay stream → queue
+        let socket_ref = Arc::clone(&socket);
+        tokio::spawn(async move {
+            loop {
+                // Read 4-byte length prefix
+                let mut len_buf = [0u8; 4];
+                if let Err(e) = recv_stream.read_exact(&mut len_buf).await {
+                    tracing::debug!(error = %e, "MasqueRelaySocket: stream read error (length)");
+                    break;
+                }
+                let frame_len = u32::from_be_bytes(len_buf) as usize;
+                if frame_len > 65536 {
+                    tracing::warn!(frame_len, "MasqueRelaySocket: oversized frame");
+                    break;
+                }
+
+                // Read frame data
+                let mut frame_buf = vec![0u8; frame_len];
+                if let Err(e) = recv_stream.read_exact(&mut frame_buf).await {
+                    tracing::debug!(error = %e, "MasqueRelaySocket: stream read error (data)");
+                    break;
+                }
+
+                // Decode as UncompressedDatagram
+                let mut cursor = Bytes::from(frame_buf);
+                match UncompressedDatagram::decode(&mut cursor) {
+                    Ok(datagram) => {
+                        let payload = datagram.payload.to_vec();
+                        let source = datagram.target; // "target" in datagram = source from relay's perspective
+
+                        if let Ok(mut queue) = socket_ref.recv_queue.lock() {
+                            queue.push_back((payload, source));
+                        }
+                        if let Ok(mut waker) = socket_ref.recv_waker.lock() {
+                            if let Some(w) = waker.take() {
+                                w.wake();
+                            }
+                        }
+                    }
+                    Err(_) => {
+                        tracing::trace!("MasqueRelaySocket: failed to decode frame");
+                    }
+                }
+            }
+
+            // Wake pending recv on stream close
+            if let Ok(mut waker) = socket_ref.recv_waker.lock() {
+                if let Some(w) = waker.take() {
+                    w.wake();
+                }
+            }
+        });
+
+        // Background task: write queued outbound packets to relay stream
+        tokio::spawn(async move {
+            while let Some(encoded) = send_rx.recv().await {
+                let frame_len = encoded.len() as u32;
+                if let Err(e) = send_stream.write_all(&frame_len.to_be_bytes()).await {
+                    tracing::debug!(error = %e, "MasqueRelaySocket: stream write error (length)");
+                    break;
+                }
+                if let Err(e) = send_stream.write_all(&encoded).await {
+                    tracing::debug!(error = %e, "MasqueRelaySocket: stream write error (data)");
+                    break;
+                }
+            }
+        });
+
+        socket
+    }
+}
+
+impl AsyncUdpSocket for MasqueRelaySocket {
+    fn create_io_poller(self: Arc<Self>) -> Pin<Box<dyn UdpPoller>> {
+        Box::pin(AlwaysWritable)
+    }
+
+    fn try_send(&self, transmit: &Transmit) -> io::Result<()> {
+        let datagram = UncompressedDatagram::new(
+            VarInt::from_u32(0),
+            transmit.destination,
+            Bytes::copy_from_slice(transmit.contents),
+        );
+        let encoded = datagram.encode();
+
+        self.send_tx
+            .send(encoded)
+            .map_err(|_| io::Error::new(io::ErrorKind::ConnectionAborted, "relay stream closed"))
+    }
+
+    fn poll_recv(
+        &self,
+        cx: &mut Context,
+        bufs: &mut [IoSliceMut<'_>],
+        meta: &mut [RecvMeta],
+    ) -> Poll<io::Result<usize>> {
+        if bufs.is_empty() || meta.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
+
+        if let Ok(mut queue) = self.recv_queue.lock() {
+            if let Some((payload, source)) = queue.pop_front() {
+                let len = payload.len().min(bufs[0].len());
+                bufs[0][..len].copy_from_slice(&payload[..len]);
+
+                let mut recv_meta = RecvMeta::default();
+                recv_meta.len = len;
+                recv_meta.stride = len;
+                recv_meta.addr = source;
+                recv_meta.ecn = None;
+                recv_meta.dst_ip = None;
+                meta[0] = recv_meta;
+
+                return Poll::Ready(Ok(1));
+            }
+        }
+
+        // Register waker for when data arrives
+        if let Ok(mut waker) = self.recv_waker.lock() {
+            *waker = Some(cx.waker().clone());
+        }
+
+        Poll::Pending
+    }
+
+    fn local_addr(&self) -> io::Result<SocketAddr> {
+        Ok(self.relay_public_addr)
+    }
+
+    fn may_fragment(&self) -> bool {
+        false
+    }
+}
+
+#[derive(Debug)]
+struct AlwaysWritable;
+
+impl UdpPoller for AlwaysWritable {
+    fn poll_writable(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+}

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -3373,6 +3373,47 @@ impl NatTraversalEndpoint {
         self.relay_public_addr.lock().ok().and_then(|g| *g)
     }
 
+    /// Check if the proactive relay session is still alive. Returns true if
+    /// no relay was established (nothing to monitor) or the relay is healthy.
+    /// Returns false if a relay was established but the underlying QUIC
+    /// connection has closed.
+    pub fn is_relay_healthy(&self) -> bool {
+        let relay_addr = match self.relay_public_addr.lock().ok().and_then(|g| *g) {
+            Some(addr) => addr,
+            None => return true, // No relay — nothing to monitor
+        };
+
+        // Check if any relay session is still active
+        for entry in self.relay_sessions.iter() {
+            if entry.value().is_active() {
+                return true;
+            }
+        }
+
+        // All relay sessions are dead
+        warn!(
+            "Relay session for {} is dead — resetting for re-establishment",
+            relay_addr
+        );
+        false
+    }
+
+    /// Reset relay state so the next poll cycle can re-establish. Called when
+    /// the relay session is detected as dead.
+    pub fn reset_relay_state(&self) {
+        self.relay_setup_attempted
+            .store(false, std::sync::atomic::Ordering::Relaxed);
+        if let Ok(mut addr) = self.relay_public_addr.lock() {
+            *addr = None;
+        }
+        if let Ok(mut peers) = self.relay_advertised_peers.lock() {
+            peers.clear();
+        }
+        // Remove dead sessions
+        self.relay_sessions.retain(|_, session| session.is_active());
+        info!("Relay state reset — will re-establish on next poll cycle");
+    }
+
     /// Check if relay fallback is available
     pub async fn has_relay_fallback(&self) -> bool {
         match &self.relay_manager {

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -310,7 +310,8 @@ pub struct NatTraversalEndpoint {
     /// When present, allows using transport-provided sockets instead of creating new ones
     transport_registry: Option<Arc<TransportRegistry>>,
     /// Channel for receiving peer address updates (ADD_ADDRESS → DHT bridge)
-    pub(crate) peer_address_update_rx: TokioMutex<mpsc::UnboundedReceiver<(SocketAddr, SocketAddr)>>,
+    pub(crate) peer_address_update_rx:
+        TokioMutex<mpsc::UnboundedReceiver<(SocketAddr, SocketAddr)>>,
     /// Whether symmetric NAT relay setup has been attempted (one-shot)
     relay_setup_attempted: Arc<std::sync::atomic::AtomicBool>,
     /// Relay address to re-advertise to new peers (set after proactive relay setup)
@@ -1398,7 +1399,9 @@ impl NatTraversalEndpoint {
             peer_address_update_rx: TokioMutex::new(peer_addr_rx),
             relay_setup_attempted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             relay_public_addr: Arc::new(std::sync::Mutex::new(None)),
-            relay_advertised_peers: Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
+            relay_advertised_peers: Arc::new(std::sync::Mutex::new(
+                std::collections::HashSet::new(),
+            )),
             server_config: relay_server_config,
             transport_listener_handles: Arc::new(ParkingMutex::new(Vec::new())),
             constrained_engine,
@@ -1806,7 +1809,9 @@ impl NatTraversalEndpoint {
             peer_address_update_rx: TokioMutex::new(peer_addr_rx),
             relay_setup_attempted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             relay_public_addr: Arc::new(std::sync::Mutex::new(None)),
-            relay_advertised_peers: Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
+            relay_advertised_peers: Arc::new(std::sync::Mutex::new(
+                std::collections::HashSet::new(),
+            )),
             server_config: relay_server_config,
             transport_listener_handles: Arc::new(ParkingMutex::new(Vec::new())),
             constrained_engine,
@@ -2725,7 +2730,13 @@ impl NatTraversalEndpoint {
         // Create event channel
         let (event_tx, event_rx) = mpsc::unbounded_channel();
 
-        Ok((endpoint, event_tx, event_rx, local_addr, server_config_for_relay))
+        Ok((
+            endpoint,
+            event_tx,
+            event_rx,
+            local_addr,
+            server_config_for_relay,
+        ))
     }
 
     /// Start listening for incoming connections (async version)
@@ -2927,12 +2938,22 @@ impl NatTraversalEndpoint {
                                                 // Send response with length prefix (stream stays open for data)
                                                 let response_bytes = response.encode();
                                                 let len = response_bytes.len() as u32;
-                                                if let Err(e) = send_stream.write_all(&len.to_be_bytes()).await {
-                                                    warn!("Failed to send relay response length to {}: {}", addr, e);
+                                                if let Err(e) =
+                                                    send_stream.write_all(&len.to_be_bytes()).await
+                                                {
+                                                    warn!(
+                                                        "Failed to send relay response length to {}: {}",
+                                                        addr, e
+                                                    );
                                                     return;
                                                 }
-                                                if let Err(e) = send_stream.write_all(&response_bytes).await {
-                                                    warn!("Failed to send relay response to {}: {}", addr, e);
+                                                if let Err(e) =
+                                                    send_stream.write_all(&response_bytes).await
+                                                {
+                                                    warn!(
+                                                        "Failed to send relay response to {}: {}",
+                                                        addr, e
+                                                    );
                                                     return;
                                                 }
                                                 // Do NOT call finish() — stream stays open for forwarding
@@ -3435,7 +3456,13 @@ impl NatTraversalEndpoint {
     pub async fn establish_relay_session(
         &self,
         relay_addr: SocketAddr,
-    ) -> Result<(Option<SocketAddr>, Option<Arc<crate::masque::MasqueRelaySocket>>), NatTraversalError> {
+    ) -> Result<
+        (
+            Option<SocketAddr>,
+            Option<Arc<crate::masque::MasqueRelaySocket>>,
+        ),
+        NatTraversalError,
+    > {
         // Check if we already have an active session to this relay
         // DashMap provides lock-free .get() that returns Option<Ref<K, V>>
         if let Some(session) = self.relay_sessions.get(&relay_addr) {
@@ -3453,10 +3480,7 @@ impl NatTraversalEndpoint {
         // already listening for bidi streams.
         let connection = if let Some(existing) = self.connections.get(&relay_addr) {
             if existing.close_reason().is_none() {
-                info!(
-                    "Reusing existing peer connection to relay {}",
-                    relay_addr
-                );
+                info!("Reusing existing peer connection to relay {}", relay_addr);
                 existing.clone()
             } else {
                 // Existing connection is dead — fall back to creating a new one
@@ -3533,9 +3557,8 @@ impl NatTraversalEndpoint {
         );
 
         // Create the MasqueRelaySocket from the open streams
-        let relay_socket = public_address.map(|addr| {
-            crate::masque::MasqueRelaySocket::new(send_stream, recv_stream, addr)
-        });
+        let relay_socket = public_address
+            .map(|addr| crate::masque::MasqueRelaySocket::new(send_stream, recv_stream, addr));
 
         // Store the session
         let session = RelaySession {
@@ -4122,14 +4145,10 @@ impl NatTraversalEndpoint {
         // Step 1: Establish relay session with bootstrap
         let (public_addr, relay_socket) = self.establish_relay_session(bootstrap_addr).await?;
         let relay_public_addr = public_addr.ok_or_else(|| {
-            NatTraversalError::ConnectionFailed(
-                "Relay did not provide public address".to_string(),
-            )
+            NatTraversalError::ConnectionFailed("Relay did not provide public address".to_string())
         })?;
         let relay_socket = relay_socket.ok_or_else(|| {
-            NatTraversalError::ConnectionFailed(
-                "Relay did not provide socket".to_string(),
-            )
+            NatTraversalError::ConnectionFailed("Relay did not provide socket".to_string())
         })?;
 
         info!(
@@ -5674,7 +5693,10 @@ impl NatTraversalEndpoint {
                                 break;
                             }
                             Some(_) => {
-                                debug!("Relay candidate {} — connection closed, skipping", candidate);
+                                debug!(
+                                    "Relay candidate {} — connection closed, skipping",
+                                    candidate
+                                );
                             }
                             None => {
                                 debug!("Relay candidate {} — no connection, skipping", candidate);
@@ -5689,7 +5711,8 @@ impl NatTraversalEndpoint {
                                 "No active connection to any relay candidate ({} tried), will retry",
                                 relay_candidates.len()
                             );
-                            relay_setup_attempted.store(false, std::sync::atomic::Ordering::Relaxed);
+                            relay_setup_attempted
+                                .store(false, std::sync::atomic::Ordering::Relaxed);
                             return;
                         }
                     };
@@ -5699,7 +5722,8 @@ impl NatTraversalEndpoint {
                         Ok(streams) => streams,
                         Err(e) => {
                             warn!("Failed to open relay stream to {}: {}", bootstrap, e);
-                            relay_setup_attempted.store(false, std::sync::atomic::Ordering::Relaxed);
+                            relay_setup_attempted
+                                .store(false, std::sync::atomic::Ordering::Relaxed);
                             return;
                         }
                     };
@@ -5734,14 +5758,16 @@ impl NatTraversalEndpoint {
                         return;
                     }
 
-                    let response = match ConnectUdpResponse::decode(&mut bytes::Bytes::from(response_bytes)) {
-                        Ok(r) => r,
-                        Err(e) => {
-                            warn!("Invalid relay response: {}", e);
-                            relay_setup_attempted.store(false, std::sync::atomic::Ordering::Relaxed);
-                            return;
-                        }
-                    };
+                    let response =
+                        match ConnectUdpResponse::decode(&mut bytes::Bytes::from(response_bytes)) {
+                            Ok(r) => r,
+                            Err(e) => {
+                                warn!("Invalid relay response: {}", e);
+                                relay_setup_attempted
+                                    .store(false, std::sync::atomic::Ordering::Relaxed);
+                                return;
+                            }
+                        };
 
                     if !response.is_success() {
                         warn!("Relay rejected: {:?}", response.reason);
@@ -5856,7 +5882,9 @@ impl NatTraversalEndpoint {
                     });
 
                     // Store for re-advertisement to future peers
-                    if let Ok(mut a) = relay_public_addr_store.lock() { *a = Some(relay_public_addr); }
+                    if let Ok(mut a) = relay_public_addr_store.lock() {
+                        *a = Some(relay_public_addr);
+                    }
 
                     // Advertise relay address to all connected peers
                     let mut advertised = 0;
@@ -5866,7 +5894,9 @@ impl NatTraversalEndpoint {
                         match conn.send_nat_address_advertisement(relay_public_addr, 100) {
                             Ok(_) => {
                                 advertised += 1;
-                                if let Ok(mut p) = relay_advertised_peers_store.lock() { p.insert(peer); }
+                                if let Ok(mut p) = relay_advertised_peers_store.lock() {
+                                    p.insert(peer);
+                                }
                             }
                             Err(e) => {
                                 debug!("Failed to advertise relay to {}: {}", entry.key(), e);
@@ -5887,21 +5917,39 @@ impl NatTraversalEndpoint {
             let relay_addr = self.relay_public_addr.lock().ok().and_then(|g| *g);
             if let Some(relay_addr) = relay_addr {
                 let unadvertised: Vec<SocketAddr> = {
-                    let advertised = self.relay_advertised_peers.lock().unwrap_or_else(|e| e.into_inner());
-                    self.connections.iter()
-                        .filter(|e| !advertised.contains(e.key()) && e.value().close_reason().is_none())
+                    let advertised = self
+                        .relay_advertised_peers
+                        .lock()
+                        .unwrap_or_else(|e| e.into_inner());
+                    self.connections
+                        .iter()
+                        .filter(|e| {
+                            !advertised.contains(e.key()) && e.value().close_reason().is_none()
+                        })
                         .map(|e| *e.key())
                         .collect()
                 };
                 if !unadvertised.is_empty() {
-                    info!("Relay re-advertise: {} new peers to notify about {}", unadvertised.len(), relay_addr);
+                    info!(
+                        "Relay re-advertise: {} new peers to notify about {}",
+                        unadvertised.len(),
+                        relay_addr
+                    );
                 }
                 for peer_addr in unadvertised {
                     if let Some(mut entry) = self.connections.get_mut(&peer_addr) {
-                        match entry.value_mut().send_nat_address_advertisement(relay_addr, 100) {
+                        match entry
+                            .value_mut()
+                            .send_nat_address_advertisement(relay_addr, 100)
+                        {
                             Ok(_) => {
-                                info!("Re-advertised relay {} to new peer {}", relay_addr, peer_addr);
-                                if let Ok(mut a) = self.relay_advertised_peers.lock() { a.insert(peer_addr); }
+                                info!(
+                                    "Re-advertised relay {} to new peer {}",
+                                    relay_addr, peer_addr
+                                );
+                                if let Ok(mut a) = self.relay_advertised_peers.lock() {
+                                    a.insert(peer_addr);
+                                }
                             }
                             Err(_) => {}
                         }

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -5596,15 +5596,17 @@ impl NatTraversalEndpoint {
             self.relay_setup_attempted
                 .store(true, std::sync::atomic::Ordering::Relaxed);
 
-            // Find a bootstrap node to use as relay
-            let bootstrap_addr = {
+            // Collect ALL bootstrap nodes as relay candidates, not just the first.
+            // The spawned task iterates through them until one succeeds.
+            let relay_candidates: Vec<SocketAddr> = {
                 let nodes = self.bootstrap_nodes.read();
-                nodes.first().map(|n| n.address)
+                nodes.iter().map(|n| n.address).collect()
             };
 
-            if let Some(bootstrap) = bootstrap_addr {
+            if relay_candidates.is_empty() {
+                debug!("Symmetric NAT detected but no bootstrap nodes available for relay");
+            } else {
                 // Clone self reference for the spawned task
-                // We need: connections, relay_sessions, inner_endpoint, config, relay_manager
                 let connections = self.connections.clone();
                 let relay_sessions = self.relay_sessions.clone();
                 let relay_setup_attempted = self.relay_setup_attempted.clone();
@@ -5614,18 +5616,38 @@ impl NatTraversalEndpoint {
                 let server_config = self.server_config.clone();
 
                 tokio::spawn(async move {
-                    // Create a minimal NatTraversalEndpoint-like context for setup_proactive_relay
-                    // We just need the relay session to be established and the endpoint rebound
                     info!(
-                        "Spawning proactive relay setup for symmetric NAT via {}",
-                        bootstrap
+                        "Spawning proactive relay setup for symmetric NAT — {} candidates",
+                        relay_candidates.len()
                     );
 
-                    // Reuse existing connection to bootstrap
-                    let connection = match connections.get(&bootstrap) {
-                        Some(conn) if conn.close_reason().is_none() => conn.clone(),
-                        _ => {
-                            warn!("No active connection to bootstrap {} for relay setup", bootstrap);
+                    let mut connection = None;
+                    let mut bootstrap = relay_candidates[0]; // default, overwritten on success
+
+                    for candidate in &relay_candidates {
+                        match connections.get(candidate) {
+                            Some(conn) if conn.close_reason().is_none() => {
+                                info!("Relay candidate {} — active connection, trying", candidate);
+                                bootstrap = *candidate;
+                                connection = Some(conn.clone());
+                                break;
+                            }
+                            Some(_) => {
+                                debug!("Relay candidate {} — connection closed, skipping", candidate);
+                            }
+                            None => {
+                                debug!("Relay candidate {} — no connection, skipping", candidate);
+                            }
+                        }
+                    }
+
+                    let connection = match connection {
+                        Some(c) => c,
+                        None => {
+                            warn!(
+                                "No active connection to any relay candidate ({} tried), will retry",
+                                relay_candidates.len()
+                            );
                             relay_setup_attempted.store(false, std::sync::atomic::Ordering::Relaxed);
                             return;
                         }
@@ -5816,8 +5838,6 @@ impl NatTraversalEndpoint {
                         relay_public_addr, advertised
                     );
                 });
-            } else {
-                debug!("Symmetric NAT detected but no bootstrap nodes available for relay");
             }
         }
 

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -309,6 +309,16 @@ pub struct NatTraversalEndpoint {
     /// Transport registry for multi-transport support
     /// When present, allows using transport-provided sockets instead of creating new ones
     transport_registry: Option<Arc<TransportRegistry>>,
+    /// Channel for receiving peer address updates (ADD_ADDRESS → DHT bridge)
+    pub(crate) peer_address_update_rx: TokioMutex<mpsc::UnboundedReceiver<(SocketAddr, SocketAddr)>>,
+    /// Whether symmetric NAT relay setup has been attempted (one-shot)
+    relay_setup_attempted: Arc<std::sync::atomic::AtomicBool>,
+    /// Relay address to re-advertise to new peers (set after proactive relay setup)
+    relay_public_addr: Arc<std::sync::Mutex<Option<SocketAddr>>>,
+    /// Peers already advertised the relay address to
+    relay_advertised_peers: Arc<std::sync::Mutex<std::collections::HashSet<SocketAddr>>>,
+    /// Server config for creating secondary endpoints (e.g., relay accept endpoint)
+    server_config: Option<crate::ServerConfig>,
     /// Task handles for transport listener tasks
     /// Used for cleanup on shutdown
     transport_listener_handles: Arc<ParkingMutex<Vec<tokio::task::JoinHandle<()>>>>,
@@ -1020,6 +1030,16 @@ pub enum NatTraversalEvent {
         /// Our observed external address
         address: SocketAddr,
     },
+    /// A connected peer advertised a new reachable address (ADD_ADDRESS frame).
+    ///
+    /// The upper layer should update its routing table so that future lookups
+    /// for this peer return the advertised address.
+    PeerAddressUpdated {
+        /// The connected peer that sent the advertisement
+        peer_addr: SocketAddr,
+        /// The address the peer is advertising as reachable
+        advertised_addr: SocketAddr,
+    },
 }
 
 /// Errors that can occur during NAT traversal
@@ -1273,7 +1293,7 @@ impl NatTraversalEndpoint {
             .as_ref()
             .map(|arc| arc.as_ref())
             .unwrap_or(&empty_registry);
-        let (inner_endpoint, event_tx, event_rx, local_addr) =
+        let (inner_endpoint, event_tx, event_rx, local_addr, relay_server_config) =
             Self::create_inner_endpoint(&config, token_store, registry_ref, None).await?;
 
         // Update discovery manager with the actual bound address
@@ -1345,6 +1365,10 @@ impl NatTraversalEndpoint {
         // instead of doing fire-and-forget connections at the Quinn level.
         inner_endpoint.set_hole_punch_tx(hole_punch_tx);
 
+        // Channel for peer address updates (ADD_ADDRESS → DHT bridge)
+        let (peer_addr_tx, peer_addr_rx) = mpsc::unbounded_channel();
+        inner_endpoint.set_peer_address_update_tx(peer_addr_tx);
+
         // Channel for background handshake completion (persistent across accept calls)
         let (hs_tx, hs_rx) = mpsc::channel(32);
 
@@ -1371,6 +1395,11 @@ impl NatTraversalEndpoint {
             successful_candidates: Arc::new(dashmap::DashMap::new()),
             transport_candidates: Arc::new(dashmap::DashMap::new()),
             transport_registry,
+            peer_address_update_rx: TokioMutex::new(peer_addr_rx),
+            relay_setup_attempted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            relay_public_addr: Arc::new(std::sync::Mutex::new(None)),
+            relay_advertised_peers: Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
+            server_config: relay_server_config,
             transport_listener_handles: Arc::new(ParkingMutex::new(Vec::new())),
             constrained_engine,
             constrained_event_tx: constrained_event_tx.clone(),
@@ -1549,6 +1578,7 @@ impl NatTraversalEndpoint {
         let connections_clone = endpoint.connections.clone();
 
         let local_session_id = DiscoverySessionId::Local;
+        let relay_setup_attempted_clone = endpoint.relay_setup_attempted.clone();
         tokio::spawn(async move {
             Self::poll_discovery(
                 discovery_manager_clone,
@@ -1557,6 +1587,7 @@ impl NatTraversalEndpoint {
                 connections_clone,
                 event_callback_for_poll,
                 local_session_id,
+                relay_setup_attempted_clone,
             )
             .await;
         });
@@ -1670,7 +1701,7 @@ impl NatTraversalEndpoint {
             .as_ref()
             .map(|arc| arc.as_ref())
             .unwrap_or(&empty_registry);
-        let (inner_endpoint, event_tx, event_rx, local_addr) =
+        let (inner_endpoint, event_tx, event_rx, local_addr, relay_server_config) =
             Self::create_inner_endpoint(&config, token_store, registry_ref, quinn_socket).await?;
 
         // Update discovery manager with the actual bound address
@@ -1742,6 +1773,10 @@ impl NatTraversalEndpoint {
         // instead of doing fire-and-forget connections at the Quinn level.
         inner_endpoint.set_hole_punch_tx(hole_punch_tx);
 
+        // Channel for peer address updates (ADD_ADDRESS → DHT bridge)
+        let (peer_addr_tx, peer_addr_rx) = mpsc::unbounded_channel();
+        inner_endpoint.set_peer_address_update_tx(peer_addr_tx);
+
         // Channel for background handshake completion (persistent across accept calls)
         let (hs_tx, hs_rx) = mpsc::channel(32);
 
@@ -1768,6 +1803,11 @@ impl NatTraversalEndpoint {
             successful_candidates: Arc::new(dashmap::DashMap::new()),
             transport_candidates: Arc::new(dashmap::DashMap::new()),
             transport_registry,
+            peer_address_update_rx: TokioMutex::new(peer_addr_rx),
+            relay_setup_attempted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            relay_public_addr: Arc::new(std::sync::Mutex::new(None)),
+            relay_advertised_peers: Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
+            server_config: relay_server_config,
             transport_listener_handles: Arc::new(ParkingMutex::new(Vec::new())),
             constrained_engine,
             constrained_event_tx: constrained_event_tx.clone(),
@@ -1946,6 +1986,7 @@ impl NatTraversalEndpoint {
         let connections_clone = endpoint.connections.clone();
 
         let local_session_id = DiscoverySessionId::Local;
+        let relay_setup_attempted_clone = endpoint.relay_setup_attempted.clone();
         tokio::spawn(async move {
             Self::poll_discovery(
                 discovery_manager_clone,
@@ -1954,6 +1995,7 @@ impl NatTraversalEndpoint {
                 connections_clone,
                 event_callback_for_poll,
                 local_session_id,
+                relay_setup_attempted_clone,
             )
             .await;
         });
@@ -2461,6 +2503,7 @@ impl NatTraversalEndpoint {
             mpsc::UnboundedSender<NatTraversalEvent>,
             mpsc::UnboundedReceiver<NatTraversalEvent>,
             SocketAddr,
+            Option<crate::ServerConfig>,
         ),
         NatTraversalError,
     > {
@@ -2656,6 +2699,9 @@ impl NatTraversalEndpoint {
             NatTraversalError::ConfigError("No compatible async runtime found".to_string())
         })?;
 
+        // Clone server config for potential secondary endpoint (relay accept)
+        let server_config_for_relay = server_config.clone();
+
         let mut endpoint = InnerEndpoint::new(
             EndpointConfig::default(),
             server_config,
@@ -2679,7 +2725,7 @@ impl NatTraversalEndpoint {
         // Create event channel
         let (event_tx, event_rx) = mpsc::unbounded_channel();
 
-        Ok((endpoint, event_tx, event_rx, local_addr))
+        Ok((endpoint, event_tx, event_rx, local_addr, server_config_for_relay))
     }
 
     /// Start listening for incoming connections (async version)
@@ -2837,11 +2883,28 @@ impl NatTraversalEndpoint {
                 Ok((mut send_stream, mut recv_stream)) => {
                     let server = Arc::clone(&relay_server);
                     let addr = client_addr;
+                    let _conn_for_relay = connection.clone();
 
                     tokio::spawn(async move {
-                        // Read the request (limit to 1KB for safety)
-                        match recv_stream.read_to_end(1024).await {
-                            Ok(request_bytes) => {
+                        // Read length-prefixed request
+                        let mut req_len_buf = [0u8; 4];
+                        if let Err(e) = recv_stream.read_exact(&mut req_len_buf).await {
+                            debug!("Failed to read relay request length from {}: {}", addr, e);
+                            return;
+                        }
+                        let req_len = u32::from_be_bytes(req_len_buf) as usize;
+                        if req_len > 1024 {
+                            debug!("Relay request too large from {}: {} bytes", addr, req_len);
+                            return;
+                        }
+                        let mut request_bytes = vec![0u8; req_len];
+                        if let Err(e) = recv_stream.read_exact(&mut request_bytes).await {
+                            debug!("Failed to read relay request from {}: {}", addr, e);
+                            return;
+                        }
+
+                        {
+                            {
                                 // Try to parse as CONNECT-UDP request
                                 match ConnectUdpRequest::decode(&mut bytes::Bytes::from(
                                     request_bytes,
@@ -2855,26 +2918,42 @@ impl NatTraversalEndpoint {
                                         // Handle the request via relay server
                                         match server.handle_connect_request(&request, addr).await {
                                             Ok(response) => {
+                                                let is_success = response.is_success();
                                                 debug!(
                                                     "Sending CONNECT-UDP response to {}: {:?}",
                                                     addr, response
                                                 );
 
-                                                // Send the response
+                                                // Send response with length prefix (stream stays open for data)
                                                 let response_bytes = response.encode();
-                                                if let Err(e) =
-                                                    send_stream.write_all(&response_bytes).await
-                                                {
-                                                    warn!(
-                                                        "Failed to send relay response to {}: {}",
-                                                        addr, e
-                                                    );
+                                                let len = response_bytes.len() as u32;
+                                                if let Err(e) = send_stream.write_all(&len.to_be_bytes()).await {
+                                                    warn!("Failed to send relay response length to {}: {}", addr, e);
+                                                    return;
                                                 }
-                                                if let Err(e) = send_stream.finish() {
-                                                    warn!(
-                                                        "Failed to finish relay stream to {}: {}",
-                                                        addr, e
-                                                    );
+                                                if let Err(e) = send_stream.write_all(&response_bytes).await {
+                                                    warn!("Failed to send relay response to {}: {}", addr, e);
+                                                    return;
+                                                }
+                                                // Do NOT call finish() — stream stays open for forwarding
+
+                                                // Start stream-based forwarding loop
+                                                if is_success {
+                                                    if let Some(session_info) =
+                                                        server.get_session_for_client(addr).await
+                                                    {
+                                                        info!(
+                                                            "Starting stream-based relay forwarding for session {} (client: {})",
+                                                            session_info.session_id, addr
+                                                        );
+                                                        server
+                                                            .run_stream_forwarding_loop(
+                                                                session_info.session_id,
+                                                                send_stream,
+                                                                recv_stream,
+                                                            )
+                                                            .await;
+                                                    }
                                                 }
                                             }
                                             Err(e) => {
@@ -2902,9 +2981,6 @@ impl NatTraversalEndpoint {
                                     }
                                 }
                             }
-                            Err(e) => {
-                                debug!("Failed to read relay request from {}: {}", addr, e);
-                            }
                         }
                     });
                 }
@@ -2928,6 +3004,7 @@ impl NatTraversalEndpoint {
         connections: Arc<dashmap::DashMap<SocketAddr, InnerConnection>>,
         event_callback: Option<Arc<dyn Fn(NatTraversalEvent) + Send + Sync>>,
         local_session_id: DiscoverySessionId,
+        relay_setup_attempted: Arc<std::sync::atomic::AtomicBool>,
     ) {
         use tokio::time::{Duration, interval};
 
@@ -2995,8 +3072,11 @@ impl NatTraversalEndpoint {
 
             // 2. Send ADD_ADDRESS to all peers for newly discovered addresses
             // (Critical for CGNAT - peers need to know our external address to hole-punch back)
-            for addr in &new_addresses {
-                broadcast_address_to_peers(&connections, *addr, 100);
+            // Skip if relay is active — only the relay address should be advertised.
+            if !relay_setup_attempted.load(std::sync::atomic::Ordering::Relaxed) {
+                for addr in &new_addresses {
+                    broadcast_address_to_peers(&connections, *addr, 100);
+                }
             }
 
             // 3. Poll the discovery manager
@@ -3288,6 +3368,11 @@ impl NatTraversalEndpoint {
         self.relay_manager.clone()
     }
 
+    /// Get the relay public address, if a proactive relay has been established.
+    pub fn relay_public_addr(&self) -> Option<SocketAddr> {
+        self.relay_public_addr.lock().ok().and_then(|g| *g)
+    }
+
     /// Check if relay fallback is available
     pub async fn has_relay_fallback(&self) -> bool {
         match &self.relay_manager {
@@ -3309,67 +3394,83 @@ impl NatTraversalEndpoint {
     pub async fn establish_relay_session(
         &self,
         relay_addr: SocketAddr,
-    ) -> Result<Option<SocketAddr>, NatTraversalError> {
+    ) -> Result<(Option<SocketAddr>, Option<Arc<crate::masque::MasqueRelaySocket>>), NatTraversalError> {
         // Check if we already have an active session to this relay
         // DashMap provides lock-free .get() that returns Option<Ref<K, V>>
         if let Some(session) = self.relay_sessions.get(&relay_addr) {
             if session.is_active() {
                 debug!("Reusing existing relay session to {}", relay_addr);
-                return Ok(session.public_address);
+                return Ok((session.public_address, None));
             }
         }
 
-        let endpoint = self.inner_endpoint.as_ref().ok_or_else(|| {
-            NatTraversalError::ConfigError("QUIC endpoint not initialized".to_string())
-        })?;
-
         info!("Establishing relay session to {}", relay_addr);
 
-        // Connect to the relay server
-        // Use the relay address as server name for TLS (relay servers use certificates)
-        let server_name = relay_addr.ip().to_string();
-        let connecting = endpoint.connect(relay_addr, &server_name).map_err(|e| {
-            NatTraversalError::ConnectionFailed(format!(
-                "Failed to initiate relay connection: {}",
-                e
-            ))
-        })?;
-
-        let connection = timeout(self.config.coordination_timeout, connecting)
-            .await
-            .map_err(|_| NatTraversalError::Timeout)?
-            .map_err(|e| {
-                NatTraversalError::ConnectionFailed(format!("Relay connection failed: {}", e))
-            })?;
-
-        info!("Connected to relay server {}", relay_addr);
+        // Prefer reusing an existing peer connection to the relay.
+        // The relay server's handle_relay_requests is spawned for each ACCEPTED
+        // connection, so using the existing connection ensures a handler is
+        // already listening for bidi streams.
+        let connection = if let Some(existing) = self.connections.get(&relay_addr) {
+            if existing.close_reason().is_none() {
+                info!(
+                    "Reusing existing peer connection to relay {}",
+                    relay_addr
+                );
+                existing.clone()
+            } else {
+                // Existing connection is dead — fall back to creating a new one
+                drop(existing);
+                self.connect_new_to_relay(relay_addr).await?
+            }
+        } else {
+            // No existing connection — create one
+            self.connect_new_to_relay(relay_addr).await?
+        };
 
         // Open a bidirectional stream for the CONNECT-UDP handshake
         let (mut send_stream, mut recv_stream) = connection.open_bi().await.map_err(|e| {
             NatTraversalError::ConnectionFailed(format!("Failed to open relay stream: {}", e))
         })?;
 
-        // Create and send CONNECT-UDP Bind request
+        // Send CONNECT-UDP Bind request with length prefix (stream stays open for data)
         let request = ConnectUdpRequest::bind_any();
         let request_bytes = request.encode();
 
         debug!("Sending CONNECT-UDP Bind request to relay: {:?}", request);
 
+        // Length-prefixed framing: [4-byte BE length][payload]
+        let req_len = request_bytes.len() as u32;
+        send_stream
+            .write_all(&req_len.to_be_bytes())
+            .await
+            .map_err(|e| {
+                NatTraversalError::ConnectionFailed(format!("Failed to send request length: {}", e))
+            })?;
         send_stream.write_all(&request_bytes).await.map_err(|e| {
             NatTraversalError::ConnectionFailed(format!("Failed to send relay request: {}", e))
         })?;
+        // Do NOT call finish() — stream stays open for data forwarding
 
-        // Signal we're done sending the request
-        send_stream.finish().map_err(|e| {
-            NatTraversalError::ConnectionFailed(format!("Failed to finish relay stream: {}", e))
-        })?;
+        // Read length-prefixed response
+        let mut resp_len_buf = [0u8; 4];
+        recv_stream
+            .read_exact(&mut resp_len_buf)
+            .await
+            .map_err(|e| {
+                NatTraversalError::ConnectionFailed(format!(
+                    "Failed to read relay response length: {}",
+                    e
+                ))
+            })?;
+        let resp_len = u32::from_be_bytes(resp_len_buf) as usize;
+        let mut response_bytes = vec![0u8; resp_len];
+        recv_stream
+            .read_exact(&mut response_bytes)
+            .await
+            .map_err(|e| {
+                NatTraversalError::ConnectionFailed(format!("Failed to read relay response: {}", e))
+            })?;
 
-        // Read the response (limit to 1KB for safety)
-        let response_bytes = recv_stream.read_to_end(1024).await.map_err(|e| {
-            NatTraversalError::ConnectionFailed(format!("Failed to read relay response: {}", e))
-        })?;
-
-        // Parse the response
         let response = ConnectUdpResponse::decode(&mut bytes::Bytes::from(response_bytes))
             .map_err(|e| {
                 NatTraversalError::ProtocolError(format!("Invalid relay response: {}", e))
@@ -3389,6 +3490,11 @@ impl NatTraversalEndpoint {
             "Relay session established with public address: {:?}",
             public_address
         );
+
+        // Create the MasqueRelaySocket from the open streams
+        let relay_socket = public_address.map(|addr| {
+            crate::masque::MasqueRelaySocket::new(send_stream, recv_stream, addr)
+        });
 
         // Store the session
         let session = RelaySession {
@@ -3410,7 +3516,37 @@ impl NatTraversalEndpoint {
             }
         }
 
-        Ok(public_address)
+        Ok((public_address, relay_socket))
+    }
+
+    /// Create a fresh QUIC connection to a relay server.
+    ///
+    /// Used as a fallback when no existing peer connection is available.
+    async fn connect_new_to_relay(
+        &self,
+        relay_addr: SocketAddr,
+    ) -> Result<InnerConnection, NatTraversalError> {
+        let endpoint = self.inner_endpoint.as_ref().ok_or_else(|| {
+            NatTraversalError::ConfigError("QUIC endpoint not initialized".to_string())
+        })?;
+
+        let server_name = relay_addr.ip().to_string();
+        let connecting = endpoint.connect(relay_addr, &server_name).map_err(|e| {
+            NatTraversalError::ConnectionFailed(format!(
+                "Failed to initiate relay connection: {}",
+                e
+            ))
+        })?;
+
+        let connection = timeout(self.config.coordination_timeout, connecting)
+            .await
+            .map_err(|_| NatTraversalError::Timeout)?
+            .map_err(|e| {
+                NatTraversalError::ConnectionFailed(format!("Relay connection failed: {}", e))
+            })?;
+
+        info!("Connected to relay server {}", relay_addr);
+        Ok(connection)
     }
 
     /// Get active relay sessions
@@ -3897,6 +4033,109 @@ impl NatTraversalEndpoint {
 
         debug!("No observed external address available from any connection");
         Ok(None)
+    }
+
+    /// Detect symmetric NAT by checking port diversity across peer connections.
+    ///
+    /// Returns `true` if at least 2 different external ports are observed from
+    /// different peers, indicating that the NAT assigns a different port per
+    /// destination (symmetric NAT behaviour).
+    pub fn is_symmetric_nat(&self) -> bool {
+        let mut observed_ports = std::collections::HashSet::new();
+
+        for entry in self.connections.iter() {
+            if let Some(addr) = entry.value().observed_address() {
+                observed_ports.insert(addr.port());
+            }
+        }
+
+        let is_symmetric = observed_ports.len() >= 2;
+        if is_symmetric {
+            info!(
+                "Symmetric NAT detected: {} different external ports observed ({:?})",
+                observed_ports.len(),
+                observed_ports
+            );
+        }
+        is_symmetric
+    }
+
+    /// Set up proactive relay for a node behind symmetric NAT.
+    ///
+    /// Establishes a MASQUE relay session with the bootstrap node, creates a
+    /// `MasqueRelaySocket` from the relay connection, rebinds the Quinn endpoint
+    /// to route all traffic through the relay, and advertises the relay's bound
+    /// address to all connected peers.
+    ///
+    /// After this, the node is reachable via the relay's bound UDP socket.
+    /// Other nodes connect to the relay address transparently (normal QUIC).
+    pub async fn setup_proactive_relay(
+        &self,
+        bootstrap_addr: SocketAddr,
+    ) -> Result<SocketAddr, NatTraversalError> {
+        info!(
+            "Setting up proactive relay via bootstrap {} for symmetric NAT",
+            bootstrap_addr
+        );
+
+        // Step 1: Establish relay session with bootstrap
+        let (public_addr, relay_socket) = self.establish_relay_session(bootstrap_addr).await?;
+        let relay_public_addr = public_addr.ok_or_else(|| {
+            NatTraversalError::ConnectionFailed(
+                "Relay did not provide public address".to_string(),
+            )
+        })?;
+        let relay_socket = relay_socket.ok_or_else(|| {
+            NatTraversalError::ConnectionFailed(
+                "Relay did not provide socket".to_string(),
+            )
+        })?;
+
+        info!(
+            "Relay session established, public address: {}",
+            relay_public_addr
+        );
+
+        // Step 3: Rebind the Quinn endpoint to route through the relay
+        let endpoint = self.inner_endpoint.as_ref().ok_or_else(|| {
+            NatTraversalError::ConfigError("QUIC endpoint not initialized".to_string())
+        })?;
+
+        endpoint.rebind_abstract(relay_socket).map_err(|e| {
+            NatTraversalError::ConnectionFailed(format!(
+                "Failed to rebind endpoint to relay socket: {}",
+                e
+            ))
+        })?;
+
+        info!(
+            "Quinn endpoint rebound to relay socket (relay addr: {})",
+            relay_public_addr
+        );
+
+        // Step 4: Advertise the relay address to all connected peers
+        let mut advertised = 0;
+        for entry in self.connections.iter() {
+            let conn = entry.value().clone();
+            // Use high priority since this is our only reachable address
+            match conn.send_nat_address_advertisement(relay_public_addr, 100) {
+                Ok(_) => advertised += 1,
+                Err(e) => {
+                    debug!(
+                        "Failed to advertise relay address to {}: {}",
+                        entry.key(),
+                        e
+                    );
+                }
+            }
+        }
+
+        info!(
+            "Advertised relay address {} to {} peers",
+            relay_public_addr, advertised
+        );
+
+        Ok(relay_public_addr)
     }
 
     // ============ Multi-Transport Address Advertising ============
@@ -5320,42 +5559,292 @@ impl NatTraversalEndpoint {
         backoff.min(max) + jitter
     }
 
-    /// Check connections for observed addresses and feed them to discovery
+    /// Check connections for observed addresses and trigger symmetric NAT relay if needed.
+    ///
+    /// Called periodically from the discovery polling loop. Once enough OBSERVED_ADDRESS
+    /// observations arrive (≥2 connections with observed addresses), checks for port
+    /// diversity. If symmetric NAT is detected, spawns a one-shot task to set up a
+    /// proactive relay through the first available bootstrap node.
     fn check_connections_for_observed_addresses(
         &self,
         _events: &mut Vec<NatTraversalEvent>,
     ) -> Result<(), NatTraversalError> {
-        // Look for bootstrap connections - they should send us OBSERVED_ADDRESS frames
-        // In the current implementation, we need to wait for the low-level connection
-        // to receive OBSERVED_ADDRESS frames and propagate them up
+        // Count connections with observed addresses
+        let mut observed_count = 0;
+        for entry in self.connections.iter() {
+            if entry.value().observed_address().is_some() {
+                observed_count += 1;
+            }
+        }
 
-        // For now, simulate the discovery for testing
-        // In production, this would be triggered by actual OBSERVED_ADDRESS frames
-        // v0.13.0+: All nodes can discover their external address from any connected peer
-        // DashMap provides lock-free iteration
-        if !self.connections.is_empty() {
-            // Check if we have any bootstrap connections
-            for entry in self.connections.iter() {
-                let remote_addr = entry.value().remote_address();
+        // Need ≥2 observations before we can detect NAT type
+        if observed_count < 2 {
+            return Ok(());
+        }
 
-                // Check if this is a bootstrap node connection
-                // parking_lot::RwLock doesn't poison
-                let is_bootstrap = self
-                    .bootstrap_nodes
-                    .read()
-                    .iter()
-                    .any(|node| node.address == remote_addr);
+        // Only attempt relay setup once
+        if self
+            .relay_setup_attempted
+            .load(std::sync::atomic::Ordering::Relaxed)
+        {
+            return Ok(());
+        }
 
-                if is_bootstrap {
-                    // In a real implementation, we would check the connection for observed addresses
-                    // For now, emit a debug message
-                    debug!(
-                        "Bootstrap connection to {} should provide our external address via OBSERVED_ADDRESS frames",
-                        remote_addr
+        // Check for symmetric NAT (port diversity)
+        if self.is_symmetric_nat() {
+            // Mark as attempted before spawning to avoid races
+            self.relay_setup_attempted
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+
+            // Find a bootstrap node to use as relay
+            let bootstrap_addr = {
+                let nodes = self.bootstrap_nodes.read();
+                nodes.first().map(|n| n.address)
+            };
+
+            if let Some(bootstrap) = bootstrap_addr {
+                // Clone self reference for the spawned task
+                // We need: connections, relay_sessions, inner_endpoint, config, relay_manager
+                let connections = self.connections.clone();
+                let relay_sessions = self.relay_sessions.clone();
+                let relay_setup_attempted = self.relay_setup_attempted.clone();
+                let relay_public_addr_store = self.relay_public_addr.clone();
+                let accepted_addrs_tx = self.accepted_addrs_tx.clone();
+                let relay_advertised_peers_store = self.relay_advertised_peers.clone();
+                let server_config = self.server_config.clone();
+
+                tokio::spawn(async move {
+                    // Create a minimal NatTraversalEndpoint-like context for setup_proactive_relay
+                    // We just need the relay session to be established and the endpoint rebound
+                    info!(
+                        "Spawning proactive relay setup for symmetric NAT via {}",
+                        bootstrap
                     );
 
-                    // The actual observed address would come from the OBSERVED_ADDRESS frame
-                    // received on this connection
+                    // Reuse existing connection to bootstrap
+                    let connection = match connections.get(&bootstrap) {
+                        Some(conn) if conn.close_reason().is_none() => conn.clone(),
+                        _ => {
+                            warn!("No active connection to bootstrap {} for relay setup", bootstrap);
+                            relay_setup_attempted.store(false, std::sync::atomic::Ordering::Relaxed);
+                            return;
+                        }
+                    };
+
+                    // Open bidi stream and send CONNECT-UDP Bind
+                    let (mut send_stream, mut recv_stream) = match connection.open_bi().await {
+                        Ok(streams) => streams,
+                        Err(e) => {
+                            warn!("Failed to open relay stream to {}: {}", bootstrap, e);
+                            relay_setup_attempted.store(false, std::sync::atomic::Ordering::Relaxed);
+                            return;
+                        }
+                    };
+
+                    // Length-prefixed request
+                    let request = ConnectUdpRequest::bind_any();
+                    let req_bytes = request.encode();
+                    let req_len = req_bytes.len() as u32;
+                    if let Err(e) = send_stream.write_all(&req_len.to_be_bytes()).await {
+                        warn!("Failed to send relay request length: {}", e);
+                        relay_setup_attempted.store(false, std::sync::atomic::Ordering::Relaxed);
+                        return;
+                    }
+                    if let Err(e) = send_stream.write_all(&req_bytes).await {
+                        warn!("Failed to send relay request: {}", e);
+                        relay_setup_attempted.store(false, std::sync::atomic::Ordering::Relaxed);
+                        return;
+                    }
+
+                    // Length-prefixed response
+                    let mut resp_len_buf = [0u8; 4];
+                    if let Err(e) = recv_stream.read_exact(&mut resp_len_buf).await {
+                        warn!("Failed to read relay response length: {}", e);
+                        relay_setup_attempted.store(false, std::sync::atomic::Ordering::Relaxed);
+                        return;
+                    }
+                    let resp_len = u32::from_be_bytes(resp_len_buf) as usize;
+                    let mut response_bytes = vec![0u8; resp_len];
+                    if let Err(e) = recv_stream.read_exact(&mut response_bytes).await {
+                        warn!("Failed to read relay response: {}", e);
+                        relay_setup_attempted.store(false, std::sync::atomic::Ordering::Relaxed);
+                        return;
+                    }
+
+                    let response = match ConnectUdpResponse::decode(&mut bytes::Bytes::from(response_bytes)) {
+                        Ok(r) => r,
+                        Err(e) => {
+                            warn!("Invalid relay response: {}", e);
+                            relay_setup_attempted.store(false, std::sync::atomic::Ordering::Relaxed);
+                            return;
+                        }
+                    };
+
+                    if !response.is_success() {
+                        warn!("Relay rejected: {:?}", response.reason);
+                        relay_setup_attempted.store(false, std::sync::atomic::Ordering::Relaxed);
+                        return;
+                    }
+
+                    let relay_public_addr = match response.proxy_public_address {
+                        Some(addr) => {
+                            // If the relay returned an unspecified IP (e.g., [::]:PORT),
+                            // replace with the bootstrap's known IP. The relay server
+                            // binds on INADDR_ANY so it doesn't know its own public IP.
+                            if addr.ip().is_unspecified() {
+                                SocketAddr::new(bootstrap.ip(), addr.port())
+                            } else {
+                                addr
+                            }
+                        }
+                        None => {
+                            warn!("Relay did not provide public address");
+                            return;
+                        }
+                    };
+
+                    info!(
+                        "Proactive relay session established: public addr {} via {}",
+                        relay_public_addr, bootstrap
+                    );
+
+                    // Store relay session
+                    let session = RelaySession {
+                        connection: connection.clone(),
+                        public_address: Some(relay_public_addr),
+                        established_at: std::time::Instant::now(),
+                        relay_addr: bootstrap,
+                    };
+                    relay_sessions.insert(bootstrap, session);
+
+                    // Create a secondary Quinn endpoint on the MasqueRelaySocket.
+                    // This endpoint accepts QUIC connections arriving via the relay's
+                    // forwarding loop. We cannot rebind the main endpoint (circular
+                    // dependency — the relay connection itself would loop).
+                    let relay_socket = crate::masque::MasqueRelaySocket::new(
+                        send_stream,
+                        recv_stream,
+                        relay_public_addr,
+                    );
+
+                    let runtime = match crate::high_level::default_runtime() {
+                        Some(r) => r,
+                        None => {
+                            warn!("No async runtime for relay endpoint");
+                            return;
+                        }
+                    };
+
+                    let relay_endpoint = match crate::high_level::Endpoint::new_with_abstract_socket(
+                        crate::EndpointConfig::default(),
+                        server_config,
+                        relay_socket,
+                        runtime,
+                    ) {
+                        Ok(ep) => ep,
+                        Err(e) => {
+                            warn!("Failed to create relay accept endpoint: {}", e);
+                            return;
+                        }
+                    };
+
+                    info!(
+                        "Secondary relay endpoint created for accepting connections at {}",
+                        relay_public_addr
+                    );
+
+                    // Run accept loop on the secondary endpoint — forward accepted
+                    // connections to the main node's connection handling.
+                    // The connection is stored in the shared connections map AND
+                    // notified via accepted_addrs_tx so the P2pEndpoint can spawn
+                    // a reader task for incoming streams (DHT, chunk protocol, etc.).
+                    let conn_map = connections.clone();
+                    let accepted_tx = accepted_addrs_tx.clone();
+                    tokio::spawn(async move {
+                        loop {
+                            match relay_endpoint.accept().await {
+                                Some(incoming) => {
+                                    match incoming.await {
+                                        Ok(conn) => {
+                                            let remote = conn.remote_address();
+                                            info!(
+                                                "Accepted relayed connection from {} via relay — registering with P2pEndpoint",
+                                                remote
+                                            );
+                                            // Store in the shared connections map so the
+                                            // send path can find the connection.
+                                            conn_map.insert(remote, conn);
+                                            // Notify P2pEndpoint so it spawns a reader
+                                            // task and registers the peer. Without this,
+                                            // incoming streams (DHT, chunk) are never read.
+                                            let _ = accepted_tx.send(remote);
+                                        }
+                                        Err(e) => {
+                                            debug!("Relayed connection handshake failed: {}", e);
+                                        }
+                                    }
+                                }
+                                None => {
+                                    info!("Relay accept endpoint closed");
+                                    break;
+                                }
+                            }
+                        }
+                    });
+
+                    // Store for re-advertisement to future peers
+                    if let Ok(mut a) = relay_public_addr_store.lock() { *a = Some(relay_public_addr); }
+
+                    // Advertise relay address to all connected peers
+                    let mut advertised = 0;
+                    for entry in connections.iter() {
+                        let peer = *entry.key();
+                        let conn = entry.value().clone();
+                        match conn.send_nat_address_advertisement(relay_public_addr, 100) {
+                            Ok(_) => {
+                                advertised += 1;
+                                if let Ok(mut p) = relay_advertised_peers_store.lock() { p.insert(peer); }
+                            }
+                            Err(e) => {
+                                debug!("Failed to advertise relay to {}: {}", entry.key(), e);
+                            }
+                        }
+                    }
+
+                    info!(
+                        "Proactive relay active at {} — advertised to {} peers",
+                        relay_public_addr, advertised
+                    );
+                });
+            } else {
+                debug!("Symmetric NAT detected but no bootstrap nodes available for relay");
+            }
+        }
+
+        // Re-advertise relay address to peers that connected after initial setup
+        {
+            let relay_addr = self.relay_public_addr.lock().ok().and_then(|g| *g);
+            if let Some(relay_addr) = relay_addr {
+                let unadvertised: Vec<SocketAddr> = {
+                    let advertised = self.relay_advertised_peers.lock().unwrap_or_else(|e| e.into_inner());
+                    self.connections.iter()
+                        .filter(|e| !advertised.contains(e.key()) && e.value().close_reason().is_none())
+                        .map(|e| *e.key())
+                        .collect()
+                };
+                if !unadvertised.is_empty() {
+                    info!("Relay re-advertise: {} new peers to notify about {}", unadvertised.len(), relay_addr);
+                }
+                for peer_addr in unadvertised {
+                    if let Some(mut entry) = self.connections.get_mut(&peer_addr) {
+                        match entry.value_mut().send_nat_address_advertisement(relay_addr, 100) {
+                            Ok(_) => {
+                                info!("Re-advertised relay {} to new peer {}", relay_addr, peer_addr);
+                                if let Ok(mut a) = self.relay_advertised_peers.lock() { a.insert(peer_addr); }
+                            }
+                            Err(_) => {}
+                        }
+                    }
                 }
             }
         }
@@ -5736,6 +6225,26 @@ impl NatTraversalEndpoint {
                     "Failed to initiate tracked hole-punch connection to {}: {}",
                     peer_address, e
                 );
+            }
+        }
+    }
+
+    /// Process pending peer address updates from ADD_ADDRESS frames.
+    ///
+    /// Emits `NatTraversalEvent::PeerAddressUpdated` for each update so the
+    /// upper layer (saorsa-core) can update its DHT routing table.
+    pub async fn process_pending_peer_address_updates(&self) {
+        let mut rx = self.peer_address_update_rx.lock().await;
+        while let Ok((peer_addr, advertised_addr)) = rx.try_recv() {
+            info!(
+                "Peer {} advertised new address {} — emitting PeerAddressUpdated event",
+                peer_addr, advertised_addr
+            );
+            if let Some(ref tx) = self.event_tx {
+                let _ = tx.send(NatTraversalEvent::PeerAddressUpdated {
+                    peer_addr,
+                    advertised_addr,
+                });
             }
         }
     }
@@ -6228,6 +6737,16 @@ impl NatTraversalEndpoint {
         addr: SocketAddr,
         candidate: &CandidateAddress,
     ) -> Result<(), NatTraversalError> {
+        // After relay setup, suppress automatic candidate advertisements.
+        // The relay address is the only reachable address for this node;
+        // advertising NATted addresses would overwrite it in peers' DHTs.
+        if self
+            .relay_setup_attempted
+            .load(std::sync::atomic::Ordering::Relaxed)
+        {
+            return Ok(());
+        }
+
         debug!(
             "Sending candidate advertisement to {}: {}",
             addr, candidate.address

--- a/src/node.rs
+++ b/src/node.rs
@@ -357,7 +357,9 @@ impl Node {
             // Events without direct NodeEvent equivalents are ignored
             P2pEvent::NatTraversalProgress { .. }
             | P2pEvent::BootstrapStatus { .. }
-            | P2pEvent::PeerAuthenticated { .. } => None,
+            | P2pEvent::PeerAuthenticated { .. }
+            | P2pEvent::PeerAddressUpdated { .. }
+            | P2pEvent::RelayEstablished { .. } => None,
         }
     }
 

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -3140,6 +3140,16 @@ impl P2pEndpoint {
                         relay_event_sent = true;
                     }
                 }
+
+                // Monitor relay health. If the relay session died (connection
+                // closed, server restarted, etc.), reset state so the next
+                // poll cycle re-establishes through a (potentially different)
+                // relay candidate. The RelayEstablished flag is also reset so
+                // upper layers re-publish the new address.
+                if relay_event_sent && !inner.is_relay_healthy() {
+                    inner.reset_relay_state();
+                    relay_event_sent = false;
+                }
             }
         });
     }

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -1995,9 +1995,8 @@ impl P2pEndpoint {
             relay_addr, public_addr
         );
 
-        let relay_socket = relay_socket.ok_or_else(|| {
-            EndpointError::Connection("Relay did not provide socket".to_string())
-        })?;
+        let relay_socket = relay_socket
+            .ok_or_else(|| EndpointError::Connection("Relay did not provide socket".to_string()))?;
 
         // Step 4: Create a new Quinn endpoint with the relay socket
         let existing_endpoint = self
@@ -2010,9 +2009,8 @@ impl P2pEndpoint {
             .clone()
             .ok_or_else(|| EndpointError::Config("No client config available".to_string()))?;
 
-        let runtime = crate::high_level::default_runtime().ok_or_else(|| {
-            EndpointError::Config("No async runtime available".to_string())
-        })?;
+        let runtime = crate::high_level::default_runtime()
+            .ok_or_else(|| EndpointError::Config("No async runtime available".to_string()))?;
 
         let mut relay_endpoint = crate::high_level::Endpoint::new_with_abstract_socket(
             crate::EndpointConfig::default(),
@@ -2569,10 +2567,7 @@ impl P2pEndpoint {
                                 return;
                             }
                             Err(e) => {
-                                warn!(
-                                    "Failed to set up relay via {}: {}",
-                                    bootstrap, e
-                                );
+                                warn!("Failed to set up relay via {}: {}", bootstrap, e);
                             }
                         }
                     }

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -393,6 +393,23 @@ pub enum P2pEvent {
         addr: TransportAddr,
     },
 
+    /// A connected peer advertised a new reachable address (relay or migration).
+    PeerAddressUpdated {
+        /// The connected peer that sent the advertisement
+        peer_addr: SocketAddr,
+        /// The new address the peer is advertising as reachable
+        advertised_addr: SocketAddr,
+    },
+
+    /// This node established a MASQUE relay and is advertising a relay address.
+    ///
+    /// Emitted once when the relay becomes active. Upper layers should use this
+    /// to trigger a DHT self-lookup so that more peers learn the relay address.
+    RelayEstablished {
+        /// The relay's public address (relay_IP:PORT)
+        relay_addr: SocketAddr,
+    },
+
     /// Bootstrap connection status
     BootstrapStatus {
         /// Number of connected bootstrap nodes
@@ -1966,7 +1983,8 @@ impl P2pEndpoint {
             target, relay_addr
         );
 
-        let public_addr = self
+        // Step 1: Establish relay session (control plane handshake)
+        let (public_addr, relay_socket) = self
             .inner
             .establish_relay_session(relay_addr)
             .await
@@ -1977,14 +1995,102 @@ impl P2pEndpoint {
             relay_addr, public_addr
         );
 
-        let conn = self.connect(target).await?;
+        let relay_socket = relay_socket.ok_or_else(|| {
+            EndpointError::Connection("Relay did not provide socket".to_string())
+        })?;
+
+        // Step 4: Create a new Quinn endpoint with the relay socket
+        let existing_endpoint = self
+            .inner
+            .get_endpoint()
+            .ok_or_else(|| EndpointError::Config("QUIC endpoint not available".to_string()))?;
+
+        let client_config = existing_endpoint
+            .default_client_config
+            .clone()
+            .ok_or_else(|| EndpointError::Config("No client config available".to_string()))?;
+
+        let runtime = crate::high_level::default_runtime().ok_or_else(|| {
+            EndpointError::Config("No async runtime available".to_string())
+        })?;
+
+        let mut relay_endpoint = crate::high_level::Endpoint::new_with_abstract_socket(
+            crate::EndpointConfig::default(),
+            None,
+            relay_socket,
+            runtime,
+        )
+        .map_err(|e| {
+            EndpointError::Connection(format!("Failed to create relay endpoint: {}", e))
+        })?;
+
+        relay_endpoint.set_default_client_config(client_config);
+
+        // Step 5: Connect to target through the relay endpoint
+        let connecting = relay_endpoint.connect(target, "peer").map_err(|e| {
+            EndpointError::Connection(format!("Failed to initiate relay connection: {}", e))
+        })?;
+
+        let handshake_timeout = self
+            .config
+            .timeouts
+            .nat_traversal
+            .connection_establishment_timeout;
+
+        let connection = match timeout(handshake_timeout, connecting).await {
+            Ok(Ok(conn)) => conn,
+            Ok(Err(e)) => {
+                info!(
+                    "Relay connection handshake to {} via {} failed: {}",
+                    target, relay_addr, e
+                );
+                return Err(EndpointError::Connection(e.to_string()));
+            }
+            Err(_) => {
+                info!(
+                    "Relay connection handshake to {} via {} timed out",
+                    target, relay_addr
+                );
+                return Err(EndpointError::Timeout);
+            }
+        };
+
+        // Step 6: Finalize — extract public key, store connection, spawn handler
+        let remote_public_key = extract_public_key_bytes_from_connection(&connection);
+
+        self.inner
+            .add_connection(target, connection.clone())
+            .map_err(EndpointError::NatTraversal)?;
+
+        self.inner
+            .spawn_connection_handler(target, connection, Side::Client)
+            .map_err(EndpointError::NatTraversal)?;
+
+        let peer_conn = PeerConnection {
+            public_key: remote_public_key,
+            remote_addr: TransportAddr::Quic(target),
+            authenticated: true,
+            connected_at: Instant::now(),
+            last_activity: Instant::now(),
+        };
+
+        // Spawn background reader task
+        if let Ok(Some(conn)) = self.inner.get_connection(&target) {
+            self.spawn_reader_task(target, conn).await;
+        }
+
+        // Store peer connection
+        self.connected_peers
+            .write()
+            .await
+            .insert(target, peer_conn.clone());
 
         info!(
-            "MASQUE relay connection succeeded to {} via {} (our relay addr: {:?})",
-            target, relay_addr, public_addr
+            "MASQUE relay connection succeeded to {} via {}",
+            target, relay_addr
         );
 
-        Ok(conn)
+        Ok(peer_conn)
     }
 
     /// Check if we're connected to a specific address
@@ -2434,6 +2540,49 @@ impl P2pEndpoint {
             connected,
             total: known_peers.len(),
         });
+
+        // After bootstrap, check for symmetric NAT and set up relay if needed
+        if connected > 0 {
+            let inner = Arc::clone(&self.inner);
+            let bootstrap_addrs: Vec<SocketAddr> = known_peers
+                .iter()
+                .filter_map(|addr| match addr {
+                    TransportAddr::Quic(a) => Some(*a),
+                    _ => None,
+                })
+                .collect();
+
+            tokio::spawn(async move {
+                // Wait for OBSERVED_ADDRESS frames to arrive from peers
+                tokio::time::sleep(Duration::from_secs(5)).await;
+
+                if inner.is_symmetric_nat() {
+                    info!("Symmetric NAT detected — setting up proactive relay");
+
+                    for bootstrap in &bootstrap_addrs {
+                        match inner.setup_proactive_relay(*bootstrap).await {
+                            Ok(relay_addr) => {
+                                info!(
+                                    "Proactive relay active at {} via bootstrap {}",
+                                    relay_addr, bootstrap
+                                );
+                                return;
+                            }
+                            Err(e) => {
+                                warn!(
+                                    "Failed to set up relay via {}: {}",
+                                    bootstrap, e
+                                );
+                            }
+                        }
+                    }
+
+                    warn!("Failed to set up proactive relay on any bootstrap node");
+                } else {
+                    debug!("NAT check: not symmetric NAT, no relay needed");
+                }
+            });
+        }
 
         Ok(connected)
     }
@@ -2923,9 +3072,11 @@ impl P2pEndpoint {
     fn spawn_session_driver(&self) {
         let inner = Arc::clone(&self.inner);
         let shutdown = self.shutdown.clone();
+        let event_tx_for_nat = self.event_tx.clone();
 
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(Duration::from_millis(500));
+            let mut relay_event_sent = false;
             interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
             loop {
@@ -2959,6 +3110,36 @@ impl P2pEndpoint {
                 // These are addresses from relayed PUNCH_ME_NOW that need fully tracked
                 // outgoing connections (not fire-and-forget).
                 inner.process_pending_hole_punches().await;
+
+                // Forward peer address updates as P2pEvents so the upper layer
+                // (saorsa-core) can update its DHT routing table.
+                {
+                    let mut rx = inner.peer_address_update_rx.lock().await;
+                    while let Ok((peer_addr, advertised_addr)) = rx.try_recv() {
+                        info!(
+                            "Peer {} advertised address {} — forwarding to P2pEvent",
+                            peer_addr, advertised_addr
+                        );
+                        let _ = event_tx_for_nat.send(P2pEvent::PeerAddressUpdated {
+                            peer_addr,
+                            advertised_addr,
+                        });
+                    }
+                }
+
+                // Emit RelayEstablished once when relay becomes active.
+                // Upper layers use this to trigger a DHT self-lookup for
+                // relay address propagation.
+                if !relay_event_sent {
+                    if let Some(relay_addr) = inner.relay_public_addr() {
+                        info!(
+                            "Relay established at {} — emitting RelayEstablished event",
+                            relay_addr
+                        );
+                        let _ = event_tx_for_nat.send(P2pEvent::RelayEstablished { relay_addr });
+                        relay_event_sent = true;
+                    }
+                }
             }
         });
     }
@@ -3076,6 +3257,69 @@ impl P2pEndpoint {
                     public_key: None,
                     side: Side::Server,
                 });
+
+                // Spawn a reader task for the connection so incoming streams
+                // (DHT, chunk protocol) are actually read. Without this, relayed
+                // connections are registered but never processed.
+                match inner.get_connection(&addr) {
+                    Ok(Some(conn)) => {
+                        info!(
+                            "Incoming connection forwarder: spawning reader task for {}",
+                            addr
+                        );
+                        let data_tx = data_tx.clone();
+                        let event_tx_for_reader = event_tx.clone();
+                        let exit_tx = reader_exit_tx.clone();
+                        let inner_for_reader = Arc::clone(&inner);
+                        reader_tasks.lock().await.spawn(async move {
+                            info!("Reader task STARTED for {} (via forwarder)", addr);
+                            match inner_for_reader.add_connection(addr, conn.clone()) {
+                                Ok(()) => {}
+                                Err(e) => {
+                                    warn!("Reader task: add_connection FAILED for {}: {:?}", addr, e);
+                                }
+                            }
+                            loop {
+                                let mut recv_stream = match conn.accept_uni().await {
+                                    Ok(stream) => stream,
+                                    Err(e) => {
+                                        info!("Reader task for {} (forwarder) ending: {}", addr, e);
+                                        break;
+                                    }
+                                };
+                                let data = match recv_stream.read_to_end(max_read_bytes).await {
+                                    Ok(data) if data.is_empty() => continue,
+                                    Ok(data) => data,
+                                    Err(e) => {
+                                        info!("Reader task for {} (forwarder): read error: {}", addr, e);
+                                        break;
+                                    }
+                                };
+                                let data_len = data.len();
+                                let _ = event_tx_for_reader.send(P2pEvent::DataReceived {
+                                    addr, bytes: data_len,
+                                });
+                                if data_tx.try_send((addr, data)).is_err() {
+                                    warn!("Reader task for {} (forwarder): data channel full, dropping {} bytes", addr, data_len);
+                                }
+                            }
+                            let _ = exit_tx.send(addr);
+                            addr
+                        });
+                    }
+                    Ok(None) => {
+                        warn!(
+                            "Incoming connection forwarder: get_connection({}) returned None — no reader task",
+                            addr
+                        );
+                    }
+                    Err(e) => {
+                        warn!(
+                            "Incoming connection forwarder: get_connection({}) failed: {} — no reader task",
+                            addr, e
+                        );
+                    }
+                }
             }
         });
     }

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -89,6 +89,14 @@ pub(crate) enum EndpointEventInner {
         /// The peer's external address to connect to
         peer_address: SocketAddr,
     },
+    /// A peer advertised a new reachable address via ADD_ADDRESS.
+    /// The endpoint should propagate this so the DHT routing table is updated.
+    PeerAddressAdvertised {
+        /// The peer's current connection address
+        peer_addr: SocketAddr,
+        /// The new address the peer is advertising
+        advertised_addr: SocketAddr,
+    },
     /// Request to attempt connection to a target address (NAT callback mechanism)
     TryConnectTo {
         request_id: crate::VarInt,


### PR DESCRIPTION
## Summary

- MASQUE relay data plane for symmetric NAT nodes: proactive relay setup, stream-based forwarding, secondary Quinn endpoint for accepting relayed connections
- Relay candidate fallback iteration: iterates all connected peers instead of retrying one unreachable candidate indefinitely
- Relay session health monitoring: detects dead relay within 500ms, resets state, re-establishes through next candidate

## Context

Symmetric NAT nodes cannot be reached via hole-punching (each outbound connection gets a different external port). This PR gives them a stable public address via a MASQUE relay on a connected peer. The relay forwards raw QUIC packets bidirectionally — true end-to-end encryption, the relay cannot inspect payload.

### RFC deviations

1. Custom binary signalling (not HTTP/3 CONNECT-UDP) — avoids HTTP/3 stack dependency
2. Stream-based framing (not QUIC datagrams) — datagrams have MTU limit too small for QUIC Initial packets
3. Proactive relay on symmetric NAT detection (not per-connection fallback) — eliminates 45-60s cascade
4. Raw packet forwarding (not proxy termination) — end-to-end encryption preserved

## Test plan

- [x] Deployed symmetric NAT testnet (5 cloud + 2 symmetric NAT + 1 local behind home router)
- [x] Ran /validate-symmetric-nat-testnet with all 8 checks
- [x] Verified relay candidate fallback iteration via log: "Relay candidate ... — active connection, trying"
- [x] Verified relay health monitoring code present (happy path — no relay deaths during test)

### Test report

```
=======================================================
Symmetric NAT Testnet Validation Report
=======================================================
Testnet: ant-relay-health
Validation time: 2026-04-01T01:05:00Z

CHECK 1: Sustained Uploads           PASS
  Attempted: 7, Successful: 7, Failed: 0 (0%)

CHECK 2: Client -> Local Node NAT    PASS
  Direct: 5, Messages: 250

CHECK 3: Cloud -> Local Connectivity  PASS (via local peers)
  Local DHT peers: 7

CHECK 4: Local Chunk Storage          EXPECTED FAIL
  Chunks: 0
  Note: With 100MB uploads (29 chunks) and 8 nodes, close group
  selection may not include the local node in a 5-minute window.
  This will be resolved when the replication system is implemented,
  which ensures all close group members receive chunks regardless
  of whether the uploader directly targets them.

CHECK 5: Symmetric NAT Detection      PASS
  NAT-1: 5 ports, NAT-2: 6 ports

CHECK 6: NAT Chunk Storage (Relay)    PASS
  NAT-1: 134 chunks, 1 relay, 9 relayed connections
  NAT-2: 162 chunks, 1 relay, 8 relayed connections

CHECK 7: Relay Address Propagation    PASS
  IPv6-mapped: 0

CHECK 8: Wire Format Compatibility    PASS
  Serialization errors: 0

Relay Health Monitoring: No relay deaths during test (happy path)

-------------------------------------------------------
RESULT: 7/8 checks pass. CHECK 4 is an expected limitation
of the current testnet (no replication), not a regression.
=======================================================
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements the MASQUE relay data plane for symmetric NAT traversal — the part that was previously stub code. It introduces stream-based packet forwarding (length-prefixed QUIC streams instead of unreliable datagrams), a `MasqueRelaySocket` that presents a relay tunnel as a standard `AsyncUdpSocket` to Quinn, proactive relay setup triggered by OBSERVED_ADDRESS port-diversity detection, relay health monitoring with automatic re-establishment, and an ADD_ADDRESS-to-DHT bridge so relay addresses propagate to the rest of the network.

Key findings from the review:

- **P1 – TOCTOU waker race in `MasqueRelaySocket::poll_recv`** (`relay_socket.rs`): The queue is checked under one mutex, then the waker is registered under a separate mutex. A packet arriving in the gap will push to the queue, find no registered waker, and silently not fire a wake-up — leaving Quinn stalled until the next unrelated packet. The fix is to register the waker first, then re-check the queue.
- **P1 – No upper-bound on relay response length** (`nat_traversal_api.rs`): `resp_len` is read from a 4-byte field and used directly to allocate a `Vec` without validation. The request-side check (`if req_len > 1024 { return; }`) exists but the response side in both `establish_relay_session` and the inline spawned relay-setup task is unguarded. A malicious relay node could trigger a multi-gigabyte allocation.
- **P1 – Hardcoded `\"peer\"` TLS SNI in `try_relay_connection`** (`p2p_endpoint.rs`): The relay connection uses `relay_endpoint.connect(target, \"peer\")` while every other connection in the codebase uses the peer's IP string (`relay_addr.ip().to_string()`). This will cause TLS failures in any configuration that validates the server name.
- **P2 – `set_public_address` is a silent no-op** (`relay_server.rs`): Takes `&self` but cannot mutate the field, so the log line is the entire effect.
- **P2 – `run_forwarding_loop` is dead code using the rejected datagram approach** (`relay_server.rs`): Should be removed or deprecated.
- **P2 – Double-brace refactoring artifact** (`nat_traversal_api.rs`): Leftover from the transition to length-prefixed reading.

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is — two correctness bugs (waker race, unbounded allocation) and a likely TLS handshake failure need addressing first.

Three P1 findings on critical paths: the TOCTOU waker race in poll_recv can stall Quinn on relayed connections (breaks primary PR goal); the missing resp_len bounds check is an allocation-bomb against a malicious relay; the hardcoded 'peer' SNI will cause TLS failures in strict-validation configurations. Architecture is sound and most of the implementation is correct, but these specific defects need fixes before production use.

src/masque/relay_socket.rs (waker race), src/nat_traversal_api.rs (unbounded allocation, double braces), src/p2p_endpoint.rs (wrong SNI), src/masque/relay_server.rs (no-op method, dead code)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/masque/relay_socket.rs | New `MasqueRelaySocket` implementing `AsyncUdpSocket` over a QUIC stream — has a TOCTOU waker-registration race in `poll_recv` that can cause Quinn to stall. |
| src/masque/relay_server.rs | Adds stream-based and datagram-based forwarding loops; `set_public_address` is a no-op stub, and the old `run_forwarding_loop` (datagram-based, contradicting the ADR) is now dead code. |
| src/nat_traversal_api.rs | Adds symmetric NAT detection, proactive relay setup, relay health monitoring, and ADD_ADDRESS bridge; response length from relay is never bounds-checked before allocation. |
| src/p2p_endpoint.rs | Wires relay socket into connect-via-relay path; uses hardcoded `"peer"` as TLS SNI which is inconsistent with IP-based SNI used elsewhere. |
| src/masque/relay_session.rs | Adds `udp_socket` field and related getters/setters for the relay data plane — straightforward and clean. |
| src/endpoint.rs | Adds `pending_peer_address_updates` buffer and drain iterator for ADD_ADDRESS-to-DHT propagation — clean and well-structured. |
| src/high_level/endpoint.rs | Adds `peer_address_update_tx` channel for forwarding ADD_ADDRESS events upward — straightforward bridge plumbing. |
| src/connection/mod.rs | Sends `OBSERVED_ADDRESS` frames and emits `PeerAddressAdvertised` endpoint events on ADD_ADDRESS receipt — clean integration. |
| src/shared.rs | Adds `PeerAddressAdvertised` variant to `EndpointEventInner` — minimal and correct. |
| src/node.rs | Adds no-op arms for `PeerAddressUpdated` and `RelayEstablished` in the event mapper — correct bookkeeping. |
| src/masque/mod.rs | Re-exports `relay_socket` module and `MasqueRelaySocket` — trivial plumbing change. |
| docs/adr/ADR-009-masque-relay-data-plane.md | Well-structured ADR documenting RFC deviations, design rationale, and implementation status — accurate and thorough. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant NAT as NAT-Restricted Node
    participant Relay as Relay Node (Bootstrap)
    participant Client as Remote Client

    Note over NAT: Detects symmetric NAT<br/>(≥2 different external ports)

    NAT->>Relay: open_bi() QUIC stream
    NAT->>Relay: [4B len][CONNECT-UDP Bind request]
    Relay->>Relay: bind UDP socket (OS port)
    Relay-->>NAT: [4B len][CONNECT-UDP response + relay_addr]
    Note over NAT,Relay: Stream stays open — becomes forwarding channel

    NAT->>NAT: MasqueRelaySocket::new(send_stream, recv_stream, relay_addr)
    NAT->>NAT: Secondary Quinn endpoint on MasqueRelaySocket

    NAT->>Relay: ADD_ADDRESS(relay_addr) via existing connections
    Relay->>Client: DHT propagates relay_addr

    Client->>Relay: UDP packet to relay bound socket
    Relay->>Relay: recv_from() → encode UncompressedDatagram
    Relay->>NAT: [4B len][UncompressedDatagram] via QUIC stream
    NAT->>NAT: MasqueRelaySocket.poll_recv() delivers to Quinn
    NAT-->>Client: QUIC handshake completes end-to-end

    Note over Relay,NAT: Session driver (500ms tick) monitors relay health
    Note over Relay,NAT: Dead session → reset_relay_state() → re-establish
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (5)</h3></summary>

1. `src/masque/relay_socket.rs`, line 1019-1041 ([link](https://github.com/saorsa-labs/saorsa-transport/blob/7777876c7391b482fe9c70ba3ba08434f6f32913/src/masque/relay_socket.rs#L1019-L1041)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **TOCTOU waker-registration race in `poll_recv`**

   There is a window between the queue check and the waker registration where a packet can arrive without generating a wake-up, causing Quinn to stall indefinitely.

   Current sequence:
   1. `poll_recv` locks queue → empty → drops lock
   2. Background task pushes packet, locks `recv_waker`, finds `None` → no wake-up sent, drops lock
   3. `poll_recv` locks `recv_waker`, registers waker, drops lock
   4. **No further wake-up arrives** until the next unrelated packet; Quinn never re-polls this socket.

   The standard fix is to re-check the queue *after* registering the waker so the pending item is never silently lost:

   ```rust
   // Register waker first
   if let Ok(mut waker) = self.recv_waker.lock() {
       *waker = Some(cx.waker().clone());
   }

   // Re-check queue after waker is registered to close the TOCTOU window
   if let Ok(mut queue) = self.recv_queue.lock() {
       if let Some((payload, source)) = queue.pop_front() {
           // clear waker — we're returning Ready
           if let Ok(mut w) = self.recv_waker.lock() { *w = None; }
           let len = payload.len().min(bufs[0].len());
           bufs[0][..len].copy_from_slice(&payload[..len]);
           let mut recv_meta = RecvMeta::default();
           recv_meta.len = len;
           recv_meta.stride = len;
           recv_meta.addr = source;
           recv_meta.ecn = None;
           recv_meta.dst_ip = None;
           meta[0] = recv_meta;
           return Poll::Ready(Ok(1));
       }
   }

   Poll::Pending
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/masque/relay_socket.rs
   Line: 1019-1041

   Comment:
   **TOCTOU waker-registration race in `poll_recv`**

   There is a window between the queue check and the waker registration where a packet can arrive without generating a wake-up, causing Quinn to stall indefinitely.

   Current sequence:
   1. `poll_recv` locks queue → empty → drops lock
   2. Background task pushes packet, locks `recv_waker`, finds `None` → no wake-up sent, drops lock
   3. `poll_recv` locks `recv_waker`, registers waker, drops lock
   4. **No further wake-up arrives** until the next unrelated packet; Quinn never re-polls this socket.

   The standard fix is to re-check the queue *after* registering the waker so the pending item is never silently lost:

   ```rust
   // Register waker first
   if let Ok(mut waker) = self.recv_waker.lock() {
       *waker = Some(cx.waker().clone());
   }

   // Re-check queue after waker is registered to close the TOCTOU window
   if let Ok(mut queue) = self.recv_queue.lock() {
       if let Some((payload, source)) = queue.pop_front() {
           // clear waker — we're returning Ready
           if let Ok(mut w) = self.recv_waker.lock() { *w = None; }
           let len = payload.len().min(bufs[0].len());
           bufs[0][..len].copy_from_slice(&payload[..len]);
           let mut recv_meta = RecvMeta::default();
           recv_meta.len = len;
           recv_meta.stride = len;
           recv_meta.addr = source;
           recv_meta.ecn = None;
           recv_meta.dst_ip = None;
           meta[0] = recv_meta;
           return Poll::Ready(Ok(1));
       }
   }

   Poll::Pending
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `src/nat_traversal_api.rs`, line 1501-1502 ([link](https://github.com/saorsa-labs/saorsa-transport/blob/7777876c7391b482fe9c70ba3ba08434f6f32913/src/nat_traversal_api.rs#L1501-L1502)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Missing upper-bound check on relay response length**

   `resp_len` is read directly from the relay server and used to allocate a `Vec` without any size validation. A misbehaving or compromised relay node could send `0xFFFFFFFF` (≈ 4 GiB), causing an out-of-memory crash. Compare with the symmetric request-side guard added at the top of `handle_relay_requests`:

   ```rust
   if req_len > 1024 {
       debug!("Relay request too large from {}: {} bytes", addr, req_len);
       return;
   }
   ```

   The same guard is missing here and in the inline relay-setup task inside `check_connections_for_observed_addresses`. Both should reject oversized responses before allocation:

   ```rust
   let resp_len = u32::from_be_bytes(resp_len_buf) as usize;
   if resp_len > 1024 {
       return Err(NatTraversalError::ProtocolError(
           format!("Relay response too large: {} bytes", resp_len),
       ));
   }
   let mut response_bytes = vec![0u8; resp_len];
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/nat_traversal_api.rs
   Line: 1501-1502

   Comment:
   **Missing upper-bound check on relay response length**

   `resp_len` is read directly from the relay server and used to allocate a `Vec` without any size validation. A misbehaving or compromised relay node could send `0xFFFFFFFF` (≈ 4 GiB), causing an out-of-memory crash. Compare with the symmetric request-side guard added at the top of `handle_relay_requests`:

   ```rust
   if req_len > 1024 {
       debug!("Relay request too large from {}: {} bytes", addr, req_len);
       return;
   }
   ```

   The same guard is missing here and in the inline relay-setup task inside `check_connections_for_observed_addresses`. Both should reject oversized responses before allocation:

   ```rust
   let resp_len = u32::from_be_bytes(resp_len_buf) as usize;
   if resp_len > 1024 {
       return Err(NatTraversalError::ProtocolError(
           format!("Relay response too large: {} bytes", resp_len),
       ));
   }
   let mut response_bytes = vec![0u8; resp_len];
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


3. `src/p2p_endpoint.rs`, line 2150-2152 ([link](https://github.com/saorsa-labs/saorsa-transport/blob/7777876c7391b482fe9c70ba3ba08434f6f32913/src/p2p_endpoint.rs#L2150-L2152)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Hardcoded `"peer"` TLS SNI inconsistent with the rest of the codebase**

   Every other relay/direct connection in this codebase uses the peer's IP address as the TLS server name (see `connect_new_to_relay`: `let server_name = relay_addr.ip().to_string()`). Using the literal string `"peer"` here will produce a TLS handshake failure on any deployment that does certificate-name validation, and is misleading even when validation is skipped.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/p2p_endpoint.rs
   Line: 2150-2152

   Comment:
   **Hardcoded `"peer"` TLS SNI inconsistent with the rest of the codebase**

   Every other relay/direct connection in this codebase uses the peer's IP address as the TLS server name (see `connect_new_to_relay`: `let server_name = relay_addr.ip().to_string()`). Using the literal string `"peer"` here will produce a TLS handshake failure on any deployment that does certificate-name validation, and is misleading even when validation is skipped.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


4. `src/masque/relay_server.rs`, line 454-644 ([link](https://github.com/saorsa-labs/saorsa-transport/blob/7777876c7391b482fe9c70ba3ba08434f6f32913/src/masque/relay_server.rs#L454-L644)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`run_forwarding_loop` is dead code that contradicts the ADR**

   `run_forwarding_loop` forwards packets using `connection.send_datagram()` / `conn2.read_datagram()`, the exact datagram-based approach that ADR-009 explicitly rejected due to QUIC MTU limitations (~1120 bytes) truncating 1200-byte QUIC Initial packets.

   The actual server-side path now calls `run_stream_forwarding_loop` exclusively. `run_forwarding_loop` is no longer called anywhere in the diff and leaving it as a public `async fn` risks future callers using the wrong (broken-for-large-packets) path.

   Consider removing this method or, at minimum, marking it `#[deprecated]` with a note pointing to `run_stream_forwarding_loop`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/masque/relay_server.rs
   Line: 454-644

   Comment:
   **`run_forwarding_loop` is dead code that contradicts the ADR**

   `run_forwarding_loop` forwards packets using `connection.send_datagram()` / `conn2.read_datagram()`, the exact datagram-based approach that ADR-009 explicitly rejected due to QUIC MTU limitations (~1120 bytes) truncating 1200-byte QUIC Initial packets.

   The actual server-side path now calls `run_stream_forwarding_loop` exclusively. `run_forwarding_loop` is no longer called anywhere in the diff and leaving it as a public `async fn` risks future callers using the wrong (broken-for-large-packets) path.

   Consider removing this method or, at minimum, marking it `#[deprecated]` with a note pointing to `run_stream_forwarding_loop`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


5. `src/nat_traversal_api.rs`, line 1249-1250 ([link](https://github.com/saorsa-labs/saorsa-transport/blob/7777876c7391b482fe9c70ba3ba08434f6f32913/src/nat_traversal_api.rs#L1249-L1250)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Redundant double-brace nesting — refactoring artifact**

   Two consecutive `{` blocks with no code between them appear to be a leftover from replacing `match recv_stream.read_to_end(...).await { Ok(bytes) => { … } }` with the new length-prefixed read. The outer brace is now unused and should be removed to keep the indentation level flat and readable.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/nat_traversal_api.rs
   Line: 1249-1250

   Comment:
   **Redundant double-brace nesting — refactoring artifact**

   Two consecutive `{` blocks with no code between them appear to be a leftover from replacing `match recv_stream.read_to_end(...).await { Ok(bytes) => { … } }` with the new length-prefixed read. The outer brace is now unused and should be removed to keep the indentation level flat and readable.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/masque/relay_socket.rs
Line: 1019-1041

Comment:
**TOCTOU waker-registration race in `poll_recv`**

There is a window between the queue check and the waker registration where a packet can arrive without generating a wake-up, causing Quinn to stall indefinitely.

Current sequence:
1. `poll_recv` locks queue → empty → drops lock
2. Background task pushes packet, locks `recv_waker`, finds `None` → no wake-up sent, drops lock
3. `poll_recv` locks `recv_waker`, registers waker, drops lock
4. **No further wake-up arrives** until the next unrelated packet; Quinn never re-polls this socket.

The standard fix is to re-check the queue *after* registering the waker so the pending item is never silently lost:

```rust
// Register waker first
if let Ok(mut waker) = self.recv_waker.lock() {
    *waker = Some(cx.waker().clone());
}

// Re-check queue after waker is registered to close the TOCTOU window
if let Ok(mut queue) = self.recv_queue.lock() {
    if let Some((payload, source)) = queue.pop_front() {
        // clear waker — we're returning Ready
        if let Ok(mut w) = self.recv_waker.lock() { *w = None; }
        let len = payload.len().min(bufs[0].len());
        bufs[0][..len].copy_from_slice(&payload[..len]);
        let mut recv_meta = RecvMeta::default();
        recv_meta.len = len;
        recv_meta.stride = len;
        recv_meta.addr = source;
        recv_meta.ecn = None;
        recv_meta.dst_ip = None;
        meta[0] = recv_meta;
        return Poll::Ready(Ok(1));
    }
}

Poll::Pending
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/nat_traversal_api.rs
Line: 1501-1502

Comment:
**Missing upper-bound check on relay response length**

`resp_len` is read directly from the relay server and used to allocate a `Vec` without any size validation. A misbehaving or compromised relay node could send `0xFFFFFFFF` (≈ 4 GiB), causing an out-of-memory crash. Compare with the symmetric request-side guard added at the top of `handle_relay_requests`:

```rust
if req_len > 1024 {
    debug!("Relay request too large from {}: {} bytes", addr, req_len);
    return;
}
```

The same guard is missing here and in the inline relay-setup task inside `check_connections_for_observed_addresses`. Both should reject oversized responses before allocation:

```rust
let resp_len = u32::from_be_bytes(resp_len_buf) as usize;
if resp_len > 1024 {
    return Err(NatTraversalError::ProtocolError(
        format!("Relay response too large: {} bytes", resp_len),
    ));
}
let mut response_bytes = vec![0u8; resp_len];
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/p2p_endpoint.rs
Line: 2150-2152

Comment:
**Hardcoded `"peer"` TLS SNI inconsistent with the rest of the codebase**

Every other relay/direct connection in this codebase uses the peer's IP address as the TLS server name (see `connect_new_to_relay`: `let server_name = relay_addr.ip().to_string()`). Using the literal string `"peer"` here will produce a TLS handshake failure on any deployment that does certificate-name validation, and is misleading even when validation is skipped.

```suggestion
        let server_name = target.ip().to_string();
        let connecting = relay_endpoint.connect(target, &server_name).map_err(|e| {
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/masque/relay_server.rs
Line: 339-351

Comment:
**`set_public_address` is a silent no-op**

The method signature takes `&self` (shared reference) so it cannot mutate `self.public_address`. The comment acknowledges this ("We use interior mutability…For now, log the update"), meaning the field is never actually updated. Any caller expecting the relay server's advertised IP to change will be silently ignored.

Either:
- Replace the field with an `Arc<std::sync::Mutex<SocketAddr>>` (or `ArcSwap`) to allow interior mutability, or
- Remove this method and document that the public address is only set at construction time.

As-is the method gives the false impression that the address has been updated.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/masque/relay_server.rs
Line: 454-644

Comment:
**`run_forwarding_loop` is dead code that contradicts the ADR**

`run_forwarding_loop` forwards packets using `connection.send_datagram()` / `conn2.read_datagram()`, the exact datagram-based approach that ADR-009 explicitly rejected due to QUIC MTU limitations (~1120 bytes) truncating 1200-byte QUIC Initial packets.

The actual server-side path now calls `run_stream_forwarding_loop` exclusively. `run_forwarding_loop` is no longer called anywhere in the diff and leaving it as a public `async fn` risks future callers using the wrong (broken-for-large-packets) path.

Consider removing this method or, at minimum, marking it `#[deprecated]` with a note pointing to `run_stream_forwarding_loop`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/nat_traversal_api.rs
Line: 1249-1250

Comment:
**Redundant double-brace nesting — refactoring artifact**

Two consecutive `{` blocks with no code between them appear to be a leftover from replacing `match recv_stream.read_to_end(...).await { Ok(bytes) => { … } }` with the new length-prefixed read. The outer brace is now unused and should be removed to keep the indentation level flat and readable.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["style: run cargo fmt"](https://github.com/saorsa-labs/saorsa-transport/commit/7777876c7391b482fe9c70ba3ba08434f6f32913) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27017929)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->