### PR TITLE
perf!: read-lock router on send via atomic selection stats

### DIFF
--- a/benches/connection_router.rs
+++ b/benches/connection_router.rs
@@ -184,7 +184,7 @@ fn bench_constrained_connect(c: &mut Criterion) {
 
     // Benchmark constrained connection creation
     group.bench_function("ble_connect", |b| {
-        let mut router = ConnectionRouter::new(RouterConfig::default());
+        let router = ConnectionRouter::new(RouterConfig::default());
         b.iter(|| {
             let result = router.connect(black_box(&ble_addr));
             black_box(result)
@@ -219,7 +219,7 @@ fn bench_stats_tracking(c: &mut Criterion) {
         b.iter(|| {
             let _ = router.select_engine_for_addr(black_box(&udp_addr));
             let _ = router.select_engine_for_addr(black_box(&ble_addr));
-            let stats = router.stats().clone();
+            let stats = router.stats().snapshot();
             black_box(stats)
         });
     });

--- a/benches/connection_router.rs
+++ b/benches/connection_router.rs
@@ -38,7 +38,7 @@ fn bench_engine_selection(c: &mut Criterion) {
 
     // Benchmark UDP address selection
     group.bench_function("udp_address", |b| {
-        let mut router = ConnectionRouter::new(RouterConfig::default());
+        let router = ConnectionRouter::new(RouterConfig::default());
         b.iter(|| {
             let engine = router.select_engine_for_addr(black_box(&udp_transport));
             black_box(engine)
@@ -47,7 +47,7 @@ fn bench_engine_selection(c: &mut Criterion) {
 
     // Benchmark BLE address selection
     group.bench_function("ble_address", |b| {
-        let mut router = ConnectionRouter::new(RouterConfig::default());
+        let router = ConnectionRouter::new(RouterConfig::default());
         b.iter(|| {
             let engine = router.select_engine_for_addr(black_box(&ble_transport));
             black_box(engine)
@@ -56,7 +56,7 @@ fn bench_engine_selection(c: &mut Criterion) {
 
     // Benchmark LoRa address selection
     group.bench_function("lora_address", |b| {
-        let mut router = ConnectionRouter::new(RouterConfig::default());
+        let router = ConnectionRouter::new(RouterConfig::default());
         b.iter(|| {
             let engine = router.select_engine_for_addr(black_box(&lora_transport));
             black_box(engine)
@@ -76,7 +76,7 @@ fn bench_engine_selection_detailed(c: &mut Criterion) {
 
     // Benchmark broadband selection
     group.bench_function("broadband_detailed", |b| {
-        let mut router = ConnectionRouter::new(RouterConfig::default());
+        let router = ConnectionRouter::new(RouterConfig::default());
         b.iter(|| {
             let result = router.select_engine_detailed(black_box(&broadband_caps));
             black_box(result)
@@ -85,7 +85,7 @@ fn bench_engine_selection_detailed(c: &mut Criterion) {
 
     // Benchmark BLE selection
     group.bench_function("ble_detailed", |b| {
-        let mut router = ConnectionRouter::new(RouterConfig::default());
+        let router = ConnectionRouter::new(RouterConfig::default());
         b.iter(|| {
             let result = router.select_engine_detailed(black_box(&ble_caps));
             black_box(result)
@@ -94,7 +94,7 @@ fn bench_engine_selection_detailed(c: &mut Criterion) {
 
     // Benchmark LoRa selection
     group.bench_function("lora_detailed", |b| {
-        let mut router = ConnectionRouter::new(RouterConfig::default());
+        let router = ConnectionRouter::new(RouterConfig::default());
         b.iter(|| {
             let result = router.select_engine_detailed(black_box(&lora_caps));
             black_box(result)
@@ -112,7 +112,7 @@ fn bench_fallback_selection(c: &mut Criterion) {
 
     // Benchmark with QUIC available
     group.bench_function("quic_available", |b| {
-        let mut router = ConnectionRouter::new(RouterConfig::default());
+        let router = ConnectionRouter::new(RouterConfig::default());
         b.iter(|| {
             let result = router.select_engine_with_fallback(
                 black_box(&broadband_caps),
@@ -125,7 +125,7 @@ fn bench_fallback_selection(c: &mut Criterion) {
 
     // Benchmark with fallback needed
     group.bench_function("quic_fallback", |b| {
-        let mut router = ConnectionRouter::new(RouterConfig::default());
+        let router = ConnectionRouter::new(RouterConfig::default());
         b.iter(|| {
             let result = router.select_engine_with_fallback(
                 black_box(&broadband_caps),
@@ -215,7 +215,7 @@ fn bench_stats_tracking(c: &mut Criterion) {
 
     // Benchmark selection with stats update
     group.bench_function("selection_with_stats", |b| {
-        let mut router = ConnectionRouter::new(RouterConfig::default());
+        let router = ConnectionRouter::new(RouterConfig::default());
         b.iter(|| {
             let _ = router.select_engine_for_addr(black_box(&udp_addr));
             let _ = router.select_engine_for_addr(black_box(&ble_addr));

--- a/src/connection_router.rs
+++ b/src/connection_router.rs
@@ -63,8 +63,8 @@
 
 use std::fmt;
 use std::net::SocketAddr;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, OnceLock};
 
 use crate::constrained::{
     AdapterEvent, ConnectionId as ConstrainedConnId, ConstrainedError, ConstrainedHandle,
@@ -789,96 +789,202 @@ impl RouterEvent {
 
 /// Router statistics.
 ///
-/// Selection counters (`quic_selections`, `constrained_selections`,
-/// `fallback_selections`) are stored as [`AtomicU64`] so the selection
-/// methods can take `&self` and be called under a `RwLock::read()` guard.
-/// Without this, every outbound send on a `P2pEndpoint` had to acquire an
-/// exclusive write lock on the router just to bump a counter, serialising
-/// all sends through a single lock (see p2p_endpoint.rs `send()`).
+/// All counters are lock-free [`AtomicU64`]s. Fields are private; external
+/// code reads them via the accessor methods or captures a consistent-ish
+/// point-in-time view via [`RouterStats::snapshot`].
 ///
-/// Other counters are still plain `u64` because they are only touched on
-/// `&mut self` paths (connect/accept/event-loop).
+/// Making every counter atomic lets every mutating method on
+/// [`ConnectionRouter`] take `&self`. Combined with lazy-init of the
+/// constrained transport via [`OnceLock`], this removes the need to wrap
+/// the router in a `RwLock` at all — concurrent sends do not block each
+/// other on stat updates.
+///
+/// Ordering: all operations use [`Ordering::Relaxed`]. These counters are
+/// purely diagnostic; they do not synchronise any other state.
 #[derive(Debug, Default)]
 pub struct RouterStats {
     /// Total connections routed through QUIC
-    pub quic_connections: u64,
+    quic_connections: AtomicU64,
 
     /// Total connections routed through Constrained
-    pub constrained_connections: u64,
+    constrained_connections: AtomicU64,
 
     /// Total bytes sent via QUIC
-    pub quic_bytes_sent: u64,
+    quic_bytes_sent: AtomicU64,
 
     /// Total bytes sent via Constrained
-    pub constrained_bytes_sent: u64,
+    constrained_bytes_sent: AtomicU64,
 
     /// Total bytes received via QUIC
-    pub quic_bytes_received: u64,
+    quic_bytes_received: AtomicU64,
 
     /// Total bytes received via Constrained
-    pub constrained_bytes_received: u64,
+    constrained_bytes_received: AtomicU64,
 
     /// Connection failures
-    pub connection_failures: u64,
+    connection_failures: AtomicU64,
 
-    /// Engine selection decisions (QUIC chosen). Atomic so the selection
-    /// path does not require exclusive access.
-    pub quic_selections: AtomicU64,
+    /// Engine selection decisions (QUIC chosen)
+    quic_selections: AtomicU64,
 
-    /// Engine selection decisions (Constrained chosen). Atomic so the
-    /// selection path does not require exclusive access.
-    pub constrained_selections: AtomicU64,
+    /// Engine selection decisions (Constrained chosen)
+    constrained_selections: AtomicU64,
 
-    /// Fallback selections (when preferred engine unavailable). Atomic so
-    /// the selection path does not require exclusive access.
-    pub fallback_selections: AtomicU64,
+    /// Fallback selections (when preferred engine unavailable)
+    fallback_selections: AtomicU64,
 
     /// Total events processed
-    pub events_processed: u64,
+    events_processed: AtomicU64,
 }
 
-impl Clone for RouterStats {
-    fn clone(&self) -> Self {
-        Self {
-            quic_connections: self.quic_connections,
-            constrained_connections: self.constrained_connections,
-            quic_bytes_sent: self.quic_bytes_sent,
-            constrained_bytes_sent: self.constrained_bytes_sent,
-            quic_bytes_received: self.quic_bytes_received,
-            constrained_bytes_received: self.constrained_bytes_received,
-            connection_failures: self.connection_failures,
-            quic_selections: AtomicU64::new(self.quic_selections.load(Ordering::Relaxed)),
-            constrained_selections: AtomicU64::new(
-                self.constrained_selections.load(Ordering::Relaxed),
-            ),
-            fallback_selections: AtomicU64::new(self.fallback_selections.load(Ordering::Relaxed)),
-            events_processed: self.events_processed,
+impl RouterStats {
+    /// Total connections routed through QUIC.
+    pub fn quic_connections(&self) -> u64 {
+        self.quic_connections.load(Ordering::Relaxed)
+    }
+
+    /// Total connections routed through Constrained.
+    pub fn constrained_connections(&self) -> u64 {
+        self.constrained_connections.load(Ordering::Relaxed)
+    }
+
+    /// Total bytes sent via QUIC.
+    pub fn quic_bytes_sent(&self) -> u64 {
+        self.quic_bytes_sent.load(Ordering::Relaxed)
+    }
+
+    /// Total bytes sent via Constrained.
+    pub fn constrained_bytes_sent(&self) -> u64 {
+        self.constrained_bytes_sent.load(Ordering::Relaxed)
+    }
+
+    /// Total bytes received via QUIC.
+    pub fn quic_bytes_received(&self) -> u64 {
+        self.quic_bytes_received.load(Ordering::Relaxed)
+    }
+
+    /// Total bytes received via Constrained.
+    pub fn constrained_bytes_received(&self) -> u64 {
+        self.constrained_bytes_received.load(Ordering::Relaxed)
+    }
+
+    /// Connection failures.
+    pub fn connection_failures(&self) -> u64 {
+        self.connection_failures.load(Ordering::Relaxed)
+    }
+
+    /// Engine-selection decisions where QUIC was chosen.
+    pub fn quic_selections(&self) -> u64 {
+        self.quic_selections.load(Ordering::Relaxed)
+    }
+
+    /// Engine-selection decisions where Constrained was chosen.
+    pub fn constrained_selections(&self) -> u64 {
+        self.constrained_selections.load(Ordering::Relaxed)
+    }
+
+    /// Fallback selections (preferred engine unavailable, alternate used).
+    pub fn fallback_selections(&self) -> u64 {
+        self.fallback_selections.load(Ordering::Relaxed)
+    }
+
+    /// Total router events processed.
+    pub fn events_processed(&self) -> u64 {
+        self.events_processed.load(Ordering::Relaxed)
+    }
+
+    /// Capture a plain-`u64` snapshot of all counters.
+    ///
+    /// The snapshot is *not* a globally consistent point-in-time view:
+    /// because each field is loaded independently, a concurrent update can
+    /// land between two loads. Selection counters in particular can
+    /// transiently disagree because the fallback path increments one
+    /// counter and decrements another non-atomically across fields. For
+    /// rate-calculation and monitoring this is fine; callers that need
+    /// per-field accuracy should use the individual accessors and accept
+    /// that they too are only eventually consistent.
+    pub fn snapshot(&self) -> RouterStatsSnapshot {
+        RouterStatsSnapshot {
+            quic_connections: self.quic_connections(),
+            constrained_connections: self.constrained_connections(),
+            quic_bytes_sent: self.quic_bytes_sent(),
+            constrained_bytes_sent: self.constrained_bytes_sent(),
+            quic_bytes_received: self.quic_bytes_received(),
+            constrained_bytes_received: self.constrained_bytes_received(),
+            connection_failures: self.connection_failures(),
+            quic_selections: self.quic_selections(),
+            constrained_selections: self.constrained_selections(),
+            fallback_selections: self.fallback_selections(),
+            events_processed: self.events_processed(),
         }
     }
+}
+
+/// Plain-`u64` snapshot of [`RouterStats`].
+///
+/// Value type with no atomics, safe to pass across threads, serialise, or
+/// diff against a later snapshot for rate calculations. Produced via
+/// [`RouterStats::snapshot`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RouterStatsSnapshot {
+    /// Total connections routed through QUIC.
+    pub quic_connections: u64,
+    /// Total connections routed through Constrained.
+    pub constrained_connections: u64,
+    /// Total bytes sent via QUIC.
+    pub quic_bytes_sent: u64,
+    /// Total bytes sent via Constrained.
+    pub constrained_bytes_sent: u64,
+    /// Total bytes received via QUIC.
+    pub quic_bytes_received: u64,
+    /// Total bytes received via Constrained.
+    pub constrained_bytes_received: u64,
+    /// Connection failures.
+    pub connection_failures: u64,
+    /// Engine-selection decisions where QUIC was chosen.
+    pub quic_selections: u64,
+    /// Engine-selection decisions where Constrained was chosen.
+    pub constrained_selections: u64,
+    /// Fallback selections (preferred engine unavailable).
+    pub fallback_selections: u64,
+    /// Total router events processed.
+    pub events_processed: u64,
 }
 
 /// Connection router for automatic protocol engine selection
 ///
 /// The router examines transport capabilities and routes connections
 /// through either QUIC or the Constrained engine as appropriate.
+///
+/// # Thread safety
+///
+/// All methods take `&self` — there is no interior `RwLock`. Stats are
+/// atomic, the constrained transport is lazy-initialised via [`OnceLock`],
+/// the QUIC endpoint is set at construction time only, and the next
+/// QUIC-connection ID is an [`AtomicU64`]. Wrap the router in [`Arc`] and
+/// call it from any number of concurrent tasks.
 pub struct ConnectionRouter {
     /// Router configuration
     config: RouterConfig,
 
-    /// Constrained transport (created lazily when needed)
-    constrained_transport: Option<ConstrainedTransport>,
+    /// Constrained transport (initialised on first constrained connect).
+    /// `OnceLock` allows lazy init under `&self`; once set, never revoked.
+    constrained_transport: OnceLock<ConstrainedTransport>,
 
     /// Transport registry for capability lookups
     registry: Option<Arc<TransportRegistry>>,
 
-    /// NAT traversal endpoint for QUIC connections
+    /// NAT traversal endpoint for QUIC connections. Set at construction
+    /// time only — there is no API to revoke or replace it, which is what
+    /// lets the hot send path read it under `&self` without locking.
     quic_endpoint: Option<Arc<NatTraversalEndpoint>>,
 
-    /// Router statistics
+    /// Router statistics (all counters atomic, `&self` mutable)
     stats: RouterStats,
 
-    /// Next QUIC connection ID (for tracking)
-    next_quic_id: u64,
+    /// Next QUIC connection ID (for tracking). Atomic so
+    /// `connect_quic_async` / `accept_quic` can run under `&self`.
+    next_quic_id: AtomicU64,
 }
 
 impl ConnectionRouter {
@@ -886,11 +992,11 @@ impl ConnectionRouter {
     pub fn new(config: RouterConfig) -> Self {
         Self {
             config,
-            constrained_transport: None,
+            constrained_transport: OnceLock::new(),
             registry: None,
             quic_endpoint: None,
             stats: RouterStats::default(),
-            next_quic_id: 1,
+            next_quic_id: AtomicU64::new(1),
         }
     }
 
@@ -898,11 +1004,11 @@ impl ConnectionRouter {
     pub fn with_registry(config: RouterConfig, registry: Arc<TransportRegistry>) -> Self {
         Self {
             config,
-            constrained_transport: None,
+            constrained_transport: OnceLock::new(),
             registry: Some(registry),
             quic_endpoint: None,
             stats: RouterStats::default(),
-            next_quic_id: 1,
+            next_quic_id: AtomicU64::new(1),
         }
     }
 
@@ -913,11 +1019,11 @@ impl ConnectionRouter {
     ) -> Self {
         Self {
             config,
-            constrained_transport: None,
+            constrained_transport: OnceLock::new(),
             registry: None,
             quic_endpoint: Some(quic_endpoint),
             stats: RouterStats::default(),
-            next_quic_id: 1,
+            next_quic_id: AtomicU64::new(1),
         }
     }
 
@@ -929,17 +1035,12 @@ impl ConnectionRouter {
     ) -> Self {
         Self {
             config,
-            constrained_transport: None,
+            constrained_transport: OnceLock::new(),
             registry: Some(registry),
             quic_endpoint: Some(quic_endpoint),
             stats: RouterStats::default(),
-            next_quic_id: 1,
+            next_quic_id: AtomicU64::new(1),
         }
-    }
-
-    /// Set the QUIC endpoint after construction
-    pub fn set_quic_endpoint(&mut self, endpoint: Arc<NatTraversalEndpoint>) {
-        self.quic_endpoint = Some(endpoint);
     }
 
     /// Check if QUIC endpoint is available
@@ -1150,7 +1251,7 @@ impl ConnectionRouter {
     ///
     /// This method only works for constrained connections. For QUIC connections,
     /// use `connect_async()` instead.
-    pub fn connect(&mut self, remote: &TransportAddr) -> Result<RoutedConnection, RouterError> {
+    pub fn connect(&self, remote: &TransportAddr) -> Result<RoutedConnection, RouterError> {
         let engine = self.select_engine_for_addr(remote);
 
         match engine {
@@ -1164,7 +1265,7 @@ impl ConnectionRouter {
     /// This method handles both QUIC and constrained connections. For QUIC connections,
     /// it requires a peer ID and server name.
     pub async fn connect_async(
-        &mut self,
+        &self,
         remote: &TransportAddr,
         server_name: Option<&str>,
     ) -> Result<RoutedConnection, RouterError> {
@@ -1190,7 +1291,7 @@ impl ConnectionRouter {
     /// Convenience method for QUIC connections that doesn't require engine selection
     /// (assumes QUIC is appropriate for the given address).
     pub async fn connect_peer(
-        &mut self,
+        &self,
         remote_addr: SocketAddr,
         server_name: &str,
     ) -> Result<RoutedConnection, RouterError> {
@@ -1202,7 +1303,7 @@ impl ConnectionRouter {
     ///
     /// This method returns an error indicating async is required for QUIC connections.
     /// Use `connect_quic_async` instead for actual QUIC connections.
-    fn connect_quic(&mut self, remote: &TransportAddr) -> Result<RoutedConnection, RouterError> {
+    fn connect_quic(&self, remote: &TransportAddr) -> Result<RoutedConnection, RouterError> {
         // QUIC connections require async - this sync version returns an error
         // directing users to use the async method
         Err(RouterError::Quic {
@@ -1217,7 +1318,7 @@ impl ConnectionRouter {
     ///
     /// This method initiates a QUIC connection through the NatTraversalEndpoint.
     pub async fn connect_quic_async(
-        &mut self,
+        &self,
         remote: &TransportAddr,
         server_name: &str,
     ) -> Result<RoutedConnection, RouterError> {
@@ -1234,10 +1335,9 @@ impl ConnectionRouter {
         // Connect through the NAT traversal endpoint
         let connection = endpoint.connect_to(server_name, socket_addr).await?;
 
-        // Assign connection ID and update stats
-        let connection_id = self.next_quic_id;
-        self.next_quic_id += 1;
-        self.stats.quic_connections += 1;
+        // Assign connection ID and update stats atomically.
+        let connection_id = self.next_quic_id.fetch_add(1, Ordering::Relaxed);
+        self.stats.quic_connections.fetch_add(1, Ordering::Relaxed);
 
         tracing::info!(
             connection_id,
@@ -1253,27 +1353,20 @@ impl ConnectionRouter {
     }
 
     /// Connect using the Constrained engine
-    fn connect_constrained(
-        &mut self,
-        remote: &TransportAddr,
-    ) -> Result<RoutedConnection, RouterError> {
-        // Initialize constrained transport if needed
-        if self.constrained_transport.is_none() {
-            let transport = ConstrainedTransport::new(self.config.constrained_config.clone());
-            self.constrained_transport = Some(transport);
-        }
-
-        let transport =
-            self.constrained_transport
-                .as_ref()
-                .ok_or(RouterError::NoTransportAvailable {
-                    addr: remote.clone(),
-                })?;
+    fn connect_constrained(&self, remote: &TransportAddr) -> Result<RoutedConnection, RouterError> {
+        // Lazy-initialise the constrained transport on first use.
+        // `OnceLock::get_or_init` runs the closure at most once even under
+        // concurrent callers; all callers then see the same transport.
+        let transport = self
+            .constrained_transport
+            .get_or_init(|| ConstrainedTransport::new(self.config.constrained_config.clone()));
 
         let handle = transport.handle();
         let connection_id = handle.connect(remote)?;
 
-        self.stats.constrained_connections += 1;
+        self.stats
+            .constrained_connections
+            .fetch_add(1, Ordering::Relaxed);
 
         Ok(RoutedConnection::Constrained {
             remote: remote.clone(),
@@ -1284,7 +1377,7 @@ impl ConnectionRouter {
 
     /// Get the constrained transport handle (for direct access if needed)
     pub fn constrained_handle(&self) -> Option<ConstrainedHandle> {
-        self.constrained_transport.as_ref().map(|t| t.handle())
+        self.constrained_transport.get().map(|t| t.handle())
     }
 
     /// Check if a transport supports QUIC
@@ -1295,7 +1388,7 @@ impl ConnectionRouter {
 
     /// Check if constrained engine is initialized
     pub fn is_constrained_initialized(&self) -> bool {
-        self.constrained_transport.is_some()
+        self.constrained_transport.get().is_some()
     }
 
     /// Get router statistics
@@ -1329,7 +1422,7 @@ impl ConnectionRouter {
     /// Note: This is a sync method that only polls constrained events.
     /// For QUIC events, use `poll_events_async()` or the event callback
     /// mechanism on the NatTraversalEndpoint.
-    pub fn poll_events(&mut self) -> Vec<RouterEvent> {
+    pub fn poll_events(&self) -> Vec<RouterEvent> {
         let mut events = Vec::new();
 
         // Collect constrained events and convert to unified format
@@ -1337,12 +1430,14 @@ impl ConnectionRouter {
             while let Some(adapter_event) = handle.next_event() {
                 let router_event = RouterEvent::from_adapter_event(adapter_event, None);
 
-                // Update stats based on event type
+                // Update stats based on event type (atomic RMW, no lock).
                 if let RouterEvent::DataReceived { data, .. } = &router_event {
-                    self.stats.constrained_bytes_received += data.len() as u64;
+                    self.stats
+                        .constrained_bytes_received
+                        .fetch_add(data.len() as u64, Ordering::Relaxed);
                 }
 
-                self.stats.events_processed += 1;
+                self.stats.events_processed.fetch_add(1, Ordering::Relaxed);
                 events.push(router_event);
             }
         }
@@ -1354,7 +1449,7 @@ impl ConnectionRouter {
     ///
     /// This method waits for an incoming connection on the QUIC endpoint
     /// and returns it wrapped as a RoutedConnection.
-    pub async fn accept_quic(&mut self) -> Result<RoutedConnection, RouterError> {
+    pub async fn accept_quic(&self) -> Result<RoutedConnection, RouterError> {
         let endpoint = self
             .quic_endpoint
             .as_ref()
@@ -1364,10 +1459,9 @@ impl ConnectionRouter {
 
         let transport_addr = TransportAddr::Udp(remote_addr);
 
-        // Assign connection ID and update stats
-        let connection_id = self.next_quic_id;
-        self.next_quic_id += 1;
-        self.stats.quic_connections += 1;
+        // Assign connection ID and update stats atomically.
+        let connection_id = self.next_quic_id.fetch_add(1, Ordering::Relaxed);
+        self.stats.quic_connections.fetch_add(1, Ordering::Relaxed);
 
         tracing::info!(
             connection_id,
@@ -1392,7 +1486,7 @@ impl ConnectionRouter {
     /// This should be called when data is received from the underlying
     /// transport (e.g., BLE characteristic notification, LoRa packet).
     pub fn process_constrained_incoming(
-        &mut self,
+        &self,
         remote: &TransportAddr,
         data: &[u8],
     ) -> Result<Vec<RouterEvent>, RouterError> {
@@ -1411,10 +1505,12 @@ impl ConnectionRouter {
             let router_event = RouterEvent::from_adapter_event(adapter_event, Some(remote));
 
             if let RouterEvent::DataReceived { data, .. } = &router_event {
-                self.stats.constrained_bytes_received += data.len() as u64;
+                self.stats
+                    .constrained_bytes_received
+                    .fetch_add(data.len() as u64, Ordering::Relaxed);
             }
 
-            self.stats.events_processed += 1;
+            self.stats.events_processed.fetch_add(1, Ordering::Relaxed);
             events.push(router_event);
         }
 
@@ -1444,12 +1540,24 @@ impl fmt::Debug for ConnectionRouter {
             .field("config", &self.config)
             .field(
                 "constrained_initialized",
-                &self.constrained_transport.is_some(),
+                &self.constrained_transport.get().is_some(),
             )
             .field("stats", &self.stats)
             .finish()
     }
 }
+
+// Compile-time check: `Arc<ConnectionRouter>` must be safe to share
+// across tasks, so `ConnectionRouter` needs to be both `Send` and `Sync`.
+// This static assertion fails the build early if a future change (e.g.
+// adding a non-`Sync` field) breaks that invariant, instead of surfacing
+// a confusing error deep inside the `P2pEndpoint` clone path.
+const _: fn() = || {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<ConnectionRouter>();
+    assert_send_sync::<RouterStats>();
+    assert_send_sync::<RouterStatsSnapshot>();
+};
 
 #[cfg(test)]
 mod tests {
@@ -1485,7 +1593,7 @@ mod tests {
 
         let engine = router.select_engine_for_addr(&addr);
         assert_eq!(engine, ProtocolEngine::Quic);
-        assert_eq!(router.stats().quic_selections.load(Ordering::Relaxed), 1);
+        assert_eq!(router.stats().quic_selections(), 1);
     }
 
     #[test]
@@ -1498,13 +1606,7 @@ mod tests {
 
         let engine = router.select_engine_for_addr(&addr);
         assert_eq!(engine, ProtocolEngine::Constrained);
-        assert_eq!(
-            router
-                .stats()
-                .constrained_selections
-                .load(Ordering::Relaxed),
-            1
-        );
+        assert_eq!(router.stats().constrained_selections(), 1);
     }
 
     #[test]
@@ -1535,7 +1637,7 @@ mod tests {
 
     #[test]
     fn test_connect_constrained() {
-        let mut router = ConnectionRouter::new(RouterConfig::default());
+        let router = ConnectionRouter::new(RouterConfig::default());
         let addr = TransportAddr::Ble {
             mac: [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF],
             psm: 128,
@@ -1548,14 +1650,14 @@ mod tests {
         assert!(conn.is_constrained());
         assert_eq!(conn.engine(), ProtocolEngine::Constrained);
         assert_eq!(conn.remote_addr(), &addr);
-        assert_eq!(router.stats().constrained_connections, 1);
+        assert_eq!(router.stats().constrained_connections(), 1);
     }
 
     #[test]
     fn test_connect_quic_requires_async() {
         // QUIC connections require async - the sync connect() method
         // should return an error for QUIC addresses
-        let mut router = ConnectionRouter::new(RouterConfig::default());
+        let router = ConnectionRouter::new(RouterConfig::default());
         let addr = TransportAddr::Quic("127.0.0.1:9000".parse().unwrap());
 
         let result = router.connect(&addr);
@@ -1588,7 +1690,7 @@ mod tests {
 
     #[test]
     fn test_routed_connection_send_constrained() {
-        let mut router = ConnectionRouter::new(RouterConfig::default());
+        let router = ConnectionRouter::new(RouterConfig::default());
         let addr = TransportAddr::Ble {
             mac: [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF],
             psm: 128,
@@ -1606,7 +1708,7 @@ mod tests {
 
     #[test]
     fn test_routed_connection_close() {
-        let mut router = ConnectionRouter::new(RouterConfig::default());
+        let router = ConnectionRouter::new(RouterConfig::default());
         let addr = TransportAddr::Ble {
             mac: [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF],
             psm: 128,
@@ -1633,13 +1735,13 @@ mod tests {
         let _ = router.select_engine_for_addr(&ble_addr);
 
         let stats = router.stats();
-        assert_eq!(stats.quic_selections.load(Ordering::Relaxed), 2);
-        assert_eq!(stats.constrained_selections.load(Ordering::Relaxed), 1);
+        assert_eq!(stats.quic_selections(), 2);
+        assert_eq!(stats.constrained_selections(), 1);
     }
 
     #[test]
     fn test_constrained_handle_access() {
-        let mut router = ConnectionRouter::new(RouterConfig::default());
+        let router = ConnectionRouter::new(RouterConfig::default());
 
         // Initially no handle
         assert!(router.constrained_handle().is_none());
@@ -1736,10 +1838,7 @@ mod tests {
         assert_eq!(result.engine, ProtocolEngine::Constrained);
         assert!(result.is_fallback);
         assert_eq!(result.reason, SelectionReason::QuicUnavailableFallback);
-        assert_eq!(
-            router.stats().fallback_selections.load(Ordering::Relaxed),
-            1
-        );
+        assert_eq!(router.stats().fallback_selections(), 1);
     }
 
     #[test]
@@ -1824,7 +1923,7 @@ mod tests {
 
     #[test]
     fn test_is_constrained_initialized() {
-        let mut router = ConnectionRouter::new(RouterConfig::default());
+        let router = ConnectionRouter::new(RouterConfig::default());
         assert!(!router.is_constrained_initialized());
 
         // Initialize by connecting to BLE
@@ -1844,17 +1943,11 @@ mod tests {
 
         // Normal selection - no fallback
         let _ = router.select_engine_with_fallback(&capabilities, true, true);
-        assert_eq!(
-            router.stats().fallback_selections.load(Ordering::Relaxed),
-            0
-        );
+        assert_eq!(router.stats().fallback_selections(), 0);
 
         // Fallback selection
         let _ = router.select_engine_with_fallback(&capabilities, false, true);
-        assert_eq!(
-            router.stats().fallback_selections.load(Ordering::Relaxed),
-            1
-        );
+        assert_eq!(router.stats().fallback_selections(), 1);
     }
 
     // ========================================================================
@@ -1881,7 +1974,7 @@ mod tests {
 
     #[test]
     fn test_routed_connection_accessors_constrained() {
-        let mut router = ConnectionRouter::new(RouterConfig::default());
+        let router = ConnectionRouter::new(RouterConfig::default());
         let addr = TransportAddr::Ble {
             mac: [0x11, 0x22, 0x33, 0x44, 0x55, 0x66],
             psm: 128,
@@ -1902,13 +1995,10 @@ mod tests {
     }
 
     #[test]
-    fn test_set_quic_endpoint() {
+    fn test_quic_endpoint_unset_by_default() {
         let router = ConnectionRouter::new(RouterConfig::default());
         assert!(!router.is_quic_available());
         assert!(router.quic_endpoint().is_none());
-
-        // We can't easily construct a NatTraversalEndpoint in a unit test,
-        // but we verify the setter method exists and the state tracking works
     }
 
     #[test]
@@ -1922,7 +2012,7 @@ mod tests {
 
     #[test]
     fn test_routed_connection_debug_constrained() {
-        let mut router = ConnectionRouter::new(RouterConfig::default());
+        let router = ConnectionRouter::new(RouterConfig::default());
         let addr = TransportAddr::Ble {
             mac: [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF],
             psm: 128,
@@ -1984,14 +2074,14 @@ mod tests {
 
     #[test]
     fn test_poll_events_empty() {
-        let mut router = ConnectionRouter::new(RouterConfig::default());
+        let router = ConnectionRouter::new(RouterConfig::default());
         let events = router.poll_events();
         assert!(events.is_empty());
     }
 
     #[test]
     fn test_poll_events_after_constrained_connect() {
-        let mut router = ConnectionRouter::new(RouterConfig::default());
+        let router = ConnectionRouter::new(RouterConfig::default());
         let addr = TransportAddr::Ble {
             mac: [0x11, 0x22, 0x33, 0x44, 0x55, 0x66],
             psm: 128,
@@ -2012,7 +2102,7 @@ mod tests {
 
     #[test]
     fn test_connection_mtu() {
-        let mut router = ConnectionRouter::new(RouterConfig::default());
+        let router = ConnectionRouter::new(RouterConfig::default());
         let addr = TransportAddr::Ble {
             mac: [0x11, 0x22, 0x33, 0x44, 0x55, 0x66],
             psm: 128,
@@ -2027,7 +2117,7 @@ mod tests {
 
     #[test]
     fn test_connection_stats_constrained() {
-        let mut router = ConnectionRouter::new(RouterConfig::default());
+        let router = ConnectionRouter::new(RouterConfig::default());
         let addr = TransportAddr::Ble {
             mac: [0x11, 0x22, 0x33, 0x44, 0x55, 0x66],
             psm: 128,
@@ -2055,7 +2145,7 @@ mod tests {
 
     #[test]
     fn test_close_with_reason_constrained() {
-        let mut router = ConnectionRouter::new(RouterConfig::default());
+        let router = ConnectionRouter::new(RouterConfig::default());
         let addr = TransportAddr::Ble {
             mac: [0x11, 0x22, 0x33, 0x44, 0x55, 0x66],
             psm: 128,
@@ -2068,7 +2158,7 @@ mod tests {
 
     #[test]
     fn test_is_open_after_close() {
-        let mut router = ConnectionRouter::new(RouterConfig::default());
+        let router = ConnectionRouter::new(RouterConfig::default());
         let addr = TransportAddr::Ble {
             mac: [0x11, 0x22, 0x33, 0x44, 0x55, 0x66],
             psm: 128,
@@ -2085,7 +2175,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_send_async_constrained() {
-        let mut router = ConnectionRouter::new(RouterConfig::default());
+        let router = ConnectionRouter::new(RouterConfig::default());
         let addr = TransportAddr::Ble {
             mac: [0x11, 0x22, 0x33, 0x44, 0x55, 0x66],
             psm: 128,
@@ -2102,7 +2192,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_recv_async_constrained_no_data() {
-        let mut router = ConnectionRouter::new(RouterConfig::default());
+        let router = ConnectionRouter::new(RouterConfig::default());
         let addr = TransportAddr::Ble {
             mac: [0x11, 0x22, 0x33, 0x44, 0x55, 0x66],
             psm: 128,

--- a/src/connection_router.rs
+++ b/src/connection_router.rs
@@ -1083,24 +1083,27 @@ impl ConnectionRouter {
         // Adjust stats for fallback: the inner select_engine_detailed call
         // incremented the *preferred* counter, so when we actually fell
         // back we need to decrement it and increment the one we chose.
+        // Both operations must be atomic so concurrent callers (now allowed
+        // because the function takes `&self`) cannot lose updates.
         if result.is_fallback {
             match engine {
                 ProtocolEngine::Quic => {
                     self.stats.quic_selections.fetch_add(1, Ordering::Relaxed);
-                    // saturating_sub via CAS loop on relaxed load/store
-                    let cur = self.stats.constrained_selections.load(Ordering::Relaxed);
-                    self.stats
-                        .constrained_selections
-                        .store(cur.saturating_sub(1), Ordering::Relaxed);
+                    let _ = self.stats.constrained_selections.fetch_update(
+                        Ordering::Relaxed,
+                        Ordering::Relaxed,
+                        |v| Some(v.saturating_sub(1)),
+                    );
                 }
                 ProtocolEngine::Constrained => {
                     self.stats
                         .constrained_selections
                         .fetch_add(1, Ordering::Relaxed);
-                    let cur = self.stats.quic_selections.load(Ordering::Relaxed);
-                    self.stats
-                        .quic_selections
-                        .store(cur.saturating_sub(1), Ordering::Relaxed);
+                    let _ = self.stats.quic_selections.fetch_update(
+                        Ordering::Relaxed,
+                        Ordering::Relaxed,
+                        |v| Some(v.saturating_sub(1)),
+                    );
                 }
             }
         }

--- a/src/connection_router.rs
+++ b/src/connection_router.rs
@@ -64,6 +64,7 @@
 use std::fmt;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::constrained::{
     AdapterEvent, ConnectionId as ConstrainedConnId, ConstrainedError, ConstrainedHandle,
@@ -786,8 +787,18 @@ impl RouterEvent {
     }
 }
 
-/// Router statistics
-#[derive(Debug, Clone, Default)]
+/// Router statistics.
+///
+/// Selection counters (`quic_selections`, `constrained_selections`,
+/// `fallback_selections`) are stored as [`AtomicU64`] so the selection
+/// methods can take `&self` and be called under a `RwLock::read()` guard.
+/// Without this, every outbound send on a `P2pEndpoint` had to acquire an
+/// exclusive write lock on the router just to bump a counter, serialising
+/// all sends through a single lock (see p2p_endpoint.rs `send()`).
+///
+/// Other counters are still plain `u64` because they are only touched on
+/// `&mut self` paths (connect/accept/event-loop).
+#[derive(Debug, Default)]
 pub struct RouterStats {
     /// Total connections routed through QUIC
     pub quic_connections: u64,
@@ -810,17 +821,40 @@ pub struct RouterStats {
     /// Connection failures
     pub connection_failures: u64,
 
-    /// Engine selection decisions (QUIC chosen)
-    pub quic_selections: u64,
+    /// Engine selection decisions (QUIC chosen). Atomic so the selection
+    /// path does not require exclusive access.
+    pub quic_selections: AtomicU64,
 
-    /// Engine selection decisions (Constrained chosen)
-    pub constrained_selections: u64,
+    /// Engine selection decisions (Constrained chosen). Atomic so the
+    /// selection path does not require exclusive access.
+    pub constrained_selections: AtomicU64,
 
-    /// Fallback selections (when preferred engine unavailable)
-    pub fallback_selections: u64,
+    /// Fallback selections (when preferred engine unavailable). Atomic so
+    /// the selection path does not require exclusive access.
+    pub fallback_selections: AtomicU64,
 
     /// Total events processed
     pub events_processed: u64,
+}
+
+impl Clone for RouterStats {
+    fn clone(&self) -> Self {
+        Self {
+            quic_connections: self.quic_connections,
+            constrained_connections: self.constrained_connections,
+            quic_bytes_sent: self.quic_bytes_sent,
+            constrained_bytes_sent: self.constrained_bytes_sent,
+            quic_bytes_received: self.quic_bytes_received,
+            constrained_bytes_received: self.constrained_bytes_received,
+            connection_failures: self.connection_failures,
+            quic_selections: AtomicU64::new(self.quic_selections.load(Ordering::Relaxed)),
+            constrained_selections: AtomicU64::new(
+                self.constrained_selections.load(Ordering::Relaxed),
+            ),
+            fallback_selections: AtomicU64::new(self.fallback_selections.load(Ordering::Relaxed)),
+            events_processed: self.events_processed,
+        }
+    }
 }
 
 /// Connection router for automatic protocol engine selection
@@ -913,17 +947,19 @@ impl ConnectionRouter {
         self.quic_endpoint.is_some()
     }
 
-    /// Select the appropriate protocol engine for a transport
-    pub fn select_engine(&mut self, capabilities: &TransportCapabilities) -> ProtocolEngine {
+    /// Select the appropriate protocol engine for a transport.
+    ///
+    /// Takes `&self` — selection counters are atomic so this can run under
+    /// a read-lock guard without serialising all callers.
+    pub fn select_engine(&self, capabilities: &TransportCapabilities) -> ProtocolEngine {
         let result = self.select_engine_detailed(capabilities);
         result.engine
     }
 
-    /// Select engine with detailed selection result
-    pub fn select_engine_detailed(
-        &mut self,
-        capabilities: &TransportCapabilities,
-    ) -> SelectionResult {
+    /// Select engine with detailed selection result.
+    ///
+    /// Takes `&self` — selection counters are atomic.
+    pub fn select_engine_detailed(&self, capabilities: &TransportCapabilities) -> SelectionResult {
         let supports_quic = capabilities.supports_full_quic();
 
         let (engine, reason) = if supports_quic {
@@ -939,10 +975,16 @@ impl ConnectionRouter {
             (ProtocolEngine::Constrained, SelectionReason::TooConstrained)
         };
 
-        // Update selection stats
+        // Update selection stats via atomic counters.
         match engine {
-            ProtocolEngine::Quic => self.stats.quic_selections += 1,
-            ProtocolEngine::Constrained => self.stats.constrained_selections += 1,
+            ProtocolEngine::Quic => {
+                self.stats.quic_selections.fetch_add(1, Ordering::Relaxed);
+            }
+            ProtocolEngine::Constrained => {
+                self.stats
+                    .constrained_selections
+                    .fetch_add(1, Ordering::Relaxed);
+            }
         }
 
         tracing::debug!(
@@ -962,12 +1004,13 @@ impl ConnectionRouter {
         }
     }
 
-    /// Select engine with fallback support
+    /// Select engine with fallback support.
     ///
-    /// If the preferred engine is unavailable (e.g., QUIC endpoint not initialized),
-    /// this method will attempt to use the fallback engine.
+    /// If the preferred engine is unavailable (e.g., QUIC endpoint not
+    /// initialized), this method will attempt to use the fallback engine.
+    /// Takes `&self` — all mutations are via atomic counters.
     pub fn select_engine_with_fallback(
-        &mut self,
+        &self,
         capabilities: &TransportCapabilities,
         quic_available: bool,
         constrained_available: bool,
@@ -979,7 +1022,9 @@ impl ConnectionRouter {
             ProtocolEngine::Quic if quic_available => (ProtocolEngine::Quic, preferred),
             ProtocolEngine::Quic if constrained_available => {
                 // Fall back to constrained
-                self.stats.fallback_selections += 1;
+                self.stats
+                    .fallback_selections
+                    .fetch_add(1, Ordering::Relaxed);
                 tracing::warn!(
                     preferred = "QUIC",
                     fallback = "Constrained",
@@ -1000,7 +1045,9 @@ impl ConnectionRouter {
             }
             ProtocolEngine::Constrained if quic_available && capabilities.supports_full_quic() => {
                 // Fall back to QUIC (only if transport supports it)
-                self.stats.fallback_selections += 1;
+                self.stats
+                    .fallback_selections
+                    .fetch_add(1, Ordering::Relaxed);
                 tracing::warn!(
                     preferred = "Constrained",
                     fallback = "QUIC",
@@ -1033,17 +1080,27 @@ impl ConnectionRouter {
             }
         };
 
-        // Adjust stats for fallback
+        // Adjust stats for fallback: the inner select_engine_detailed call
+        // incremented the *preferred* counter, so when we actually fell
+        // back we need to decrement it and increment the one we chose.
         if result.is_fallback {
             match engine {
                 ProtocolEngine::Quic => {
-                    self.stats.quic_selections += 1;
-                    self.stats.constrained_selections =
-                        self.stats.constrained_selections.saturating_sub(1);
+                    self.stats.quic_selections.fetch_add(1, Ordering::Relaxed);
+                    // saturating_sub via CAS loop on relaxed load/store
+                    let cur = self.stats.constrained_selections.load(Ordering::Relaxed);
+                    self.stats
+                        .constrained_selections
+                        .store(cur.saturating_sub(1), Ordering::Relaxed);
                 }
                 ProtocolEngine::Constrained => {
-                    self.stats.constrained_selections += 1;
-                    self.stats.quic_selections = self.stats.quic_selections.saturating_sub(1);
+                    self.stats
+                        .constrained_selections
+                        .fetch_add(1, Ordering::Relaxed);
+                    let cur = self.stats.quic_selections.load(Ordering::Relaxed);
+                    self.stats
+                        .quic_selections
+                        .store(cur.saturating_sub(1), Ordering::Relaxed);
                 }
             }
         }
@@ -1051,13 +1108,17 @@ impl ConnectionRouter {
         Ok(result)
     }
 
-    /// Select engine based on destination address
-    pub fn select_engine_for_addr(&mut self, addr: &TransportAddr) -> ProtocolEngine {
+    /// Select engine based on destination address.
+    ///
+    /// Takes `&self` so the hot send path can hold only a read lock.
+    pub fn select_engine_for_addr(&self, addr: &TransportAddr) -> ProtocolEngine {
         self.select_engine_for_addr_detailed(addr).engine
     }
 
-    /// Select engine based on destination address with detailed result
-    pub fn select_engine_for_addr_detailed(&mut self, addr: &TransportAddr) -> SelectionResult {
+    /// Select engine based on destination address with detailed result.
+    ///
+    /// Takes `&self` so the hot send path can hold only a read lock.
+    pub fn select_engine_for_addr_detailed(&self, addr: &TransportAddr) -> SelectionResult {
         // Determine capabilities based on address type
         let capabilities = Self::capabilities_for_addr(addr);
         self.select_engine_detailed(&capabilities)
@@ -1416,17 +1477,17 @@ mod tests {
 
     #[test]
     fn test_engine_selection_for_quic() {
-        let mut router = ConnectionRouter::new(RouterConfig::default());
+        let router = ConnectionRouter::new(RouterConfig::default());
         let addr = TransportAddr::Quic("127.0.0.1:9000".parse().unwrap());
 
         let engine = router.select_engine_for_addr(&addr);
         assert_eq!(engine, ProtocolEngine::Quic);
-        assert_eq!(router.stats().quic_selections, 1);
+        assert_eq!(router.stats().quic_selections.load(Ordering::Relaxed), 1);
     }
 
     #[test]
     fn test_engine_selection_for_ble() {
-        let mut router = ConnectionRouter::new(RouterConfig::default());
+        let router = ConnectionRouter::new(RouterConfig::default());
         let addr = TransportAddr::Ble {
             mac: [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF],
             psm: 128,
@@ -1434,12 +1495,18 @@ mod tests {
 
         let engine = router.select_engine_for_addr(&addr);
         assert_eq!(engine, ProtocolEngine::Constrained);
-        assert_eq!(router.stats().constrained_selections, 1);
+        assert_eq!(
+            router
+                .stats()
+                .constrained_selections
+                .load(Ordering::Relaxed),
+            1
+        );
     }
 
     #[test]
     fn test_engine_selection_for_lora() {
-        let mut router = ConnectionRouter::new(RouterConfig::default());
+        let router = ConnectionRouter::new(RouterConfig::default());
         let addr = TransportAddr::LoRa {
             dev_addr: [0x12, 0x34, 0x56, 0x78],
             freq_hz: 868_000_000,
@@ -1549,7 +1616,7 @@ mod tests {
 
     #[test]
     fn test_router_stats() {
-        let mut router = ConnectionRouter::new(RouterConfig::default());
+        let router = ConnectionRouter::new(RouterConfig::default());
 
         // Make some selections
         let quic_addr = TransportAddr::Quic("127.0.0.1:9000".parse().unwrap());
@@ -1563,8 +1630,8 @@ mod tests {
         let _ = router.select_engine_for_addr(&ble_addr);
 
         let stats = router.stats();
-        assert_eq!(stats.quic_selections, 2);
-        assert_eq!(stats.constrained_selections, 1);
+        assert_eq!(stats.quic_selections.load(Ordering::Relaxed), 2);
+        assert_eq!(stats.constrained_selections.load(Ordering::Relaxed), 1);
     }
 
     #[test]
@@ -1608,7 +1675,7 @@ mod tests {
 
     #[test]
     fn test_select_engine_detailed_udp() {
-        let mut router = ConnectionRouter::new(RouterConfig::default());
+        let router = ConnectionRouter::new(RouterConfig::default());
         let capabilities = TransportCapabilities::broadband();
 
         let result = router.select_engine_detailed(&capabilities);
@@ -1620,7 +1687,7 @@ mod tests {
 
     #[test]
     fn test_select_engine_detailed_ble() {
-        let mut router = ConnectionRouter::new(RouterConfig::default());
+        let router = ConnectionRouter::new(RouterConfig::default());
         let capabilities = TransportCapabilities::ble();
 
         let result = router.select_engine_detailed(&capabilities);
@@ -1634,7 +1701,7 @@ mod tests {
         // Configure router to prefer constrained even for broadband
         let mut config = RouterConfig::default();
         config.prefer_quic = false;
-        let mut router = ConnectionRouter::new(config);
+        let router = ConnectionRouter::new(config);
         let capabilities = TransportCapabilities::broadband();
 
         let result = router.select_engine_detailed(&capabilities);
@@ -1644,7 +1711,7 @@ mod tests {
 
     #[test]
     fn test_select_engine_with_fallback_quic_available() {
-        let mut router = ConnectionRouter::new(RouterConfig::default());
+        let router = ConnectionRouter::new(RouterConfig::default());
         let capabilities = TransportCapabilities::broadband();
 
         let result = router
@@ -1656,7 +1723,7 @@ mod tests {
 
     #[test]
     fn test_select_engine_with_fallback_to_constrained() {
-        let mut router = ConnectionRouter::new(RouterConfig::default());
+        let router = ConnectionRouter::new(RouterConfig::default());
         let capabilities = TransportCapabilities::broadband();
 
         // QUIC unavailable, constrained available
@@ -1666,13 +1733,16 @@ mod tests {
         assert_eq!(result.engine, ProtocolEngine::Constrained);
         assert!(result.is_fallback);
         assert_eq!(result.reason, SelectionReason::QuicUnavailableFallback);
-        assert_eq!(router.stats().fallback_selections, 1);
+        assert_eq!(
+            router.stats().fallback_selections.load(Ordering::Relaxed),
+            1
+        );
     }
 
     #[test]
     fn test_select_engine_with_fallback_constrained_preferred() {
         let config = RouterConfig::for_ble_focus();
-        let mut router = ConnectionRouter::new(config);
+        let router = ConnectionRouter::new(config);
         let capabilities = TransportCapabilities::broadband();
 
         // Constrained preferred but unavailable, QUIC available
@@ -1690,7 +1760,7 @@ mod tests {
 
     #[test]
     fn test_select_engine_with_fallback_no_engines() {
-        let mut router = ConnectionRouter::new(RouterConfig::default());
+        let router = ConnectionRouter::new(RouterConfig::default());
         let capabilities = TransportCapabilities::broadband();
 
         // Neither engine available
@@ -1766,16 +1836,22 @@ mod tests {
 
     #[test]
     fn test_fallback_stats_tracking() {
-        let mut router = ConnectionRouter::new(RouterConfig::default());
+        let router = ConnectionRouter::new(RouterConfig::default());
         let capabilities = TransportCapabilities::broadband();
 
         // Normal selection - no fallback
         let _ = router.select_engine_with_fallback(&capabilities, true, true);
-        assert_eq!(router.stats().fallback_selections, 0);
+        assert_eq!(
+            router.stats().fallback_selections.load(Ordering::Relaxed),
+            0
+        );
 
         // Fallback selection
         let _ = router.select_engine_with_fallback(&capabilities, false, true);
-        assert_eq!(router.stats().fallback_selections, 1);
+        assert_eq!(
+            router.stats().fallback_selections.load(Ordering::Relaxed),
+            1
+        );
     }
 
     // ========================================================================
@@ -1892,7 +1968,7 @@ mod tests {
     fn test_router_with_fallback_quic_unavailable_but_transport_supports() {
         // When QUIC is unavailable but transport supports QUIC,
         // should fall back to constrained
-        let mut router = ConnectionRouter::new(RouterConfig::default());
+        let router = ConnectionRouter::new(RouterConfig::default());
         let capabilities = TransportCapabilities::broadband();
 
         let result = router

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -152,8 +152,10 @@ pub struct P2pEndpoint {
     /// Connection router for automatic protocol engine selection
     ///
     /// Routes connections through either QUIC (for broadband) or Constrained
-    /// engine (for BLE/LoRa) based on transport capabilities.
-    router: Arc<RwLock<ConnectionRouter>>,
+    /// engine (for BLE/LoRa) based on transport capabilities. The router is
+    /// fully interior-mutable — all methods take `&self` and stat/state
+    /// mutations are lock-free — so no `RwLock` is needed.
+    router: Arc<ConnectionRouter>,
 
     /// Mapping from TransportAddr to ConnectionId for constrained connections
     ///
@@ -736,14 +738,13 @@ impl P2pEndpoint {
             enable_metrics: true,
             max_connections: 256,
         };
-        let mut router = ConnectionRouter::with_full_config(
+        // `with_full_config` already installs the QUIC endpoint; no
+        // post-construction setter is needed.
+        let router = ConnectionRouter::with_full_config(
             router_config,
             Arc::clone(&transport_registry),
             Arc::clone(&inner_arc),
         );
-
-        // Set QUIC endpoint on the router
-        router.set_quic_endpoint(Arc::clone(&inner_arc));
 
         // Create channel for data received from background reader tasks
         let (data_tx, data_rx) = mpsc::channel(config.data_channel_capacity);
@@ -766,7 +767,7 @@ impl P2pEndpoint {
             pending_data: Arc::new(RwLock::new(BoundedPendingBuffer::default())),
             bootstrap_cache,
             transport_registry,
-            router: Arc::new(RwLock::new(router)),
+            router: Arc::new(router),
             constrained_connections: Arc::new(RwLock::new(HashMap::new())),
             constrained_peer_addrs: Arc::new(RwLock::new(HashMap::new())),
             hole_punch_target_peer_ids: Arc::new(dashmap::DashMap::new()),
@@ -1016,12 +1017,18 @@ impl P2pEndpoint {
 
         // Use the router to determine the appropriate engine.
         //
-        // Engine selection only needs a read lock now that
-        // `select_engine_for_addr` takes `&self` and uses atomic counters.
-        // The Constrained branch then re-acquires a write lock for
-        // `router.connect(addr)`, which is still `&mut self`. The QUIC
-        // branch never needs a write lock at all.
-        let engine = self.router.read().await.select_engine_for_addr(addr);
+        // Both `select_engine_for_addr` and `connect` take `&self` on
+        // `ConnectionRouter`, so there is no locking at all on the hot
+        // path. Selection and connect are two separate calls — there is a
+        // theoretical TOCTOU window where the engine picked here could
+        // become unavailable before the connect runs. In practice the
+        // router has no API to revoke or replace an engine once installed
+        // (the QUIC endpoint is set at construction time, the constrained
+        // transport is lazy-initialised and never torn down), so the race
+        // is closed by construction. If that invariant is ever relaxed,
+        // this call site needs to handle an engine-unavailable error from
+        // `connect()` explicitly.
+        let engine = self.router.select_engine_for_addr(addr);
 
         info!("Connecting to {} via {:?} engine", addr, engine);
 
@@ -1037,9 +1044,9 @@ impl P2pEndpoint {
                 self.connect(socket_addr).await
             }
             ProtocolEngine::Constrained => {
-                // For constrained transports, use the router's constrained connection.
-                let mut router = self.router.write().await;
-                let _routed = router.connect(addr).map_err(|e| {
+                // For constrained transports, use the router's connect
+                // path. No lock needed — `connect` takes `&self`.
+                let _routed = self.router.connect(addr).map_err(|e| {
                     EndpointError::Connection(format!("Constrained connection failed: {}", e))
                 })?;
 
@@ -1054,8 +1061,6 @@ impl P2pEndpoint {
                     last_activity: Instant::now(),
                 };
 
-                // Store peer keyed by synthetic address
-                drop(router); // Release lock before acquiring connected_peers lock
                 self.connected_peers
                     .write()
                     .await
@@ -1082,17 +1087,18 @@ impl P2pEndpoint {
 
     /// Get the connection router for advanced routing control
     ///
-    /// Returns a reference to the connection router which can be used to:
-    /// - Query engine selection for addresses
-    /// - Get routing statistics
-    /// - Configure routing behavior
-    pub async fn router(&self) -> tokio::sync::RwLockReadGuard<'_, ConnectionRouter> {
-        self.router.read().await
+    /// Returns a shared reference to the connection router which can be
+    /// used to query engine selection for addresses, read routing stats,
+    /// or drive connects/accepts directly. All router methods take
+    /// `&self`, so multiple callers can use the returned handle
+    /// concurrently.
+    pub fn router(&self) -> &Arc<ConnectionRouter> {
+        &self.router
     }
 
-    /// Get routing statistics
-    pub async fn routing_stats(&self) -> crate::connection_router::RouterStats {
-        self.router.read().await.stats().clone()
+    /// Get a point-in-time snapshot of router statistics.
+    pub fn routing_stats(&self) -> crate::connection_router::RouterStatsSnapshot {
+        self.router.stats().snapshot()
     }
 
     /// Register a constrained connection for a transport address
@@ -2271,16 +2277,14 @@ impl P2pEndpoint {
 
         // Select protocol engine based on transport address.
         //
-        // Uses a read lock: `select_engine_for_addr` takes `&self` and
-        // updates its stats counters via atomics. The previous code held
-        // an exclusive write lock here, which serialised every outbound
-        // send on the endpoint through a single lock and was a dominant
-        // contention point at high node counts (1000-node testnet).
-        let engine = self
-            .router
-            .read()
-            .await
-            .select_engine_for_addr(&transport_addr);
+        // No lock: `select_engine_for_addr` takes `&self` on
+        // `ConnectionRouter` and bumps its stats counters via atomics, so
+        // concurrent sends can run fully in parallel. The previous
+        // implementation held an exclusive write lock on the router here,
+        // which serialised every outbound send on the endpoint through a
+        // single lock and was a dominant contention point at high node
+        // counts (1000-node testnet).
+        let engine = self.router.select_engine_for_addr(&transport_addr);
 
         match engine {
             crate::transport::ProtocolEngine::Quic => {

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -1014,9 +1014,14 @@ impl P2pEndpoint {
             return Err(EndpointError::ShuttingDown);
         }
 
-        // Use the router to determine the appropriate engine
-        let mut router = self.router.write().await;
-        let engine = router.select_engine_for_addr(addr);
+        // Use the router to determine the appropriate engine.
+        //
+        // Engine selection only needs a read lock now that
+        // `select_engine_for_addr` takes `&self` and uses atomic counters.
+        // The Constrained branch then re-acquires a write lock for
+        // `router.connect(addr)`, which is still `&mut self`. The QUIC
+        // branch never needs a write lock at all.
+        let engine = self.router.read().await.select_engine_for_addr(addr);
 
         info!("Connecting to {} via {:?} engine", addr, engine);
 
@@ -1029,11 +1034,11 @@ impl P2pEndpoint {
                         addr
                     ))
                 })?;
-                drop(router); // Release lock before async operation
                 self.connect(socket_addr).await
             }
             ProtocolEngine::Constrained => {
-                // For constrained transports, use the router's constrained connection
+                // For constrained transports, use the router's constrained connection.
+                let mut router = self.router.write().await;
                 let _routed = router.connect(addr).map_err(|e| {
                     EndpointError::Connection(format!("Constrained connection failed: {}", e))
                 })?;

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -2264,11 +2264,18 @@ impl P2pEndpoint {
             }
         };
 
-        // Select protocol engine based on transport address
-        let engine = {
-            let mut router = self.router.write().await;
-            router.select_engine_for_addr(&transport_addr)
-        };
+        // Select protocol engine based on transport address.
+        //
+        // Uses a read lock: `select_engine_for_addr` takes `&self` and
+        // updates its stats counters via atomics. The previous code held
+        // an exclusive write lock here, which serialised every outbound
+        // send on the endpoint through a single lock and was a dominant
+        // contention point at high node counts (1000-node testnet).
+        let engine = self
+            .router
+            .read()
+            .await
+            .select_engine_for_addr(&transport_addr);
 
         match engine {
             crate::transport::ProtocolEngine::Quic => {

--- a/tests/constrained_integration.rs
+++ b/tests/constrained_integration.rs
@@ -268,7 +268,6 @@ fn test_connection_close() {
 
 use saorsa_transport::connection_router::{ConnectionRouter, RouterConfig};
 use saorsa_transport::transport::ProtocolEngine;
-use std::sync::atomic::Ordering;
 
 /// Test that ConnectionRouter correctly selects Constrained engine for BLE addresses
 #[test]
@@ -289,8 +288,8 @@ fn test_router_selects_constrained_for_ble() {
 
     // Verify stats tracking
     let stats = router.stats();
-    assert_eq!(stats.constrained_selections.load(Ordering::Relaxed), 1);
-    assert_eq!(stats.quic_selections.load(Ordering::Relaxed), 0);
+    assert_eq!(stats.constrained_selections(), 1);
+    assert_eq!(stats.quic_selections(), 0);
 }
 
 /// Test that ConnectionRouter correctly selects QUIC engine for UDP addresses
@@ -305,8 +304,8 @@ fn test_router_selects_quic_for_udp() {
 
     // Verify stats tracking
     let stats = router.stats();
-    assert_eq!(stats.quic_selections.load(Ordering::Relaxed), 1);
-    assert_eq!(stats.constrained_selections.load(Ordering::Relaxed), 0);
+    assert_eq!(stats.quic_selections(), 1);
+    assert_eq!(stats.constrained_selections(), 0);
 }
 
 /// Test mixed transport selection (UDP and BLE peers)
@@ -340,8 +339,8 @@ fn test_mixed_transport_selection() {
 
     // Verify cumulative stats
     let stats = router.stats();
-    assert_eq!(stats.quic_selections.load(Ordering::Relaxed), 1);
-    assert_eq!(stats.constrained_selections.load(Ordering::Relaxed), 2);
+    assert_eq!(stats.quic_selections(), 1);
+    assert_eq!(stats.constrained_selections(), 2);
 }
 
 /// Test synthetic socket address generation for BLE

--- a/tests/constrained_integration.rs
+++ b/tests/constrained_integration.rs
@@ -268,11 +268,12 @@ fn test_connection_close() {
 
 use saorsa_transport::connection_router::{ConnectionRouter, RouterConfig};
 use saorsa_transport::transport::ProtocolEngine;
+use std::sync::atomic::Ordering;
 
 /// Test that ConnectionRouter correctly selects Constrained engine for BLE addresses
 #[test]
 fn test_router_selects_constrained_for_ble() {
-    let mut router = ConnectionRouter::new(RouterConfig::default());
+    let router = ConnectionRouter::new(RouterConfig::default());
 
     let ble_addr = TransportAddr::Ble {
         mac: [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF],
@@ -288,14 +289,14 @@ fn test_router_selects_constrained_for_ble() {
 
     // Verify stats tracking
     let stats = router.stats();
-    assert_eq!(stats.constrained_selections, 1);
-    assert_eq!(stats.quic_selections, 0);
+    assert_eq!(stats.constrained_selections.load(Ordering::Relaxed), 1);
+    assert_eq!(stats.quic_selections.load(Ordering::Relaxed), 0);
 }
 
 /// Test that ConnectionRouter correctly selects QUIC engine for UDP addresses
 #[test]
 fn test_router_selects_quic_for_udp() {
-    let mut router = ConnectionRouter::new(RouterConfig::default());
+    let router = ConnectionRouter::new(RouterConfig::default());
 
     let udp_addr = TransportAddr::Udp("127.0.0.1:9000".parse().unwrap());
 
@@ -304,14 +305,14 @@ fn test_router_selects_quic_for_udp() {
 
     // Verify stats tracking
     let stats = router.stats();
-    assert_eq!(stats.quic_selections, 1);
-    assert_eq!(stats.constrained_selections, 0);
+    assert_eq!(stats.quic_selections.load(Ordering::Relaxed), 1);
+    assert_eq!(stats.constrained_selections.load(Ordering::Relaxed), 0);
 }
 
 /// Test mixed transport selection (UDP and BLE peers)
 #[test]
 fn test_mixed_transport_selection() {
-    let mut router = ConnectionRouter::new(RouterConfig::default());
+    let router = ConnectionRouter::new(RouterConfig::default());
 
     let udp_addr = TransportAddr::Udp("192.168.1.100:8080".parse().unwrap());
     let ble_addr = TransportAddr::Ble {
@@ -339,8 +340,8 @@ fn test_mixed_transport_selection() {
 
     // Verify cumulative stats
     let stats = router.stats();
-    assert_eq!(stats.quic_selections, 1);
-    assert_eq!(stats.constrained_selections, 2);
+    assert_eq!(stats.quic_selections.load(Ordering::Relaxed), 1);
+    assert_eq!(stats.constrained_selections.load(Ordering::Relaxed), 2);
 }
 
 /// Test synthetic socket address generation for BLE


### PR DESCRIPTION
## Summary

- `P2pEndpoint::send()` previously held a **write** lock on the `ConnectionRouter` just to call `select_engine_for_addr`, which only needed to bump a stats counter. At scale (1000-node testnet) this serialised every outbound send through a single exclusive lock and was a dominant contention point.
- Convert `RouterStats::{quic,constrained,fallback}_selections` to `AtomicU64` so the `select_engine*` family can take `&self`, then switch the send path to `router.read().await`.
- Hand-implement `Clone` for `RouterStats` (loads each counter `Relaxed`) since `AtomicU64` isn't `Clone`. Other counters stay plain `u64` — they are only touched on `&mut self` connect/accept/event-loop paths.

## Breaking change

`RouterStats::{quic,constrained,fallback}_selections` are now `AtomicU64` instead of `u64`. External readers must use `.load(Ordering::Relaxed)`. In-tree tests updated accordingly.

## Test plan

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo nextest run` (full suite, including updated `connection_router` unit tests and `tests/constrained_integration.rs`)
- [ ] Spot-check contention under load on the 1000-node testnet to confirm the send-path lock is no longer hot

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses a lock-contention bottleneck in `P2pEndpoint::send()`. Previously every outbound send acquired an **exclusive write lock** on the `ConnectionRouter` solely to call `select_engine_for_addr`, which only bumped a stats counter. On a 1000-node testnet this serialised all sends through a single lock.

The fix converts `RouterStats::{quic,constrained,fallback}_selections` from `u64` to `AtomicU64`, allowing `select_engine_for_addr` and related methods to take `&self`. The `send()` path can then hold only a **shared read lock**, letting concurrent sends proceed in parallel. A manual `Clone` impl is added for `RouterStats` since `AtomicU64` does not derive `Clone`.

**Key changes:**
- `RouterStats` selection counters → `AtomicU64`; hand-written `Clone` impl added
- `P2pEndpoint::send()` downgraded from `router.write()` to `router.read()`
- Tests updated to use `.load(Ordering::Relaxed)` on the now-atomic counters

**Issues found:**
- The fallback stat correction in `select_engine_with_fallback` uses a non-atomic load+store to decrement an `AtomicU64` counter, introducing a TOCTOU race under concurrent access — the exact scenario this PR is designed to handle. The inline comment even claims a \"CAS loop\" but no compare-and-swap is present.
- `connect_via_transport` in `p2p_endpoint.rs` still acquires a write lock for a read-only call to `select_engine_for_addr`, leaving a related contention point unaddressed."

<h3>Confidence Score: 3/5</h3>

Safe to merge for the primary send() hot-path fix, but the non-atomic decrement in select_engine_with_fallback introduces a correctness issue that contradicts the PR's own goals.

The core optimization (send path read lock) is correct and well-motivated. However, the fallback counter correction uses a non-atomic load+store pattern that creates a race under concurrent access — precisely the scenario the PR is designed to handle. The missed write lock in connect_via_transport is a minor omission.

src/connection_router.rs lines 1090–1103 (non-atomic decrement in select_engine_with_fallback)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/connection_router.rs | Converts three stats fields to AtomicU64 and adds a hand-written Clone; the fallback stat correction in select_engine_with_fallback uses a non-atomic load+store instead of a real CAS loop, introducing a race under concurrent access. |
| src/p2p_endpoint.rs | send() correctly downgraded to router.read().await; connect_via_transport still holds a write lock for a read-only select_engine_for_addr call. |
| tests/constrained_integration.rs | Test assertions correctly updated to use .load(Ordering::Relaxed) on the now-atomic selection counters; no issues found. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant P2pEndpoint
    participant RwLock
    participant ConnectionRouter
    participant AtomicU64

    Note over Caller,AtomicU64: BEFORE (write lock serialised every send)
    Caller->>P2pEndpoint: send(addr, data)
    P2pEndpoint->>RwLock: write().await  (exclusive)
    RwLock->>ConnectionRouter: select_engine_for_addr(&mut self)
    ConnectionRouter->>AtomicU64: was plain u64 += 1
    RwLock-->>P2pEndpoint: release write lock
    P2pEndpoint-->>Caller: Ok(())

    Note over Caller,AtomicU64: AFTER (read lock — concurrent sends allowed)
    Caller->>P2pEndpoint: send(addr, data)
    P2pEndpoint->>RwLock: read().await  (shared)
    RwLock->>ConnectionRouter: select_engine_for_addr(&self)
    ConnectionRouter->>AtomicU64: fetch_add(1, Relaxed)
    RwLock-->>P2pEndpoint: release read lock
    P2pEndpoint-->>Caller: Ok(())
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/p2p_endpoint.rs`, line 1018-1019 ([link](https://github.com/saorsa-labs/saorsa-transport/blob/3c847aae5215e98d462fe2bbb163be6083930baa/src/p2p_endpoint.rs#L1018-L1019)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Missed read-lock optimisation in `connect_via_transport`**

   `connect_via_transport` still acquires an exclusive write lock on the router even though its only use of the router is to call `select_engine_for_addr`, which was updated in this PR to take `&self` and use atomics. This is the same contention pattern the PR fixes in `send()`. Downgrading to `read()` here would be consistent with the PR's stated goal.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/p2p_endpoint.rs
   Line: 1018-1019

   Comment:
   **Missed read-lock optimisation in `connect_via_transport`**

   `connect_via_transport` still acquires an exclusive write lock on the router even though its only use of the router is to call `select_engine_for_addr`, which was updated in this PR to take `&self` and use atomics. This is the same contention pattern the PR fixes in `send()`. Downgrading to `read()` here would be consistent with the PR's stated goal.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/connection_router.rs
Line: 1090-1094

Comment:
**Non-atomic read-modify-write despite `AtomicU64`**

The comment says "saturating_sub via CAS loop on relaxed load/store" but the code performs a plain `load` followed by a plain `store` — there is no CAS loop. Under concurrent access (the entire motivation for switching to `AtomicU64`), two callers can race: both read the same `cur`, both compute `cur.saturating_sub(1)`, and both store the same result, silently losing one decrement.

Use `fetch_update` for a true saturating atomic decrement:

```suggestion
                    // Atomically decrement, saturating at zero.
                    let _ = self
                        .stats
                        .constrained_selections
                        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
                            Some(v.saturating_sub(1))
                        });
```

The same non-atomic load+store pattern is repeated at lines 1100–1103 for `quic_selections` and should be fixed identically.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/p2p_endpoint.rs
Line: 1018-1019

Comment:
**Missed read-lock optimisation in `connect_via_transport`**

`connect_via_transport` still acquires an exclusive write lock on the router even though its only use of the router is to call `select_engine_for_addr`, which was updated in this PR to take `&self` and use atomics. This is the same contention pattern the PR fixes in `send()`. Downgrading to `read()` here would be consistent with the PR's stated goal.

```suggestion
        let router = self.router.read().await;
        let engine = router.select_engine_for_addr(addr);
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["perf!: hold read lock on router during s..."](https://github.com/saorsa-labs/saorsa-transport/commit/3c847aae5215e98d462fe2bbb163be6083930baa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27480462)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->