### PR TITLE
feat(nat): rotate hole-punch coordinators with capped per-attempt timeout

### DIFF
--- a/src/config/transport.rs
+++ b/src/config/transport.rs
@@ -66,18 +66,17 @@ pub struct TransportConfig {
     /// Allow loopback addresses as valid NAT traversal candidates
     pub(crate) allow_loopback: bool,
 
-    /// Maximum number of concurrent hole-punch relay slots this node will
-    /// service when acting as a coordinator (Tier 4 lite back-pressure).
-    /// When the active count reaches this cap, incoming `PUNCH_ME_NOW`
-    /// frames that would otherwise be relayed are silently refused so the
-    /// initiator advances to its next preferred coordinator.
-    pub(crate) coordinator_max_active_relays: usize,
-
-    /// Reclamation timeout for stale coordinator relay slots. Acts as a
-    /// safety net so a relay slot cannot leak forever if a peer crashes
-    /// mid-coordination, a NAT rebind silently drops the session, or a
-    /// follow-up signal is lost.
-    pub(crate) coordinator_relay_slot_timeout: Duration,
+    /// Shared, node-wide hole-punch coordinator back-pressure table
+    /// (Tier 4 lite). When this is `Some`, every connection that lands
+    /// at this node and acts as a coordinator gates incoming
+    /// `PUNCH_ME_NOW` relay frames against the shared table — the cap
+    /// is enforced *across* connections, not per-connection. When `None`
+    /// (low-level test fixtures, internal Quinn-style use), back-pressure
+    /// is disabled and the coordinator behaves as in pre-Tier-4 builds.
+    ///
+    /// Owned and instantiated by `P2pEndpoint::new`; injected into
+    /// `TransportConfig` before the config is frozen behind `Arc`.
+    pub(crate) relay_slot_table: Option<Arc<crate::relay_slot_table::RelaySlotTable>>,
 }
 
 impl TransportConfig {
@@ -484,18 +483,16 @@ impl TransportConfig {
         self
     }
 
-    /// Cap on simultaneous hole-punch relay slots when this node acts as a
-    /// coordinator. Higher = more concurrency capacity, lower = stricter
-    /// back-pressure shedding under storm load. Default: 32.
-    pub fn coordinator_max_active_relays(&mut self, max: usize) -> &mut Self {
-        self.coordinator_max_active_relays = max;
-        self
-    }
-
-    /// Maximum lifetime of a coordinator relay slot before it is reclaimed
-    /// by the inline garbage-collection sweep. Default: 5 seconds.
-    pub fn coordinator_relay_slot_timeout(&mut self, timeout: Duration) -> &mut Self {
-        self.coordinator_relay_slot_timeout = timeout;
+    /// Inject the node-wide hole-punch coordinator back-pressure table
+    /// (Tier 4 lite). Called from `P2pEndpoint::new` so that every QUIC
+    /// connection spawned from this transport config shares one table.
+    /// `None` disables back-pressure (used by Quinn-style low-level
+    /// fixtures that do not run a coordinator).
+    pub fn relay_slot_table(
+        &mut self,
+        table: Option<Arc<crate::relay_slot_table::RelaySlotTable>>,
+    ) -> &mut Self {
+        self.relay_slot_table = table;
         self
     }
 }
@@ -551,11 +548,12 @@ impl Default for TransportConfig {
                 ml_dsa_65: false,
             }),
             allow_loopback: false,
-            // Tier 4 (lite) coordinator back-pressure defaults. See
-            // `coordinator_max_active_relays`/`coordinator_relay_slot_timeout`
-            // setters for the rationale behind these numbers.
-            coordinator_max_active_relays: 32,
-            coordinator_relay_slot_timeout: Duration::from_secs(5),
+            // No back-pressure table by default — `P2pEndpoint::new`
+            // injects one before connections are spawned. Quinn-style
+            // fixtures that bypass `P2pEndpoint` opt out of coordinator
+            // back-pressure entirely, which matches the pre-Tier-4
+            // behaviour they were originally written against.
+            relay_slot_table: None,
         }
     }
 }
@@ -592,8 +590,7 @@ impl fmt::Debug for TransportConfig {
             address_discovery_config,
             pqc_algorithms,
             allow_loopback,
-            coordinator_max_active_relays,
-            coordinator_relay_slot_timeout,
+            relay_slot_table,
         } = self;
         fmt.debug_struct("TransportConfig")
             .field("max_concurrent_bidi_streams", max_concurrent_bidi_streams)
@@ -626,14 +623,7 @@ impl fmt::Debug for TransportConfig {
             .field("address_discovery_config", address_discovery_config)
             .field("pqc_algorithms", pqc_algorithms)
             .field("allow_loopback", allow_loopback)
-            .field(
-                "coordinator_max_active_relays",
-                coordinator_max_active_relays,
-            )
-            .field(
-                "coordinator_relay_slot_timeout",
-                coordinator_relay_slot_timeout,
-            )
+            .field("relay_slot_table", relay_slot_table)
             .finish_non_exhaustive()
     }
 }

--- a/src/config/transport.rs
+++ b/src/config/transport.rs
@@ -65,6 +65,19 @@ pub struct TransportConfig {
 
     /// Allow loopback addresses as valid NAT traversal candidates
     pub(crate) allow_loopback: bool,
+
+    /// Maximum number of concurrent hole-punch relay slots this node will
+    /// service when acting as a coordinator (Tier 4 lite back-pressure).
+    /// When the active count reaches this cap, incoming `PUNCH_ME_NOW`
+    /// frames that would otherwise be relayed are silently refused so the
+    /// initiator advances to its next preferred coordinator.
+    pub(crate) coordinator_max_active_relays: usize,
+
+    /// Reclamation timeout for stale coordinator relay slots. Acts as a
+    /// safety net so a relay slot cannot leak forever if a peer crashes
+    /// mid-coordination, a NAT rebind silently drops the session, or a
+    /// follow-up signal is lost.
+    pub(crate) coordinator_relay_slot_timeout: Duration,
 }
 
 impl TransportConfig {
@@ -470,6 +483,21 @@ impl TransportConfig {
         self.allow_loopback = allow;
         self
     }
+
+    /// Cap on simultaneous hole-punch relay slots when this node acts as a
+    /// coordinator. Higher = more concurrency capacity, lower = stricter
+    /// back-pressure shedding under storm load. Default: 32.
+    pub fn coordinator_max_active_relays(&mut self, max: usize) -> &mut Self {
+        self.coordinator_max_active_relays = max;
+        self
+    }
+
+    /// Maximum lifetime of a coordinator relay slot before it is reclaimed
+    /// by the inline garbage-collection sweep. Default: 5 seconds.
+    pub fn coordinator_relay_slot_timeout(&mut self, timeout: Duration) -> &mut Self {
+        self.coordinator_relay_slot_timeout = timeout;
+        self
+    }
 }
 
 impl Default for TransportConfig {
@@ -523,6 +551,11 @@ impl Default for TransportConfig {
                 ml_dsa_65: false,
             }),
             allow_loopback: false,
+            // Tier 4 (lite) coordinator back-pressure defaults. See
+            // `coordinator_max_active_relays`/`coordinator_relay_slot_timeout`
+            // setters for the rationale behind these numbers.
+            coordinator_max_active_relays: 32,
+            coordinator_relay_slot_timeout: Duration::from_secs(5),
         }
     }
 }
@@ -559,6 +592,8 @@ impl fmt::Debug for TransportConfig {
             address_discovery_config,
             pqc_algorithms,
             allow_loopback,
+            coordinator_max_active_relays,
+            coordinator_relay_slot_timeout,
         } = self;
         fmt.debug_struct("TransportConfig")
             .field("max_concurrent_bidi_streams", max_concurrent_bidi_streams)
@@ -591,6 +626,14 @@ impl fmt::Debug for TransportConfig {
             .field("address_discovery_config", address_discovery_config)
             .field("pqc_algorithms", pqc_algorithms)
             .field("allow_loopback", allow_loopback)
+            .field(
+                "coordinator_max_active_relays",
+                coordinator_max_active_relays,
+            )
+            .field(
+                "coordinator_relay_slot_timeout",
+                coordinator_relay_slot_timeout,
+            )
             .finish_non_exhaustive()
     }
 }

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -4535,8 +4535,7 @@ impl Connection {
             max_candidates,
             coordination_timeout,
             self.config.allow_loopback,
-            self.config.coordinator_max_active_relays,
-            self.config.coordinator_relay_slot_timeout,
+            self.config.relay_slot_table.clone(),
         ));
 
         trace!("NAT traversal initialized for symmetric P2P node");
@@ -4735,8 +4734,7 @@ impl Connection {
             8,
             Duration::from_secs(10),
             self.config.allow_loopback,
-            self.config.coordinator_max_active_relays,
-            self.config.coordinator_relay_slot_timeout,
+            self.config.relay_slot_table.clone(),
         ));
     }
 
@@ -4870,7 +4868,13 @@ impl Connection {
                         return Ok(());
                     }
                     Ok(None) => {
-                        trace!("Coordination completed or no action needed");
+                        // Reaching this branch with `target_peer_id.is_some()`
+                        // (the only branch that calls this) means the
+                        // shared back-pressure table refused the relay.
+                        // The table itself logs and counts the refusal —
+                        // we drop silently so the initiator falls back
+                        // to the per-attempt timeout (Tier 2 rotation).
+                        trace!("PUNCH_ME_NOW relay refused by node-wide back-pressure");
                         return Ok(());
                     }
                     Err(e) => {

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -4535,6 +4535,8 @@ impl Connection {
             max_candidates,
             coordination_timeout,
             self.config.allow_loopback,
+            self.config.coordinator_max_active_relays,
+            self.config.coordinator_relay_slot_timeout,
         ));
 
         trace!("NAT traversal initialized for symmetric P2P node");
@@ -4733,6 +4735,8 @@ impl Connection {
             8,
             Duration::from_secs(10),
             self.config.allow_loopback,
+            self.config.coordinator_max_active_relays,
+            self.config.coordinator_relay_slot_timeout,
         ));
     }
 

--- a/src/connection/nat_traversal.rs
+++ b/src/connection/nat_traversal.rs
@@ -8,6 +8,7 @@
 use std::{
     collections::{HashMap, VecDeque},
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    sync::Arc,
     time::Duration,
 };
 
@@ -1821,24 +1822,23 @@ impl NatTraversalState {
     /// v0.13.0: Role parameter removed - all nodes are symmetric P2P nodes.
     /// Every node can initiate, accept, and coordinate NAT traversal.
     ///
-    /// `coordinator_max_active_relays` and `coordinator_relay_slot_timeout`
-    /// configure Tier 4 (lite) coordinator-side back-pressure: when this
-    /// node acts as a hole-punch coordinator, it will silently refuse new
-    /// `PUNCH_ME_NOW` relays once `coordinator_max_active_relays` slots are
-    /// in flight, and reclaim stale slots that exceed the timeout.
+    /// `relay_slot_table` is the shared, node-wide back-pressure table
+    /// (Tier 4 lite). When `Some`, the bootstrap coordinator embedded in
+    /// this state gates incoming `PUNCH_ME_NOW` relay frames against the
+    /// shared table — the cap is enforced across *all* connections at
+    /// this node, not per-connection. Pass `None` in low-level fixtures
+    /// that do not run a coordinator.
     pub(super) fn new(
         max_candidates: u32,
         coordination_timeout: Duration,
         allow_loopback: bool,
-        coordinator_max_active_relays: usize,
-        coordinator_relay_slot_timeout: Duration,
+        relay_slot_table: Option<Arc<crate::relay_slot_table::RelaySlotTable>>,
     ) -> Self {
         // v0.13.0: All nodes can coordinate - always create coordinator
         let bootstrap_coordinator = Some(BootstrapCoordinator::new(
             BootstrapConfig::default(),
             allow_loopback,
-            coordinator_max_active_relays,
-            coordinator_relay_slot_timeout,
+            relay_slot_table,
         ));
 
         Self {
@@ -3566,22 +3566,33 @@ pub(crate) struct BootstrapCoordinator {
     security_validator: SecurityValidationState,
     /// Statistics for bootstrap operations
     stats: BootstrapStats,
-    /// Active hole-punch relay slots indexed by `(initiator_peer_id,
-    /// target_peer_id)`. Each entry records the wall-clock arrival time of
-    /// the `PUNCH_ME_NOW` frame that opened the slot. Slots are reclaimed
-    /// either implicitly (when a follow-up frame from the same pair lands)
-    /// or by the inline garbage-collection sweep run on every incoming
-    /// frame: any slot older than `coordinator_relay_slot_timeout` is
-    /// evicted before the back-pressure check, which keeps the active
-    /// count from leaking on ghost sessions where the initiator crashed
-    /// or the target became unreachable mid-coordination.
-    relay_slots: HashMap<(PeerId, PeerId), Instant>,
-    /// Cap on simultaneous relay slots (Tier 4 lite back-pressure).
-    /// Plumbed from [`crate::config::TransportConfig::coordinator_max_active_relays`].
-    relay_slot_capacity: usize,
-    /// Reclamation timeout for stale relay slots. Plumbed from
-    /// [`crate::config::TransportConfig::coordinator_relay_slot_timeout`].
-    relay_slot_timeout: Duration,
+    /// Shared, node-wide back-pressure table (Tier 4 lite). When `Some`,
+    /// every incoming `PUNCH_ME_NOW` relay frame must acquire a slot in
+    /// this table before being relayed; the cap is enforced *across all*
+    /// connections at this node, not per-connection.
+    ///
+    /// On `Drop` (i.e. when the connection that hosts this coordinator
+    /// closes) all slots whose initiator address matches the connection's
+    /// remote address are released — the explicit-completion path that
+    /// reclaims capacity ahead of the idle-timeout safety net.
+    relay_slot_table: Option<Arc<crate::relay_slot_table::RelaySlotTable>>,
+    /// Remote address of the connection that owns this coordinator.
+    /// Captured the first time we relay a frame; used as the slot key's
+    /// initiator-side identifier and as the argument to
+    /// `release_for_initiator` in [`Drop`]. `None` until the first
+    /// `PUNCH_ME_NOW` arrives.
+    relay_initiator_addr: Option<SocketAddr>,
+}
+
+impl Drop for BootstrapCoordinator {
+    fn drop(&mut self) {
+        // Explicitly release every slot we opened so the shared table
+        // doesn't have to wait out the idle timeout for a connection
+        // that has just closed.
+        if let (Some(table), Some(addr)) = (&self.relay_slot_table, self.relay_initiator_addr) {
+            table.release_for_initiator(addr);
+        }
+    }
 }
 // Removed legacy CoordinationSessionId type
 /// Peer identifier for bootstrap coordination
@@ -3667,25 +3678,21 @@ pub(crate) struct BootstrapStats {
     successful_coordinations: u64,
     /// Security rejections
     security_rejections: u64,
-    /// Refusals due to active-relay back-pressure (Tier 4 lite). Tracks the
-    /// number of `PUNCH_ME_NOW` frames silently dropped because the
-    /// coordinator was at `relay_slot_capacity` when they arrived.
-    backpressure_refusals: u64,
 }
 // Removed session state machine enums and recovery actions
 impl BootstrapCoordinator {
     /// Create a new bootstrap coordinator.
     ///
-    /// `relay_slot_capacity` and `relay_slot_timeout` configure the
-    /// Tier 4 (lite) back-pressure: incoming `PUNCH_ME_NOW` relay frames
-    /// are silently refused once `relay_slot_capacity` slots are in
-    /// flight, and any slot older than `relay_slot_timeout` is reclaimed
-    /// by the inline garbage-collection sweep on every incoming frame.
+    /// `relay_slot_table` is the shared, node-wide back-pressure table
+    /// (Tier 4 lite). When `Some`, incoming `PUNCH_ME_NOW` relay frames
+    /// must acquire a slot from the table before being relayed; the cap
+    /// is enforced across all connections at this node. Pass `None` in
+    /// low-level test fixtures that exercise the connection state machine
+    /// without a P2pEndpoint.
     pub(crate) fn new(
         _config: BootstrapConfig,
         allow_loopback: bool,
-        relay_slot_capacity: usize,
-        relay_slot_timeout: Duration,
+        relay_slot_table: Option<Arc<crate::relay_slot_table::RelaySlotTable>>,
     ) -> Self {
         Self {
             address_observations: HashMap::new(),
@@ -3693,21 +3700,11 @@ impl BootstrapCoordinator {
             coordination_table: HashMap::new(),
             security_validator: SecurityValidationState::new(allow_loopback),
             stats: BootstrapStats::default(),
-            relay_slots: HashMap::new(),
-            relay_slot_capacity,
-            relay_slot_timeout,
+            relay_slot_table,
+            relay_initiator_addr: None,
         }
     }
 
-    /// Reclaim relay slots whose arrival timestamp is older than the
-    /// configured `relay_slot_timeout`. Called inline at the start of
-    /// every `PUNCH_ME_NOW` frame so that ghost slots from crashed peers
-    /// or dropped sessions cannot leak the active-relay counter.
-    fn sweep_stale_relay_slots(&mut self, now: Instant) {
-        let timeout = self.relay_slot_timeout;
-        self.relay_slots
-            .retain(|_, &mut arrived_at| now.duration_since(arrived_at) < timeout);
-    }
     /// Observe a peer's address from an incoming connection
     ///
     /// This is called when a peer connects to this bootstrap node,
@@ -3844,34 +3841,34 @@ impl BootstrapCoordinator {
             })?;
 
         // Tier 4 (lite) back-pressure: only the relay branch (where the
-        // frame carries an explicit `target_peer_id`) consumes a slot. If
-        // we are at capacity for active relays, silently drop the frame —
-        // the initiator's per-attempt timeout (Tier 2 rotation) will move
-        // it on to its next preferred coordinator.
+        // frame carries an explicit `target_peer_id`) consumes a slot.
+        // The shared `RelaySlotTable` enforces the cap *across all
+        // connections* at this node — when full, the relay is silently
+        // refused and the initiator's per-attempt timeout (Tier 2
+        // rotation) drives it to its next preferred coordinator.
         //
-        // Inline garbage-collection sweep first so any stale slots from
-        // crashed peers are reclaimed before the cap check.
+        // Slots are keyed by `(initiator_addr, target_peer_id)`. The
+        // initiator address is the connection's remote socket address
+        // (constant for the lifetime of this BootstrapCoordinator), so
+        // multi-round coordination from the same peer naturally re-arms
+        // the same slot without consuming additional capacity.
         if let Some(target_peer_id) = frame.target_peer_id {
-            self.sweep_stale_relay_slots(now);
-            let slot_key = (from_peer, target_peer_id);
-            // Re-arming an existing slot for the same (initiator, target)
-            // pair does not consume an additional slot — common during
-            // multi-round coordination where the same pair re-sends.
-            let already_active = self.relay_slots.contains_key(&slot_key);
-            if !already_active && self.relay_slots.len() >= self.relay_slot_capacity {
-                self.stats.backpressure_refusals =
-                    self.stats.backpressure_refusals.saturating_add(1);
-                debug!(
-                    "PUNCH_ME_NOW relay refused: coordinator at capacity ({}/{}) — initiator {:?} → target {:?}",
-                    self.relay_slots.len(),
-                    self.relay_slot_capacity,
-                    hex::encode(&from_peer[..8]),
-                    hex::encode(&target_peer_id[..8])
-                );
+            // Cache the initiator addr the first time we see it so
+            // `Drop` can release every slot we opened, even if the
+            // connection closes mid-session.
+            if self.relay_initiator_addr.is_none() {
+                self.relay_initiator_addr = Some(source_addr);
+            }
+            if let Some(table) = &self.relay_slot_table
+                && !table.try_acquire(source_addr, target_peer_id, now)
+            {
+                // Refused. The table itself logs/counts the event;
+                // returning `Ok(None)` means "no coordination frame
+                // produced" and is dispatched at the call site as a
+                // silent drop, surfacing to the initiator only as a
+                // per-attempt timeout.
                 return Ok(None);
             }
-            // Accept: insert/refresh the slot timestamp.
-            self.relay_slots.insert(slot_key, now);
         }
 
         // Track coordination entry minimally
@@ -3986,14 +3983,23 @@ impl BootstrapCoordinator {
 mod tests {
     use super::*;
 
+    /// Build a test fixture `RelaySlotTable` so the BootstrapCoordinator
+    /// embedded in `NatTraversalState` can exercise the back-pressure
+    /// path. Production code obtains the table from `P2pEndpoint`.
+    fn make_test_relay_slot_table() -> Arc<crate::relay_slot_table::RelaySlotTable> {
+        Arc::new(crate::relay_slot_table::RelaySlotTable::new(
+            32,
+            Duration::from_secs(5),
+        ))
+    }
+
     // v0.13.0: Role parameter removed - all nodes are symmetric P2P nodes
     fn create_test_state() -> NatTraversalState {
         NatTraversalState::new(
             10,                      // max_candidates
             Duration::from_secs(30), // coordination_timeout
             true,                    // allow_loopback for tests
-            32,                      // coordinator_max_active_relays
-            Duration::from_secs(5),  // coordinator_relay_slot_timeout
+            Some(make_test_relay_slot_table()),
         )
     }
 
@@ -4376,8 +4382,7 @@ mod tests {
             100, // max_candidates (high enough to not limit)
             Duration::from_secs(30),
             true, // allow_loopback for tests
-            32,
-            Duration::from_secs(5),
+            Some(make_test_relay_slot_table()),
         );
         let now = Instant::now();
 
@@ -4412,8 +4417,7 @@ mod tests {
             100,
             Duration::from_secs(30),
             true,
-            32,
-            Duration::from_secs(5),
+            Some(make_test_relay_slot_table()),
         );
         let now = Instant::now();
 
@@ -4498,8 +4502,7 @@ mod tests {
             100,
             Duration::from_secs(30),
             true,
-            32,
-            Duration::from_secs(5),
+            Some(make_test_relay_slot_table()),
         );
         let now = Instant::now();
 
@@ -4534,22 +4537,40 @@ mod tests {
     }
 
     // ---- Tier 4 (lite): coordinator-side back-pressure ----
+    //
+    // The pure data-structure tests live next to the table itself in
+    // `crate::relay_slot_table::tests`. The tests below verify the
+    // *integration* between `BootstrapCoordinator` and the shared
+    // `RelaySlotTable`: that the relay branch consumes a slot, the
+    // non-relay (echo) branch does not, and that the coordinator
+    // releases its slots in `Drop` so a closed connection reclaims
+    // capacity ahead of the idle-timeout safety net.
 
-    /// Helper: build a `BootstrapCoordinator` with controllable cap and
-    /// timeout for back-pressure tests.
-    fn make_bp_coordinator(capacity: usize, timeout: Duration) -> BootstrapCoordinator {
-        BootstrapCoordinator::new(
+    /// Build a `BootstrapCoordinator` wired to a fresh shared
+    /// `RelaySlotTable` with the given capacity. Returns both so tests
+    /// can inspect the table directly.
+    fn make_coord_with_table(
+        capacity: usize,
+        timeout: Duration,
+    ) -> (
+        BootstrapCoordinator,
+        Arc<crate::relay_slot_table::RelaySlotTable>,
+    ) {
+        let table = Arc::new(crate::relay_slot_table::RelaySlotTable::new(
+            capacity, timeout,
+        ));
+        let coord = BootstrapCoordinator::new(
             BootstrapConfig::default(),
-            true, // allow_loopback so test addrs aren't rejected
-            capacity,
-            timeout,
-        )
+            true, // allow_loopback for test addrs
+            Some(Arc::clone(&table)),
+        );
+        (coord, table)
     }
 
-    /// Helper: build a `PunchMeNow` frame for the relay path (with target).
-    fn make_relay_frame(round: u64, target_peer_id: [u8; 32]) -> crate::frame::PunchMeNow {
+    /// `PunchMeNow` frame for the relay path (with target).
+    fn relay_frame(round: u32, target_peer_id: [u8; 32]) -> crate::frame::PunchMeNow {
         crate::frame::PunchMeNow {
-            round: VarInt::from_u64(round).unwrap_or(VarInt::from_u32(0)),
+            round: VarInt::from_u32(round),
             paired_with_sequence_number: VarInt::from_u32(0),
             address: SocketAddr::from(([127, 0, 0, 1], 9000)),
             target_peer_id: Some(target_peer_id),
@@ -4563,151 +4584,52 @@ mod tests {
     }
 
     #[test]
-    fn coordinator_accepts_relay_under_capacity() {
-        let mut coord = make_bp_coordinator(4, Duration::from_secs(5));
+    fn coordinator_relay_consumes_shared_slot() {
+        let (mut coord, table) = make_coord_with_table(4, Duration::from_secs(5));
         let now = Instant::now();
         let from = peer_id_with_byte(0x01);
         let target = peer_id_with_byte(0x02);
-        let frame = make_relay_frame(1, target);
         let source_addr = SocketAddr::from(([127, 0, 0, 1], 5000));
 
         let result = coord
-            .process_punch_me_now_frame(from, source_addr, &frame, now)
+            .process_punch_me_now_frame(from, source_addr, &relay_frame(1, target), now)
             .expect("relay under cap should not error");
 
         assert!(
             result.is_some(),
             "relay under capacity should produce a coordination frame"
         );
-        assert_eq!(coord.relay_slots.len(), 1, "one slot should be allocated");
-        assert_eq!(
-            coord.stats.backpressure_refusals, 0,
-            "no refusal stat increment expected when under cap"
-        );
+        assert_eq!(table.active_count(), 1);
+        assert_eq!(table.backpressure_refusals(), 0);
     }
 
     #[test]
-    fn coordinator_refuses_silently_at_capacity() {
-        let capacity = 2;
-        let mut coord = make_bp_coordinator(capacity, Duration::from_secs(5));
+    fn coordinator_refuses_silently_when_table_at_capacity() {
+        // Pre-fill the shared table from outside the coordinator. The
+        // coordinator's relay attempt then sees the cap and silently
+        // refuses, returning Ok(None).
+        let (mut coord, table) = make_coord_with_table(1, Duration::from_secs(5));
         let now = Instant::now();
+        let other_initiator = SocketAddr::from(([127, 0, 0, 1], 9999));
+        assert!(table.try_acquire(other_initiator, peer_id_with_byte(0xAB), now));
+        assert_eq!(table.active_count(), 1);
+
+        let from = peer_id_with_byte(0x01);
+        let target = peer_id_with_byte(0x02);
         let source_addr = SocketAddr::from(([127, 0, 0, 1], 5000));
-
-        // Fill capacity with two distinct (initiator, target) pairs.
-        for i in 0..capacity {
-            let from = peer_id_with_byte(0x10 + i as u8);
-            let target = peer_id_with_byte(0x20 + i as u8);
-            let frame = make_relay_frame(i as u64 + 1, target);
-            let result = coord
-                .process_punch_me_now_frame(from, source_addr, &frame, now)
-                .expect("under-cap relay should not error");
-            assert!(result.is_some(), "slot {} should be accepted", i);
-        }
-        assert_eq!(coord.relay_slots.len(), capacity);
-
-        // The next distinct pair must be silently refused: Ok(None).
-        let overflow_from = peer_id_with_byte(0xFE);
-        let overflow_target = peer_id_with_byte(0xFD);
-        let overflow_frame = make_relay_frame(99, overflow_target);
         let result = coord
-            .process_punch_me_now_frame(overflow_from, source_addr, &overflow_frame, now)
-            .expect("at-cap refusal must be silent (no error)");
+            .process_punch_me_now_frame(from, source_addr, &relay_frame(1, target), now)
+            .expect("refusal must be silent (Ok)");
 
         assert!(
             result.is_none(),
             "at-cap refusal must produce no coordination frame"
         );
+        assert_eq!(table.active_count(), 1, "refused frame must not insert");
         assert_eq!(
-            coord.relay_slots.len(),
-            capacity,
-            "refused frame must not consume a slot"
-        );
-        assert_eq!(
-            coord.stats.backpressure_refusals, 1,
-            "back-pressure stat must increment on refusal"
-        );
-    }
-
-    #[test]
-    fn coordinator_re_arms_existing_slot_without_consuming_capacity() {
-        let mut coord = make_bp_coordinator(2, Duration::from_secs(5));
-        let now = Instant::now();
-        let source_addr = SocketAddr::from(([127, 0, 0, 1], 5000));
-        let from = peer_id_with_byte(0x01);
-        let target = peer_id_with_byte(0x02);
-        let frame = make_relay_frame(1, target);
-
-        // Fill the first slot.
-        coord
-            .process_punch_me_now_frame(from, source_addr, &frame, now)
-            .expect("first frame ok");
-        assert_eq!(coord.relay_slots.len(), 1);
-
-        // Re-send for the same (from, target) pair: must not consume an
-        // additional slot, must still be accepted.
-        let later = now + Duration::from_millis(500);
-        let result = coord
-            .process_punch_me_now_frame(from, source_addr, &frame, later)
-            .expect("re-arm ok");
-        assert!(result.is_some(), "re-armed slot should still be relayed");
-        assert_eq!(
-            coord.relay_slots.len(),
+            table.backpressure_refusals(),
             1,
-            "re-arming the same pair must not allocate a second slot"
-        );
-        // Slot timestamp should refresh to the later instant.
-        let slot_arrived = coord
-            .relay_slots
-            .get(&(from, target))
-            .copied()
-            .expect("slot present");
-        assert_eq!(
-            slot_arrived, later,
-            "re-arm must refresh the slot timestamp"
-        );
-    }
-
-    #[test]
-    fn coordinator_sweep_reclaims_stale_slots() {
-        let timeout = Duration::from_secs(5);
-        let mut coord = make_bp_coordinator(2, timeout);
-        let now = Instant::now();
-        let source_addr = SocketAddr::from(([127, 0, 0, 1], 5000));
-
-        // Fill capacity.
-        for i in 0..2u8 {
-            let from = peer_id_with_byte(0x10 + i);
-            let target = peer_id_with_byte(0x20 + i);
-            let frame = make_relay_frame(i as u64 + 1, target);
-            coord
-                .process_punch_me_now_frame(from, source_addr, &frame, now)
-                .expect("under-cap ok");
-        }
-        assert_eq!(coord.relay_slots.len(), 2);
-
-        // Advance well past the slot timeout. The next incoming frame's
-        // inline sweep must reclaim both stale slots before applying the
-        // back-pressure check.
-        let much_later = now + timeout + Duration::from_secs(1);
-        let new_from = peer_id_with_byte(0xAA);
-        let new_target = peer_id_with_byte(0xBB);
-        let new_frame = make_relay_frame(42, new_target);
-        let result = coord
-            .process_punch_me_now_frame(new_from, source_addr, &new_frame, much_later)
-            .expect("post-sweep frame should succeed");
-
-        assert!(
-            result.is_some(),
-            "frame after sweep must be accepted (capacity reclaimed)"
-        );
-        assert_eq!(
-            coord.relay_slots.len(),
-            1,
-            "stale slots must be reclaimed; only the new one remains"
-        );
-        assert_eq!(
-            coord.stats.backpressure_refusals, 0,
-            "no refusal expected because sweep freed capacity in time"
+            "table refusal stat must increment"
         );
     }
 
@@ -4715,7 +4637,7 @@ mod tests {
     fn coordinator_non_relay_frame_does_not_consume_slot() {
         // PUNCH_ME_NOW without a target_peer_id is the response/echo path,
         // not a relay request — it must NOT consume a back-pressure slot.
-        let mut coord = make_bp_coordinator(1, Duration::from_secs(5));
+        let (mut coord, table) = make_coord_with_table(1, Duration::from_secs(5));
         let now = Instant::now();
         let source_addr = SocketAddr::from(([127, 0, 0, 1], 5000));
         let from = peer_id_with_byte(0x01);
@@ -4730,9 +4652,47 @@ mod tests {
             .process_punch_me_now_frame(from, source_addr, &frame, now)
             .expect("non-relay frame ok");
         assert_eq!(
-            coord.relay_slots.len(),
+            table.active_count(),
             0,
             "non-relay frame must not consume a slot"
+        );
+    }
+
+    #[test]
+    fn coordinator_drop_releases_owned_slots() {
+        // This is the "explicit completion" path that fixes H2 — when
+        // the connection that hosts a coordinator drops, every slot it
+        // opened must be reclaimed without waiting out the idle timeout.
+        let (mut coord, table) = make_coord_with_table(8, Duration::from_secs(5));
+        let now = Instant::now();
+        let from = peer_id_with_byte(0x01);
+        let source_addr = SocketAddr::from(([127, 0, 0, 1], 5000));
+
+        // Open three slots from this coordinator (three distinct targets).
+        for t in [0xAA, 0xBB, 0xCC] {
+            let _ = coord
+                .process_punch_me_now_frame(
+                    from,
+                    source_addr,
+                    &relay_frame(1, peer_id_with_byte(t)),
+                    now,
+                )
+                .expect("relay under cap ok");
+        }
+        // And one slot from a *different* initiator (a different
+        // BootstrapCoordinator instance would normally own this; we
+        // simulate by acquiring directly).
+        let other_initiator = SocketAddr::from(([10, 0, 0, 1], 7777));
+        assert!(table.try_acquire(other_initiator, peer_id_with_byte(0xDD), now));
+        assert_eq!(table.active_count(), 4);
+
+        // Drop the coordinator. Its three slots must be released; the
+        // other initiator's slot must remain.
+        drop(coord);
+        assert_eq!(
+            table.active_count(),
+            1,
+            "Drop must release every slot owned by this initiator address"
         );
     }
 }

--- a/src/connection/nat_traversal.rs
+++ b/src/connection/nat_traversal.rs
@@ -480,7 +480,7 @@ impl SecurityValidationState {
             max_candidates_per_window: 20, // Max 20 candidates per 60 seconds
             rate_window: Duration::from_secs(60),
             coordination_requests: VecDeque::new(),
-            max_coordination_per_window: 5, // Max 5 coordination requests per 60 seconds
+            max_coordination_per_window: 50, // Max 50 coordination requests per 60 seconds
             address_validation_cache: HashMap::new(),
             validation_cache_timeout: Duration::from_secs(300), // 5 minute cache
             allow_loopback,

--- a/src/connection/nat_traversal.rs
+++ b/src/connection/nat_traversal.rs
@@ -1820,15 +1820,25 @@ impl NatTraversalState {
     ///
     /// v0.13.0: Role parameter removed - all nodes are symmetric P2P nodes.
     /// Every node can initiate, accept, and coordinate NAT traversal.
+    ///
+    /// `coordinator_max_active_relays` and `coordinator_relay_slot_timeout`
+    /// configure Tier 4 (lite) coordinator-side back-pressure: when this
+    /// node acts as a hole-punch coordinator, it will silently refuse new
+    /// `PUNCH_ME_NOW` relays once `coordinator_max_active_relays` slots are
+    /// in flight, and reclaim stale slots that exceed the timeout.
     pub(super) fn new(
         max_candidates: u32,
         coordination_timeout: Duration,
         allow_loopback: bool,
+        coordinator_max_active_relays: usize,
+        coordinator_relay_slot_timeout: Duration,
     ) -> Self {
         // v0.13.0: All nodes can coordinate - always create coordinator
         let bootstrap_coordinator = Some(BootstrapCoordinator::new(
             BootstrapConfig::default(),
             allow_loopback,
+            coordinator_max_active_relays,
+            coordinator_relay_slot_timeout,
         ));
 
         Self {
@@ -3556,6 +3566,22 @@ pub(crate) struct BootstrapCoordinator {
     security_validator: SecurityValidationState,
     /// Statistics for bootstrap operations
     stats: BootstrapStats,
+    /// Active hole-punch relay slots indexed by `(initiator_peer_id,
+    /// target_peer_id)`. Each entry records the wall-clock arrival time of
+    /// the `PUNCH_ME_NOW` frame that opened the slot. Slots are reclaimed
+    /// either implicitly (when a follow-up frame from the same pair lands)
+    /// or by the inline garbage-collection sweep run on every incoming
+    /// frame: any slot older than `coordinator_relay_slot_timeout` is
+    /// evicted before the back-pressure check, which keeps the active
+    /// count from leaking on ghost sessions where the initiator crashed
+    /// or the target became unreachable mid-coordination.
+    relay_slots: HashMap<(PeerId, PeerId), Instant>,
+    /// Cap on simultaneous relay slots (Tier 4 lite back-pressure).
+    /// Plumbed from [`crate::config::TransportConfig::coordinator_max_active_relays`].
+    relay_slot_capacity: usize,
+    /// Reclamation timeout for stale relay slots. Plumbed from
+    /// [`crate::config::TransportConfig::coordinator_relay_slot_timeout`].
+    relay_slot_timeout: Duration,
 }
 // Removed legacy CoordinationSessionId type
 /// Peer identifier for bootstrap coordination
@@ -3641,18 +3667,46 @@ pub(crate) struct BootstrapStats {
     successful_coordinations: u64,
     /// Security rejections
     security_rejections: u64,
+    /// Refusals due to active-relay back-pressure (Tier 4 lite). Tracks the
+    /// number of `PUNCH_ME_NOW` frames silently dropped because the
+    /// coordinator was at `relay_slot_capacity` when they arrived.
+    backpressure_refusals: u64,
 }
 // Removed session state machine enums and recovery actions
 impl BootstrapCoordinator {
-    /// Create a new bootstrap coordinator
-    pub(crate) fn new(_config: BootstrapConfig, allow_loopback: bool) -> Self {
+    /// Create a new bootstrap coordinator.
+    ///
+    /// `relay_slot_capacity` and `relay_slot_timeout` configure the
+    /// Tier 4 (lite) back-pressure: incoming `PUNCH_ME_NOW` relay frames
+    /// are silently refused once `relay_slot_capacity` slots are in
+    /// flight, and any slot older than `relay_slot_timeout` is reclaimed
+    /// by the inline garbage-collection sweep on every incoming frame.
+    pub(crate) fn new(
+        _config: BootstrapConfig,
+        allow_loopback: bool,
+        relay_slot_capacity: usize,
+        relay_slot_timeout: Duration,
+    ) -> Self {
         Self {
             address_observations: HashMap::new(),
             peer_index: HashMap::new(),
             coordination_table: HashMap::new(),
             security_validator: SecurityValidationState::new(allow_loopback),
             stats: BootstrapStats::default(),
+            relay_slots: HashMap::new(),
+            relay_slot_capacity,
+            relay_slot_timeout,
         }
+    }
+
+    /// Reclaim relay slots whose arrival timestamp is older than the
+    /// configured `relay_slot_timeout`. Called inline at the start of
+    /// every `PUNCH_ME_NOW` frame so that ghost slots from crashed peers
+    /// or dropped sessions cannot leak the active-relay counter.
+    fn sweep_stale_relay_slots(&mut self, now: Instant) {
+        let timeout = self.relay_slot_timeout;
+        self.relay_slots
+            .retain(|_, &mut arrived_at| now.duration_since(arrived_at) < timeout);
     }
     /// Observe a peer's address from an incoming connection
     ///
@@ -3789,6 +3843,37 @@ impl BootstrapCoordinator {
                 );
             })?;
 
+        // Tier 4 (lite) back-pressure: only the relay branch (where the
+        // frame carries an explicit `target_peer_id`) consumes a slot. If
+        // we are at capacity for active relays, silently drop the frame —
+        // the initiator's per-attempt timeout (Tier 2 rotation) will move
+        // it on to its next preferred coordinator.
+        //
+        // Inline garbage-collection sweep first so any stale slots from
+        // crashed peers are reclaimed before the cap check.
+        if let Some(target_peer_id) = frame.target_peer_id {
+            self.sweep_stale_relay_slots(now);
+            let slot_key = (from_peer, target_peer_id);
+            // Re-arming an existing slot for the same (initiator, target)
+            // pair does not consume an additional slot — common during
+            // multi-round coordination where the same pair re-sends.
+            let already_active = self.relay_slots.contains_key(&slot_key);
+            if !already_active && self.relay_slots.len() >= self.relay_slot_capacity {
+                self.stats.backpressure_refusals =
+                    self.stats.backpressure_refusals.saturating_add(1);
+                debug!(
+                    "PUNCH_ME_NOW relay refused: coordinator at capacity ({}/{}) — initiator {:?} → target {:?}",
+                    self.relay_slots.len(),
+                    self.relay_slot_capacity,
+                    hex::encode(&from_peer[..8]),
+                    hex::encode(&target_peer_id[..8])
+                );
+                return Ok(None);
+            }
+            // Accept: insert/refresh the slot timestamp.
+            self.relay_slots.insert(slot_key, now);
+        }
+
         // Track coordination entry minimally
         let _entry = self
             .coordination_table
@@ -3907,6 +3992,8 @@ mod tests {
             10,                      // max_candidates
             Duration::from_secs(30), // coordination_timeout
             true,                    // allow_loopback for tests
+            32,                      // coordinator_max_active_relays
+            Duration::from_secs(5),  // coordinator_relay_slot_timeout
         )
     }
 
@@ -4289,6 +4376,8 @@ mod tests {
             100, // max_candidates (high enough to not limit)
             Duration::from_secs(30),
             true, // allow_loopback for tests
+            32,
+            Duration::from_secs(5),
         );
         let now = Instant::now();
 
@@ -4319,7 +4408,13 @@ mod tests {
     #[test]
     fn test_add_pairs_at_exact_limit() {
         // Test behavior when exactly at the limit
-        let mut state = NatTraversalState::new(100, Duration::from_secs(30), true);
+        let mut state = NatTraversalState::new(
+            100,
+            Duration::from_secs(30),
+            true,
+            32,
+            Duration::from_secs(5),
+        );
         let now = Instant::now();
 
         // Add candidates to get close to limit (14 × 14 = 196 pairs)
@@ -4399,7 +4494,13 @@ mod tests {
     #[test]
     fn test_incremental_add_with_zero_remaining_capacity() {
         // Test that incremental add gracefully handles zero capacity
-        let mut state = NatTraversalState::new(100, Duration::from_secs(30), true);
+        let mut state = NatTraversalState::new(
+            100,
+            Duration::from_secs(30),
+            true,
+            32,
+            Duration::from_secs(5),
+        );
         let now = Instant::now();
 
         // Fill up to the limit
@@ -4429,6 +4530,209 @@ mod tests {
         assert!(
             state.candidate_pairs.len() <= 200,
             "Should handle limit gracefully without panic"
+        );
+    }
+
+    // ---- Tier 4 (lite): coordinator-side back-pressure ----
+
+    /// Helper: build a `BootstrapCoordinator` with controllable cap and
+    /// timeout for back-pressure tests.
+    fn make_bp_coordinator(capacity: usize, timeout: Duration) -> BootstrapCoordinator {
+        BootstrapCoordinator::new(
+            BootstrapConfig::default(),
+            true, // allow_loopback so test addrs aren't rejected
+            capacity,
+            timeout,
+        )
+    }
+
+    /// Helper: build a `PunchMeNow` frame for the relay path (with target).
+    fn make_relay_frame(round: u64, target_peer_id: [u8; 32]) -> crate::frame::PunchMeNow {
+        crate::frame::PunchMeNow {
+            round: VarInt::from_u64(round).unwrap_or(VarInt::from_u32(0)),
+            paired_with_sequence_number: VarInt::from_u32(0),
+            address: SocketAddr::from(([127, 0, 0, 1], 9000)),
+            target_peer_id: Some(target_peer_id),
+        }
+    }
+
+    fn peer_id_with_byte(byte: u8) -> [u8; 32] {
+        let mut id = [0u8; 32];
+        id[0] = byte;
+        id
+    }
+
+    #[test]
+    fn coordinator_accepts_relay_under_capacity() {
+        let mut coord = make_bp_coordinator(4, Duration::from_secs(5));
+        let now = Instant::now();
+        let from = peer_id_with_byte(0x01);
+        let target = peer_id_with_byte(0x02);
+        let frame = make_relay_frame(1, target);
+        let source_addr = SocketAddr::from(([127, 0, 0, 1], 5000));
+
+        let result = coord
+            .process_punch_me_now_frame(from, source_addr, &frame, now)
+            .expect("relay under cap should not error");
+
+        assert!(
+            result.is_some(),
+            "relay under capacity should produce a coordination frame"
+        );
+        assert_eq!(coord.relay_slots.len(), 1, "one slot should be allocated");
+        assert_eq!(
+            coord.stats.backpressure_refusals, 0,
+            "no refusal stat increment expected when under cap"
+        );
+    }
+
+    #[test]
+    fn coordinator_refuses_silently_at_capacity() {
+        let capacity = 2;
+        let mut coord = make_bp_coordinator(capacity, Duration::from_secs(5));
+        let now = Instant::now();
+        let source_addr = SocketAddr::from(([127, 0, 0, 1], 5000));
+
+        // Fill capacity with two distinct (initiator, target) pairs.
+        for i in 0..capacity {
+            let from = peer_id_with_byte(0x10 + i as u8);
+            let target = peer_id_with_byte(0x20 + i as u8);
+            let frame = make_relay_frame(i as u64 + 1, target);
+            let result = coord
+                .process_punch_me_now_frame(from, source_addr, &frame, now)
+                .expect("under-cap relay should not error");
+            assert!(result.is_some(), "slot {} should be accepted", i);
+        }
+        assert_eq!(coord.relay_slots.len(), capacity);
+
+        // The next distinct pair must be silently refused: Ok(None).
+        let overflow_from = peer_id_with_byte(0xFE);
+        let overflow_target = peer_id_with_byte(0xFD);
+        let overflow_frame = make_relay_frame(99, overflow_target);
+        let result = coord
+            .process_punch_me_now_frame(overflow_from, source_addr, &overflow_frame, now)
+            .expect("at-cap refusal must be silent (no error)");
+
+        assert!(
+            result.is_none(),
+            "at-cap refusal must produce no coordination frame"
+        );
+        assert_eq!(
+            coord.relay_slots.len(),
+            capacity,
+            "refused frame must not consume a slot"
+        );
+        assert_eq!(
+            coord.stats.backpressure_refusals, 1,
+            "back-pressure stat must increment on refusal"
+        );
+    }
+
+    #[test]
+    fn coordinator_re_arms_existing_slot_without_consuming_capacity() {
+        let mut coord = make_bp_coordinator(2, Duration::from_secs(5));
+        let now = Instant::now();
+        let source_addr = SocketAddr::from(([127, 0, 0, 1], 5000));
+        let from = peer_id_with_byte(0x01);
+        let target = peer_id_with_byte(0x02);
+        let frame = make_relay_frame(1, target);
+
+        // Fill the first slot.
+        coord
+            .process_punch_me_now_frame(from, source_addr, &frame, now)
+            .expect("first frame ok");
+        assert_eq!(coord.relay_slots.len(), 1);
+
+        // Re-send for the same (from, target) pair: must not consume an
+        // additional slot, must still be accepted.
+        let later = now + Duration::from_millis(500);
+        let result = coord
+            .process_punch_me_now_frame(from, source_addr, &frame, later)
+            .expect("re-arm ok");
+        assert!(result.is_some(), "re-armed slot should still be relayed");
+        assert_eq!(
+            coord.relay_slots.len(),
+            1,
+            "re-arming the same pair must not allocate a second slot"
+        );
+        // Slot timestamp should refresh to the later instant.
+        let slot_arrived = coord
+            .relay_slots
+            .get(&(from, target))
+            .copied()
+            .expect("slot present");
+        assert_eq!(
+            slot_arrived, later,
+            "re-arm must refresh the slot timestamp"
+        );
+    }
+
+    #[test]
+    fn coordinator_sweep_reclaims_stale_slots() {
+        let timeout = Duration::from_secs(5);
+        let mut coord = make_bp_coordinator(2, timeout);
+        let now = Instant::now();
+        let source_addr = SocketAddr::from(([127, 0, 0, 1], 5000));
+
+        // Fill capacity.
+        for i in 0..2u8 {
+            let from = peer_id_with_byte(0x10 + i);
+            let target = peer_id_with_byte(0x20 + i);
+            let frame = make_relay_frame(i as u64 + 1, target);
+            coord
+                .process_punch_me_now_frame(from, source_addr, &frame, now)
+                .expect("under-cap ok");
+        }
+        assert_eq!(coord.relay_slots.len(), 2);
+
+        // Advance well past the slot timeout. The next incoming frame's
+        // inline sweep must reclaim both stale slots before applying the
+        // back-pressure check.
+        let much_later = now + timeout + Duration::from_secs(1);
+        let new_from = peer_id_with_byte(0xAA);
+        let new_target = peer_id_with_byte(0xBB);
+        let new_frame = make_relay_frame(42, new_target);
+        let result = coord
+            .process_punch_me_now_frame(new_from, source_addr, &new_frame, much_later)
+            .expect("post-sweep frame should succeed");
+
+        assert!(
+            result.is_some(),
+            "frame after sweep must be accepted (capacity reclaimed)"
+        );
+        assert_eq!(
+            coord.relay_slots.len(),
+            1,
+            "stale slots must be reclaimed; only the new one remains"
+        );
+        assert_eq!(
+            coord.stats.backpressure_refusals, 0,
+            "no refusal expected because sweep freed capacity in time"
+        );
+    }
+
+    #[test]
+    fn coordinator_non_relay_frame_does_not_consume_slot() {
+        // PUNCH_ME_NOW without a target_peer_id is the response/echo path,
+        // not a relay request — it must NOT consume a back-pressure slot.
+        let mut coord = make_bp_coordinator(1, Duration::from_secs(5));
+        let now = Instant::now();
+        let source_addr = SocketAddr::from(([127, 0, 0, 1], 5000));
+        let from = peer_id_with_byte(0x01);
+
+        let frame = crate::frame::PunchMeNow {
+            round: VarInt::from_u32(1),
+            paired_with_sequence_number: VarInt::from_u32(0),
+            address: SocketAddr::from(([127, 0, 0, 1], 9000)),
+            target_peer_id: None,
+        };
+        let _ = coord
+            .process_punch_me_now_frame(from, source_addr, &frame, now)
+            .expect("non-relay frame ok");
+        assert_eq!(
+            coord.relay_slots.len(),
+            0,
+            "non-relay frame must not consume a slot"
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,6 +259,9 @@ pub mod metrics;
 /// TURN-style relay protocol for NAT traversal fallback
 pub mod relay;
 
+/// Node-wide hole-punch coordinator back-pressure (Tier 4 lite).
+pub mod relay_slot_table;
+
 /// MASQUE CONNECT-UDP Bind protocol for fully connectable P2P nodes
 pub mod masque;
 

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -492,44 +492,51 @@ pub struct NatTraversalConfig {
     #[serde(default)]
     pub allow_loopback: bool,
 
-    /// Maximum number of concurrent hole-punch relay slots this node will
-    /// service as a coordinator.
+    /// Cap on simultaneous in-flight hole-punch coordinator sessions
+    /// **across the entire node** (Tier 4 lite back-pressure).
     ///
-    /// When the active relay count reaches this cap, incoming `PUNCH_ME_NOW`
-    /// frames that would otherwise be relayed are *silently refused*: the
-    /// coordinator drops the relay without notifying the initiator. The
-    /// initiator's per-attempt timeout (Tier 2 rotation) drives it to
-    /// advance to the next preferred coordinator in its list.
+    /// When the shared `RelaySlotTable` is full, additional `PUNCH_ME_NOW`
+    /// relay frames are *silently refused*: the coordinator drops them
+    /// without notifying the initiator, and the initiator's per-attempt
+    /// timeout (Tier 2 rotation) advances to the next preferred
+    /// coordinator in its list.
+    ///
+    /// A "session" is one `(initiator_addr, target_peer_id)` pair. The
+    /// same pair re-sending across rounds re-arms one slot rather than
+    /// allocating new ones. Slots are released either by the explicit
+    /// connection-close path (when the initiator's connection drops, the
+    /// `BootstrapCoordinator::Drop` releases every slot it owned) or by
+    /// the [`Self::coordinator_relay_slot_idle_timeout`] safety net for
+    /// peers that vanish without an orderly close.
     ///
     /// Defaults to [`NatTraversalConfig::DEFAULT_COORDINATOR_MAX_ACTIVE_RELAYS`]
-    /// (32). Picked as roughly 32% of saorsa-core's 100-connection cap so
-    /// the coordinator still has headroom for its own peer traffic, while
-    /// being low enough that a cold-start storm is shed and pushed onto
-    /// alternates.
-    ///
-    /// Each "active relay" represents one in-flight initiator→target
-    /// coordination, indexed by `(initiator_peer_id, target_peer_id)`. The
-    /// counter is decremented when the relay completes or after
-    /// [`Self::coordinator_relay_slot_timeout`] elapses (whichever first).
+    /// (32). Sized to keep a coordinator's worst-case in-flight
+    /// coordination work bounded under a cold-start storm of peers all
+    /// converging on the same bootstrap, while still leaving headroom
+    /// for steady-state per-peer traffic.
     #[serde(default = "default_coordinator_max_active_relays")]
     pub coordinator_max_active_relays: usize,
 
-    /// Maximum lifetime of a coordinator relay slot before it is reclaimed
-    /// by the inline garbage-collection sweep.
+    /// Idle-release timeout for an in-flight coordinator relay session.
     ///
-    /// A successful hole-punch typically completes in 1-3 seconds; this
-    /// timeout exists purely as a safety net so that a relay slot cannot
-    /// leak forever if a peer crashes mid-coordination, a NAT rebind
-    /// silently drops the session, or a follow-up signal is lost. Without
-    /// it the active-relay counter would drift upward over time and the
-    /// coordinator would eventually refuse legitimate traffic.
+    /// A slot lasts from the first `PUNCH_ME_NOW` arrival until either
+    /// (a) the connection that owns it closes — in which case
+    /// `BootstrapCoordinator::Drop` releases all of that connection's
+    /// slots immediately, or (b) no new round arrives for the same
+    /// `(initiator_addr, target_peer_id)` pair within this idle window —
+    /// the *safety net* for peers that crash, get NAT-rebound, or stop
+    /// rotating without an orderly close. The coordinator cannot
+    /// directly observe whether the punch ultimately succeeded (the
+    /// punch traffic flows initiator↔target, bypassing the coordinator),
+    /// so the idle timeout is the only signal available for "vanished"
+    /// sessions.
     ///
-    /// Defaults to [`NatTraversalConfig::DEFAULT_COORDINATOR_RELAY_SLOT_TIMEOUT`]
+    /// Defaults to [`NatTraversalConfig::DEFAULT_COORDINATOR_RELAY_SLOT_IDLE_TIMEOUT`]
     /// (5 seconds): comfortably above the worst-case successful punch
-    /// latency on high-RTT links, but short enough to keep ghost slots
-    /// from impacting steady-state burst capacity.
-    #[serde(default = "default_coordinator_relay_slot_timeout")]
-    pub coordinator_relay_slot_timeout: Duration,
+    /// latency on high-RTT links, short enough to keep capacity from
+    /// being held by ghost sessions.
+    #[serde(default = "default_coordinator_relay_slot_idle_timeout")]
+    pub coordinator_relay_slot_idle_timeout: Duration,
 
     /// Best-effort UPnP IGD port mapping configuration.
     ///
@@ -552,18 +559,19 @@ fn default_coordinator_max_active_relays() -> usize {
     NatTraversalConfig::DEFAULT_COORDINATOR_MAX_ACTIVE_RELAYS
 }
 
-fn default_coordinator_relay_slot_timeout() -> Duration {
-    NatTraversalConfig::DEFAULT_COORDINATOR_RELAY_SLOT_TIMEOUT
+fn default_coordinator_relay_slot_idle_timeout() -> Duration {
+    NatTraversalConfig::DEFAULT_COORDINATOR_RELAY_SLOT_IDLE_TIMEOUT
 }
 
 impl NatTraversalConfig {
-    /// Default cap on simultaneous coordinator relay slots.
+    /// Default cap on simultaneous coordinator relay sessions.
     /// See [`Self::coordinator_max_active_relays`] for rationale.
     pub const DEFAULT_COORDINATOR_MAX_ACTIVE_RELAYS: usize = 32;
 
-    /// Default reclamation timeout for stale coordinator relay slots.
-    /// See [`Self::coordinator_relay_slot_timeout`] for rationale.
-    pub const DEFAULT_COORDINATOR_RELAY_SLOT_TIMEOUT: Duration = Duration::from_secs(5);
+    /// Default idle-release timeout for in-flight coordinator relay
+    /// sessions. See [`Self::coordinator_relay_slot_idle_timeout`] for
+    /// rationale.
+    pub const DEFAULT_COORDINATOR_RELAY_SLOT_IDLE_TIMEOUT: Duration = Duration::from_secs(5);
 }
 
 /// Convert `max_message_size` to a QUIC `VarInt` for stream/send window configuration.
@@ -1146,7 +1154,7 @@ impl Default for NatTraversalConfig {
             max_message_size: crate::unified_config::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
             allow_loopback: false,
             coordinator_max_active_relays: Self::DEFAULT_COORDINATOR_MAX_ACTIVE_RELAYS,
-            coordinator_relay_slot_timeout: Self::DEFAULT_COORDINATOR_RELAY_SLOT_TIMEOUT,
+            coordinator_relay_slot_idle_timeout: Self::DEFAULT_COORDINATOR_RELAY_SLOT_IDLE_TIMEOUT,
             upnp: crate::upnp::UpnpConfig::default(),
         }
     }
@@ -1201,14 +1209,14 @@ impl ConfigValidator for NatTraversalConfig {
         validate_range(
             self.coordinator_max_active_relays,
             1,
-            256,
+            1024,
             "coordinator_max_active_relays",
         )?;
         validate_duration(
-            self.coordinator_relay_slot_timeout,
+            self.coordinator_relay_slot_idle_timeout,
             Duration::from_millis(100),
             Duration::from_secs(60),
-            "coordinator_relay_slot_timeout",
+            "coordinator_relay_slot_idle_timeout",
         )?;
 
         Ok(())
@@ -2623,6 +2631,18 @@ impl NatTraversalEndpoint {
     > {
         use std::sync::Arc;
 
+        // Tier 4 (lite) coordinator back-pressure: every connection
+        // spawned by this endpoint shares ONE node-wide
+        // `RelaySlotTable`. Both the server-side `TransportConfig` and
+        // the client-side `TransportConfig` get a clone of the same
+        // `Arc`, so a relay arriving on a server-accepted connection
+        // and a relay arriving on a client-initiated connection both
+        // count against the same cap.
+        let relay_slot_table = Arc::new(crate::relay_slot_table::RelaySlotTable::new(
+            config.coordinator_max_active_relays,
+            config.coordinator_relay_slot_idle_timeout,
+        ));
+
         // v0.13.0+: All nodes are symmetric P2P nodes - always create server config
         let server_config = {
             info!("Creating server config using Raw Public Keys (RFC 7250) for symmetric P2P node");
@@ -2686,8 +2706,7 @@ impl NatTraversalEndpoint {
             };
             transport_config.nat_traversal_config(Some(nat_config));
             transport_config.allow_loopback(config.allow_loopback);
-            transport_config.coordinator_max_active_relays(config.coordinator_max_active_relays);
-            transport_config.coordinator_relay_slot_timeout(config.coordinator_relay_slot_timeout);
+            transport_config.relay_slot_table(Some(Arc::clone(&relay_slot_table)));
 
             server_config.transport_config(Arc::new(transport_config));
 
@@ -2759,8 +2778,7 @@ impl NatTraversalEndpoint {
             };
             transport_config.nat_traversal_config(Some(nat_config));
             transport_config.allow_loopback(config.allow_loopback);
-            transport_config.coordinator_max_active_relays(config.coordinator_max_active_relays);
-            transport_config.coordinator_relay_slot_timeout(config.coordinator_relay_slot_timeout);
+            transport_config.relay_slot_table(Some(Arc::clone(&relay_slot_table)));
 
             client_config.transport_config(Arc::new(transport_config));
 

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -492,6 +492,45 @@ pub struct NatTraversalConfig {
     #[serde(default)]
     pub allow_loopback: bool,
 
+    /// Maximum number of concurrent hole-punch relay slots this node will
+    /// service as a coordinator.
+    ///
+    /// When the active relay count reaches this cap, incoming `PUNCH_ME_NOW`
+    /// frames that would otherwise be relayed are *silently refused*: the
+    /// coordinator drops the relay without notifying the initiator. The
+    /// initiator's per-attempt timeout (Tier 2 rotation) drives it to
+    /// advance to the next preferred coordinator in its list.
+    ///
+    /// Defaults to [`NatTraversalConfig::DEFAULT_COORDINATOR_MAX_ACTIVE_RELAYS`]
+    /// (32). Picked as roughly 32% of saorsa-core's 100-connection cap so
+    /// the coordinator still has headroom for its own peer traffic, while
+    /// being low enough that a cold-start storm is shed and pushed onto
+    /// alternates.
+    ///
+    /// Each "active relay" represents one in-flight initiator→target
+    /// coordination, indexed by `(initiator_peer_id, target_peer_id)`. The
+    /// counter is decremented when the relay completes or after
+    /// [`Self::coordinator_relay_slot_timeout`] elapses (whichever first).
+    #[serde(default = "default_coordinator_max_active_relays")]
+    pub coordinator_max_active_relays: usize,
+
+    /// Maximum lifetime of a coordinator relay slot before it is reclaimed
+    /// by the inline garbage-collection sweep.
+    ///
+    /// A successful hole-punch typically completes in 1-3 seconds; this
+    /// timeout exists purely as a safety net so that a relay slot cannot
+    /// leak forever if a peer crashes mid-coordination, a NAT rebind
+    /// silently drops the session, or a follow-up signal is lost. Without
+    /// it the active-relay counter would drift upward over time and the
+    /// coordinator would eventually refuse legitimate traffic.
+    ///
+    /// Defaults to [`NatTraversalConfig::DEFAULT_COORDINATOR_RELAY_SLOT_TIMEOUT`]
+    /// (5 seconds): comfortably above the worst-case successful punch
+    /// latency on high-RTT links, but short enough to keep ghost slots
+    /// from impacting steady-state burst capacity.
+    #[serde(default = "default_coordinator_relay_slot_timeout")]
+    pub coordinator_relay_slot_timeout: Duration,
+
     /// Best-effort UPnP IGD port mapping configuration.
     ///
     /// When enabled, the endpoint asks the local Internet Gateway Device
@@ -507,6 +546,24 @@ pub struct NatTraversalConfig {
 
 fn default_max_message_size() -> usize {
     crate::unified_config::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE
+}
+
+fn default_coordinator_max_active_relays() -> usize {
+    NatTraversalConfig::DEFAULT_COORDINATOR_MAX_ACTIVE_RELAYS
+}
+
+fn default_coordinator_relay_slot_timeout() -> Duration {
+    NatTraversalConfig::DEFAULT_COORDINATOR_RELAY_SLOT_TIMEOUT
+}
+
+impl NatTraversalConfig {
+    /// Default cap on simultaneous coordinator relay slots.
+    /// See [`Self::coordinator_max_active_relays`] for rationale.
+    pub const DEFAULT_COORDINATOR_MAX_ACTIVE_RELAYS: usize = 32;
+
+    /// Default reclamation timeout for stale coordinator relay slots.
+    /// See [`Self::coordinator_relay_slot_timeout`] for rationale.
+    pub const DEFAULT_COORDINATOR_RELAY_SLOT_TIMEOUT: Duration = Duration::from_secs(5);
 }
 
 /// Convert `max_message_size` to a QUIC `VarInt` for stream/send window configuration.
@@ -1088,6 +1145,8 @@ impl Default for NatTraversalConfig {
             transport_registry: None, // Use direct UDP binding by default
             max_message_size: crate::unified_config::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
             allow_loopback: false,
+            coordinator_max_active_relays: Self::DEFAULT_COORDINATOR_MAX_ACTIVE_RELAYS,
+            coordinator_relay_slot_timeout: Self::DEFAULT_COORDINATOR_RELAY_SLOT_TIMEOUT,
             upnp: crate::upnp::UpnpConfig::default(),
         }
     }
@@ -1137,6 +1196,20 @@ impl ConfigValidator for NatTraversalConfig {
                 "max_concurrent_attempts cannot exceed max_candidates".to_string(),
             ));
         }
+
+        // Validate coordinator back-pressure limits (Tier 4 lite).
+        validate_range(
+            self.coordinator_max_active_relays,
+            1,
+            256,
+            "coordinator_max_active_relays",
+        )?;
+        validate_duration(
+            self.coordinator_relay_slot_timeout,
+            Duration::from_millis(100),
+            Duration::from_secs(60),
+            "coordinator_relay_slot_timeout",
+        )?;
 
         Ok(())
     }
@@ -2613,6 +2686,8 @@ impl NatTraversalEndpoint {
             };
             transport_config.nat_traversal_config(Some(nat_config));
             transport_config.allow_loopback(config.allow_loopback);
+            transport_config.coordinator_max_active_relays(config.coordinator_max_active_relays);
+            transport_config.coordinator_relay_slot_timeout(config.coordinator_relay_slot_timeout);
 
             server_config.transport_config(Arc::new(transport_config));
 
@@ -2684,6 +2759,8 @@ impl NatTraversalEndpoint {
             };
             transport_config.nat_traversal_config(Some(nat_config));
             transport_config.allow_loopback(config.allow_loopback);
+            transport_config.coordinator_max_active_relays(config.coordinator_max_active_relays);
+            transport_config.coordinator_relay_slot_timeout(config.coordinator_relay_slot_timeout);
 
             client_config.transport_config(Arc::new(transport_config));
 

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -1257,6 +1257,23 @@ impl P2pEndpoint {
     /// hole-punch timeout to give it time to complete the punch.
     ///
     /// Empty `coordinators` removes any preferred coordinators for `target`.
+    ///
+    /// ## Interaction with `StrategyConfig::max_holepunch_rounds`
+    ///
+    /// Each rotation step in the connect loop calls
+    /// `ConnectionStrategy::increment_round`, so the strategy's per-round
+    /// counter and the rotation index advance together. With the default
+    /// `max_holepunch_rounds = 2`, supplying `K ≥ 2` preferred coordinators
+    /// gives each coordinator (including the final one) exactly one
+    /// attempt — the rotation fully replaces the legacy retry loop and the
+    /// worst-case dial time is `(K-1) * 1.5s + 8s`.
+    ///
+    /// If a caller has explicitly raised `max_holepunch_rounds` (e.g.
+    /// `with_max_holepunch_rounds(5)`) **and** also supplies a preferred
+    /// list, the *final* coordinator inherits the leftover round budget
+    /// — it will be retried `max_rounds - K + 1` times at the full
+    /// hole-punch timeout. This is usually fine but worth knowing if you
+    /// were expecting the rotation to be the only retry mechanism.
     pub async fn set_hole_punch_preferred_coordinators(
         &self,
         target: SocketAddr,
@@ -1381,11 +1398,13 @@ impl P2pEndpoint {
         // Drop any pre-existing copies of the preferred entries from the
         // tail so we don't end up with duplicates after the front-insert.
         coordinator_candidates.retain(|a| !preferred.contains(a));
-        // Insert in reverse so `preferred[0]` ends up at index 0,
-        // `preferred[1]` at index 1, etc.
-        for preferred_addr in preferred.iter().rev() {
-            coordinator_candidates.insert(0, *preferred_addr);
-        }
+        // Build the merged list in one allocation rather than calling
+        // `Vec::insert(0, ..)` in a loop (which shifts the entire tail
+        // on every iteration — O(N·M) instead of O(N+M)).
+        let mut merged = Vec::with_capacity(preferred.len() + coordinator_candidates.len());
+        merged.extend_from_slice(preferred);
+        merged.append(coordinator_candidates);
+        *coordinator_candidates = merged;
     }
 
     /// Inner implementation of connect_with_fallback (separated for dedup wrapper).
@@ -1702,6 +1721,25 @@ impl P2pEndpoint {
                     } else {
                         strategy.holepunch_timeout()
                     };
+
+                    // Invariant: while rotating, the strategy's current
+                    // coordinator must equal `coordinator_candidates[idx]`.
+                    // This is maintained by `set_coordinator()` on every
+                    // rotation step; the assert catches any future
+                    // regression where a caller sets the strategy's
+                    // coordinator out of band without updating the
+                    // candidate list.
+                    debug_assert!(
+                        !is_rotating
+                            || coordinator_candidates
+                                .get(current_preferred_coordinator_idx)
+                                .copied()
+                                == Some(coordinator),
+                        "rotation index out of sync with strategy coordinator: idx={}, coord={}, candidates={:?}",
+                        current_preferred_coordinator_idx,
+                        coordinator,
+                        coordinator_candidates,
+                    );
 
                     info!(
                         "Trying hole-punch to {} via {} (round {}, attempt timeout {:?}, rotating={})",

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -92,6 +92,19 @@ const STALE_REAPER_INTERVAL: Duration = Duration::from_secs(10);
 /// through the pinhole needs only 1-2 RTTs (~600ms at 300ms worst-case RTT).
 const POST_HOLEPUNCH_DIRECT_RETRY_TIMEOUT: Duration = Duration::from_secs(1);
 
+/// Per-attempt hole-punch timeout used when rotating through a list of
+/// preferred coordinators. Kept short so a busy or unreachable coordinator
+/// is abandoned quickly and the next one in the list is tried; the *last*
+/// coordinator in the rotation falls back to the strategy's full
+/// hole-punch timeout to give it time to actually complete the punch.
+///
+/// Tuned for the Tier 2 + Tier 4 (lite) coordinator-rotation flow: 1.5s
+/// is comfortably above one round-trip on most internet links but well
+/// below the strategy default (~8s), so the worst-case wait for K
+/// preferred coordinators is roughly `(K-1) * 1.5s + 8s` instead of
+/// `K * 8s`.
+const PER_COORDINATOR_QUICK_HOLEPUNCH_TIMEOUT: Duration = Duration::from_millis(1500);
+
 use crate::SHUTDOWN_DRAIN_TIMEOUT;
 
 /// Extract the raw SPKI (SubjectPublicKeyInfo) bytes from a QUIC connection's
@@ -176,12 +189,17 @@ pub struct P2pEndpoint {
     /// address so concurrent dials don't race on shared state.
     hole_punch_target_peer_ids: Arc<dashmap::DashMap<SocketAddr, [u8; 32]>>,
 
-    /// Per-target preferred coordinator for hole-punch relay. When the DHT
-    /// lookup discovers a peer via a FindNode response from another node, that
-    /// responding node (the "referrer") has a connection to the discovered peer
-    /// and is an ideal coordinator for PUNCH_ME_NOW relay. Keyed by target
-    /// address, value is the referrer's socket address.
-    hole_punch_preferred_coordinators: Arc<dashmap::DashMap<SocketAddr, SocketAddr>>,
+    /// Per-target preferred coordinators for hole-punch relay. When the DHT
+    /// lookup discovers a peer via FindNode responses from one or more peers,
+    /// those responding nodes (the "referrers") all have a connection to the
+    /// discovered peer and are good coordinator candidates. Keyed by target
+    /// address, value is an ordered list of referrer socket addresses ranked
+    /// best-first by the caller (e.g. by DHT lookup round, trust score).
+    /// During hole-punching the list is iterated front to back: the first
+    /// candidates get a short per-attempt timeout so we rotate quickly past
+    /// busy or unreachable coordinators; the last candidate gets the full
+    /// hole-punch timeout to give it time to actually complete the punch.
+    hole_punch_preferred_coordinators: Arc<dashmap::DashMap<SocketAddr, Vec<SocketAddr>>>,
 
     /// Channel sender for data received from QUIC reader tasks and constrained poller
     data_tx: mpsc::Sender<(SocketAddr, Vec<u8>)>,
@@ -1227,16 +1245,44 @@ impl P2pEndpoint {
         self.hole_punch_target_peer_ids.insert(target, peer_id);
     }
 
-    /// Set a preferred coordinator for hole-punching to a specific target.
-    /// The preferred coordinator is a peer that referred us to the target
-    /// during a DHT lookup, so it has a connection to the target.
+    /// Set an ordered list of preferred coordinators for hole-punching to a
+    /// specific target.
+    ///
+    /// The caller (typically saorsa-core's DHT layer) is expected to rank
+    /// the list best-first using its own quality signals — e.g. DHT lookup
+    /// round, trust score, observed latency. During hole-punching the list
+    /// is iterated front to back: the first `coordinators.len() - 1` get a
+    /// short per-attempt timeout so a busy or unreachable coordinator is
+    /// abandoned quickly; the last coordinator gets the full strategy
+    /// hole-punch timeout to give it time to complete the punch.
+    ///
+    /// Empty `coordinators` removes any preferred coordinators for `target`.
+    pub async fn set_hole_punch_preferred_coordinators(
+        &self,
+        target: SocketAddr,
+        coordinators: Vec<SocketAddr>,
+    ) {
+        if coordinators.is_empty() {
+            self.hole_punch_preferred_coordinators.remove(&target);
+        } else {
+            self.hole_punch_preferred_coordinators
+                .insert(target, coordinators);
+        }
+    }
+
+    /// Set a single preferred coordinator for hole-punching to a specific
+    /// target.
+    ///
+    /// Thin wrapper around [`Self::set_hole_punch_preferred_coordinators`]
+    /// retained for callers that have only one coordinator candidate. New
+    /// callers should prefer the list form.
     pub async fn set_hole_punch_preferred_coordinator(
         &self,
         target: SocketAddr,
         coordinator: SocketAddr,
     ) {
-        self.hole_punch_preferred_coordinators
-            .insert(target, coordinator);
+        self.set_hole_punch_preferred_coordinators(target, vec![coordinator])
+            .await;
     }
 
     /// Connect with automatic fallback: Direct → HolePunch → Relay.
@@ -1312,6 +1358,36 @@ impl P2pEndpoint {
         result
     }
 
+    /// Merge a ranked list of preferred hole-punch coordinators into the
+    /// front of `coordinator_candidates`, preserving the relative order of
+    /// `preferred` and removing any pre-existing duplicates from the
+    /// candidate list.
+    ///
+    /// After this call returns, `coordinator_candidates[0..preferred.len()]`
+    /// equals `preferred` (in order). The hole-punch loop uses
+    /// `preferred.len()` directly to decide which attempts get the short
+    /// rotation timeout vs. the strategy's full hole-punch timeout.
+    ///
+    /// Pure function (no `&self`, no I/O) — extracted from
+    /// `connect_with_fallback_inner` so the front-insertion behaviour can
+    /// be unit-tested without spinning up a full endpoint.
+    fn merge_preferred_coordinators(
+        coordinator_candidates: &mut Vec<SocketAddr>,
+        preferred: &[SocketAddr],
+    ) {
+        if preferred.is_empty() {
+            return;
+        }
+        // Drop any pre-existing copies of the preferred entries from the
+        // tail so we don't end up with duplicates after the front-insert.
+        coordinator_candidates.retain(|a| !preferred.contains(a));
+        // Insert in reverse so `preferred[0]` ends up at index 0,
+        // `preferred[1]` at index 1, etc.
+        for preferred_addr in preferred.iter().rev() {
+            coordinator_candidates.insert(0, *preferred_addr);
+        }
+    }
+
     /// Inner implementation of connect_with_fallback (separated for dedup wrapper).
     async fn connect_with_fallback_inner(
         &self,
@@ -1343,17 +1419,32 @@ impl P2pEndpoint {
             }
         }
 
-        // If the DHT referrer set a preferred coordinator for this target,
-        // move it to the front of the candidate list so round 1 uses it.
+        // If the DHT layer set preferred coordinators for this target, move
+        // them to the front of the candidate list in order so the hole-punch
+        // loop tries them first. Each preferred coordinator is removed from
+        // its existing position (if any) before being inserted at the front
+        // so the relative ordering of the preferred list is preserved.
+        //
+        // `preferred_coordinator_count` is captured for the hole-punch loop:
+        // when > 0 the loop rotates through `coordinator_candidates[0..count]`
+        // with `PER_COORDINATOR_QUICK_HOLEPUNCH_TIMEOUT` per non-final attempt,
+        // and the strategy's full timeout for the last attempt. When 0 the
+        // loop falls back to the existing single-coordinator retry behaviour.
+        let mut preferred_coordinator_count: usize = 0;
         if let Some(target_addr) = target {
             if let Some(preferred) = self.hole_punch_preferred_coordinators.get(&target_addr) {
-                let preferred_addr = *preferred;
-                coordinator_candidates.retain(|a| *a != preferred_addr);
-                coordinator_candidates.insert(0, preferred_addr);
-                info!(
-                    "Using preferred coordinator {} for target {} (DHT referrer)",
-                    preferred_addr, target_addr
-                );
+                let preferred_list: Vec<SocketAddr> = preferred.clone();
+                drop(preferred); // Release the DashMap entry guard before mutating coordinator_candidates.
+                Self::merge_preferred_coordinators(&mut coordinator_candidates, &preferred_list);
+                preferred_coordinator_count = preferred_list.len();
+                if preferred_coordinator_count > 0 {
+                    info!(
+                        "Using {} preferred coordinator(s) for target {} (DHT referrers): {:?}",
+                        preferred_list.len(),
+                        target_addr,
+                        preferred_list
+                    );
+                }
             } else {
                 info!(
                     "No preferred coordinator for target {} (not discovered via DHT referral)",
@@ -1437,6 +1528,14 @@ impl P2pEndpoint {
         if let Some(v4) = target_ipv4 {
             direct_addresses.push(v4);
         }
+
+        // Index of the preferred coordinator currently being attempted (when
+        // `preferred_coordinator_count > 0`). The hole-punch loop advances
+        // this on each failed round and uses it together with
+        // `preferred_coordinator_count` to decide whether the *next* attempt
+        // is the final one (full strategy timeout) or an interim rotation
+        // attempt (`PER_COORDINATOR_QUICK_HOLEPUNCH_TIMEOUT`).
+        let mut current_preferred_coordinator_idx: usize = 0;
 
         loop {
             // Check if a previous hole-punch attempt established the connection
@@ -1578,44 +1677,94 @@ impl P2pEndpoint {
                         .or(target_ipv6)
                         .ok_or(EndpointError::NoAddress)?;
 
+                    // Coordinator-rotation policy (Tier 2):
+                    //
+                    // When `preferred_coordinator_count > 0` we have a ranked
+                    // list of DHT-supplied coordinators at
+                    // `coordinator_candidates[0..preferred_coordinator_count]`
+                    // and we rotate through them on each failed round. The
+                    // first `count - 1` attempts use a short timeout
+                    // (`PER_COORDINATOR_QUICK_HOLEPUNCH_TIMEOUT`) so a busy or
+                    // unreachable coordinator is abandoned quickly; the final
+                    // attempt uses the strategy's full hole-punch timeout to
+                    // give it time to actually complete.
+                    //
+                    // When `preferred_coordinator_count == 0` (no DHT
+                    // referrers — first contact, or non-DHT dial) we fall
+                    // back to the legacy single-coordinator behaviour:
+                    // strategy timeout per round, retry the same coordinator
+                    // until `should_retry_holepunch` is exhausted.
+                    let is_rotating = preferred_coordinator_count > 0;
+                    let is_final_rotation_attempt = is_rotating
+                        && current_preferred_coordinator_idx + 1 >= preferred_coordinator_count;
+                    let attempt_timeout = if is_rotating && !is_final_rotation_attempt {
+                        PER_COORDINATOR_QUICK_HOLEPUNCH_TIMEOUT
+                    } else {
+                        strategy.holepunch_timeout()
+                    };
+
                     info!(
-                        "Trying hole-punch to {} via {} (round {})",
-                        target, coordinator, round
+                        "Trying hole-punch to {} via {} (round {}, attempt timeout {:?}, rotating={})",
+                        target, coordinator, round, attempt_timeout, is_rotating
                     );
 
                     // Use our existing NAT traversal infrastructure
-                    match timeout(
-                        strategy.holepunch_timeout(),
-                        self.try_hole_punch(target, coordinator),
-                    )
-                    .await
-                    {
+                    let attempt_result =
+                        timeout(attempt_timeout, self.try_hole_punch(target, coordinator)).await;
+
+                    // Common post-attempt step: try a quick direct connect.
+                    // The NAT binding may have been created by the target's
+                    // outgoing packets even though our try_hole_punch didn't
+                    // detect the connection.
+                    let post_direct = async {
+                        if let Ok(Ok(peer_conn)) =
+                            timeout(POST_HOLEPUNCH_DIRECT_RETRY_TIMEOUT, self.connect(target)).await
+                        {
+                            info!("✓ Post-hole-punch direct connect succeeded to {}", target);
+                            Some(peer_conn)
+                        } else {
+                            None
+                        }
+                    };
+
+                    match attempt_result {
                         Ok(Ok(conn)) => {
                             info!("✓ Hole-punch succeeded to {} via {}", target, coordinator);
                             return Ok((conn, ConnectionMethod::HolePunched { coordinator }));
                         }
                         Ok(Err(e)) => {
-                            // After a failed hole-punch round, try a quick direct
-                            // connect — the NAT binding may have been created by
-                            // the target's outgoing packets even though our
-                            // try_hole_punch didn't detect the connection.
-                            if let Ok(Ok(peer_conn)) =
-                                timeout(POST_HOLEPUNCH_DIRECT_RETRY_TIMEOUT, self.connect(target))
-                                    .await
-                            {
-                                info!("✓ Post-hole-punch direct connect succeeded to {}", target);
+                            if let Some(peer_conn) = post_direct.await {
                                 return Ok((
                                     peer_conn,
                                     ConnectionMethod::HolePunched { coordinator },
                                 ));
                             }
                             strategy.record_holepunch_error(round, e.to_string());
-                            if strategy.should_retry_holepunch() {
-                                // Keep the same coordinator for retries. The preferred
-                                // coordinator (index 0) was chosen because it has a
-                                // known connection to the target. Switching to a random
-                                // fallback wastes another round on a coordinator that
-                                // likely can't relay to the target.
+                            // Bounds-safe rotation: bail out of rotation and
+                            // fall back to relay if for any reason the index
+                            // would go out of bounds (defensive — by
+                            // construction the bound holds while
+                            // `current_preferred_coordinator_idx + 1 < preferred_coordinator_count`).
+                            let next_coord = if is_rotating && !is_final_rotation_attempt {
+                                coordinator_candidates
+                                    .get(current_preferred_coordinator_idx + 1)
+                                    .copied()
+                            } else {
+                                None
+                            };
+                            if let Some(next_coord) = next_coord {
+                                current_preferred_coordinator_idx += 1;
+                                info!(
+                                    "Hole-punch via {} failed ({}), rotating to preferred coordinator {}/{}: {}",
+                                    coordinator,
+                                    e,
+                                    current_preferred_coordinator_idx + 1,
+                                    preferred_coordinator_count,
+                                    next_coord
+                                );
+                                strategy.set_coordinator(next_coord);
+                                strategy.increment_round();
+                            } else if strategy.should_retry_holepunch() {
                                 info!(
                                     "Hole-punch round {} failed, retrying with same coordinator",
                                     round
@@ -1627,19 +1776,33 @@ impl P2pEndpoint {
                             }
                         }
                         Err(_) => {
-                            // Same: try a quick direct connect after timeout
-                            if let Ok(Ok(peer_conn)) =
-                                timeout(POST_HOLEPUNCH_DIRECT_RETRY_TIMEOUT, self.connect(target))
-                                    .await
-                            {
-                                info!("✓ Post-hole-punch direct connect succeeded to {}", target);
+                            if let Some(peer_conn) = post_direct.await {
                                 return Ok((
                                     peer_conn,
                                     ConnectionMethod::HolePunched { coordinator },
                                 ));
                             }
                             strategy.record_holepunch_error(round, "Timeout".to_string());
-                            if strategy.should_retry_holepunch() {
+                            let next_coord = if is_rotating && !is_final_rotation_attempt {
+                                coordinator_candidates
+                                    .get(current_preferred_coordinator_idx + 1)
+                                    .copied()
+                            } else {
+                                None
+                            };
+                            if let Some(next_coord) = next_coord {
+                                current_preferred_coordinator_idx += 1;
+                                info!(
+                                    "Hole-punch via {} timed out after {:?}, rotating to preferred coordinator {}/{}: {}",
+                                    coordinator,
+                                    attempt_timeout,
+                                    current_preferred_coordinator_idx + 1,
+                                    preferred_coordinator_count,
+                                    next_coord
+                                );
+                                strategy.set_coordinator(next_coord);
+                                strategy.increment_round();
+                            } else if strategy.should_retry_holepunch() {
                                 info!(
                                     "Hole-punch round {} timed out, retrying with same coordinator",
                                     round
@@ -3818,5 +3981,87 @@ mod tests {
         // Verify transport address is preserved
         assert_eq!(conn.remote_addr, TransportAddr::Quic(socket_addr));
         assert!(conn.authenticated);
+    }
+
+    // ---- Tier 2: preferred-coordinator front-merge ----
+
+    fn make_addr(octet: u8) -> SocketAddr {
+        SocketAddr::from(([10, 0, 0, octet], 9000))
+    }
+
+    #[test]
+    fn merge_preferred_coordinators_empty_preferred_is_no_op() {
+        let mut candidates = vec![make_addr(1), make_addr(2)];
+        let original = candidates.clone();
+        P2pEndpoint::merge_preferred_coordinators(&mut candidates, &[]);
+        assert_eq!(
+            candidates, original,
+            "empty preferred must not mutate the candidate list"
+        );
+    }
+
+    #[test]
+    fn merge_preferred_coordinators_inserts_at_front_in_order() {
+        let mut candidates = vec![make_addr(10), make_addr(11)];
+        let preferred = vec![make_addr(1), make_addr(2), make_addr(3)];
+        P2pEndpoint::merge_preferred_coordinators(&mut candidates, &preferred);
+
+        assert_eq!(
+            candidates,
+            vec![
+                make_addr(1),
+                make_addr(2),
+                make_addr(3),
+                make_addr(10),
+                make_addr(11),
+            ],
+            "preferred entries must occupy [0..preferred.len()] in order"
+        );
+    }
+
+    #[test]
+    fn merge_preferred_coordinators_dedupes_existing_entries() {
+        // make_addr(2) is BOTH a pre-existing candidate AND in the preferred
+        // list. After the merge it should appear exactly once, at its
+        // preferred-list position (index 1), not at its original tail spot.
+        let mut candidates = vec![make_addr(2), make_addr(10), make_addr(11)];
+        let preferred = vec![make_addr(1), make_addr(2)];
+        P2pEndpoint::merge_preferred_coordinators(&mut candidates, &preferred);
+
+        assert_eq!(
+            candidates,
+            vec![make_addr(1), make_addr(2), make_addr(10), make_addr(11),],
+            "duplicate preferred entries must end up in the preferred slot, not the tail"
+        );
+        // No accidental duplication.
+        assert_eq!(
+            candidates.iter().filter(|a| **a == make_addr(2)).count(),
+            1,
+            "make_addr(2) must appear exactly once after dedup"
+        );
+    }
+
+    #[test]
+    fn merge_preferred_coordinators_only_dedupes_preferred_entries() {
+        // Pre-existing candidates that are NOT in the preferred list must
+        // remain in their original tail order.
+        let mut candidates = vec![make_addr(10), make_addr(11), make_addr(12)];
+        let preferred = vec![make_addr(1)];
+        P2pEndpoint::merge_preferred_coordinators(&mut candidates, &preferred);
+
+        assert_eq!(
+            candidates,
+            vec![make_addr(1), make_addr(10), make_addr(11), make_addr(12),],
+            "non-preferred candidates must keep their original relative order"
+        );
+    }
+
+    #[test]
+    fn merge_preferred_coordinators_works_on_empty_candidate_list() {
+        let mut candidates: Vec<SocketAddr> = Vec::new();
+        let preferred = vec![make_addr(1), make_addr(2)];
+        P2pEndpoint::merge_preferred_coordinators(&mut candidates, &preferred);
+
+        assert_eq!(candidates, vec![make_addr(1), make_addr(2)]);
     }
 }

--- a/src/relay_slot_table.rs
+++ b/src/relay_slot_table.rs
@@ -1,0 +1,325 @@
+// Copyright 2024 Saorsa Labs Ltd.
+//
+// This Saorsa Network Software is licensed under the General Public License (GPL), version 3.
+// Please see the file LICENSE-GPL, or visit <http://www.gnu.org/licenses/> for the full text.
+//
+// Full details available at https://saorsalabs.com/licenses
+
+//! Node-wide hole-punch coordinator back-pressure (Tier 4 lite).
+//!
+//! Every connection that lands at a node and acts as a hole-punch coordinator
+//! shares one [`RelaySlotTable`]. The table caps the number of in-flight
+//! `(initiator, target)` relay sessions across the entire node, so a storm
+//! of cold-starting peers cannot pile up unbounded coordination work on a
+//! single bootstrap. When the cap is reached, additional `PUNCH_ME_NOW`
+//! relay frames are silently refused — the initiator's per-attempt timeout
+//! drives it to its next preferred coordinator (Tier 2 rotation).
+//!
+//! ## Lifetime model
+//!
+//! A "slot" represents an active coordination *session*: the same
+//! `(initiator_addr, target_peer_id)` pair sending one or more
+//! `PUNCH_ME_NOW` frames over the lifetime of a hole-punch attempt. The
+//! coordinator cannot directly observe whether a punch ultimately succeeded
+//! (the punch traffic flows initiator↔target, bypassing the coordinator),
+//! so slot release happens via three mechanisms:
+//!
+//! 1. **Inactivity timeout** ([`RelaySlotTable::idle_timeout`]). If no new
+//!    rounds for the same key arrive within this window the session is
+//!    considered done — either the punch succeeded (no more rounds needed)
+//!    or it definitively failed (the initiator rotated away). Default 5s.
+//!
+//! 2. **Connection close** via [`RelaySlotTable::release_for_initiator`].
+//!    When the initiator's connection drops, every slot it owned is
+//!    reclaimed immediately rather than waiting for the inactivity timeout.
+//!    Called from `BootstrapCoordinator::Drop`.
+//!
+//! 3. **Explicit re-arm refresh**. A re-sent frame for the same key
+//!    refreshes the timestamp without consuming additional capacity.
+//!
+//! ## Key choice
+//!
+//! Slots are keyed by `(initiator_addr, target_peer_id)` rather than
+//! `(initiator_peer_id, target_peer_id)` because the cryptographic PeerId
+//! is not available inside the QUIC connection state machine where the
+//! `PUNCH_ME_NOW` frame is processed (PQC auth state lives one layer up
+//! in `P2pEndpoint`). The remote socket address is constant across rounds
+//! within a session and unique enough across distinct initiators to give
+//! correct dedup behaviour for the back-pressure cap.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use tracing::{debug, warn};
+
+/// Cryptographic peer identifier — BLAKE3 hash of an ML-DSA-65 public key.
+/// Local alias to keep the table independent of the connection layer.
+pub(crate) type RelayTargetId = [u8; 32];
+
+/// Minimum interval between consecutive amortized sweeps. Sweeping less
+/// often than this on a hot path keeps the per-frame overhead bounded
+/// without letting expired entries pile up.
+const SWEEP_AMORTIZATION_INTERVAL: Duration = Duration::from_millis(100);
+
+/// One refusal warning every this many refusals, so an operator gets a
+/// log line at the start of a storm and periodically thereafter without
+/// flooding logs at line-rate.
+const REFUSAL_WARN_INTERVAL: u64 = 16;
+
+/// Node-wide table of in-flight hole-punch coordinator relay slots.
+///
+/// Cheap to clone via `Arc`. Internal state is guarded by a single
+/// `Mutex`; contention is bounded because each acquire/release holds the
+/// lock for a short critical section (a HashMap lookup plus optional
+/// amortized retain).
+pub struct RelaySlotTable {
+    inner: Mutex<RelaySlotTableInner>,
+    capacity: usize,
+    idle_timeout: Duration,
+    backpressure_refusals: AtomicU64,
+}
+
+struct RelaySlotTableInner {
+    slots: HashMap<(SocketAddr, RelayTargetId), Instant>,
+    last_swept: Instant,
+}
+
+impl RelaySlotTable {
+    /// Create a new shared table with the given capacity and idle timeout.
+    ///
+    /// `capacity` caps the number of distinct simultaneous in-flight
+    /// `(initiator_addr, target_peer_id)` sessions across the node.
+    /// `idle_timeout` is how long a slot lingers after its last refresh
+    /// before being reclaimed by the inline sweep — picks up the slack
+    /// when an initiator stops sending without explicitly releasing
+    /// (e.g. NAT rebind or process crash).
+    pub fn new(capacity: usize, idle_timeout: Duration) -> Self {
+        Self {
+            inner: Mutex::new(RelaySlotTableInner {
+                slots: HashMap::new(),
+                last_swept: Instant::now(),
+            }),
+            capacity,
+            idle_timeout,
+            backpressure_refusals: AtomicU64::new(0),
+        }
+    }
+
+    /// Try to acquire a slot for `(initiator_addr, target_peer_id)`.
+    ///
+    /// Returns `true` if the relay should proceed, `false` if the table
+    /// is at capacity. A re-acquisition for an already-held key always
+    /// succeeds and refreshes the timestamp without consuming additional
+    /// capacity — exactly what multi-round coordination needs.
+    pub(crate) fn try_acquire(
+        &self,
+        initiator_addr: SocketAddr,
+        target_peer_id: RelayTargetId,
+        now: Instant,
+    ) -> bool {
+        let mut inner = match self.inner.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        Self::sweep_if_due(&mut inner, self.idle_timeout, now);
+
+        let key = (initiator_addr, target_peer_id);
+        let already_active = inner.slots.contains_key(&key);
+        if !already_active && inner.slots.len() >= self.capacity {
+            // Drop the lock before logging so the warn! call cannot
+            // back-pressure the lock holder under contention.
+            let active = inner.slots.len();
+            drop(inner);
+            let prior = self.backpressure_refusals.fetch_add(1, Ordering::Relaxed);
+            // Log once at first refusal, then periodically.
+            if prior == 0 || (prior + 1).is_multiple_of(REFUSAL_WARN_INTERVAL) {
+                warn!(
+                    "hole-punch coordinator at capacity: refused relay #{} ({}/{} slots in use, initiator={})",
+                    prior + 1,
+                    active,
+                    self.capacity,
+                    initiator_addr,
+                );
+            } else {
+                debug!(
+                    "hole-punch relay refused (back-pressure): initiator={} target={}",
+                    initiator_addr,
+                    hex::encode(&target_peer_id[..8])
+                );
+            }
+            return false;
+        }
+        inner.slots.insert(key, now);
+        true
+    }
+
+    /// Explicitly release every slot owned by `initiator_addr`. Called
+    /// from `BootstrapCoordinator::Drop` when the initiator's connection
+    /// closes, so the table doesn't have to wait out the idle timeout to
+    /// reclaim capacity for a known-dead session.
+    pub(crate) fn release_for_initiator(&self, initiator_addr: SocketAddr) {
+        let mut inner = match self.inner.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        inner.slots.retain(|(addr, _), _| *addr != initiator_addr);
+    }
+
+    /// Total number of relay frames refused since the table was created.
+    pub fn backpressure_refusals(&self) -> u64 {
+        self.backpressure_refusals.load(Ordering::Relaxed)
+    }
+
+    /// Configured capacity (maximum simultaneous active slots).
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Configured idle-release timeout for inactive slots.
+    pub fn idle_timeout(&self) -> Duration {
+        self.idle_timeout
+    }
+
+    /// Snapshot of the current active slot count. Test/diagnostic only;
+    /// callers must treat the value as advisory because the table may
+    /// change between calls.
+    pub fn active_count(&self) -> usize {
+        match self.inner.lock() {
+            Ok(g) => g.slots.len(),
+            Err(poisoned) => poisoned.into_inner().slots.len(),
+        }
+    }
+
+    /// Amortized sweep: prune slots whose last refresh is older than the
+    /// idle timeout, but only if the previous sweep was at least
+    /// [`SWEEP_AMORTIZATION_INTERVAL`] ago. This bounds the per-frame
+    /// retain cost on hot paths while still draining stale entries
+    /// promptly enough to free capacity ahead of the next storm.
+    fn sweep_if_due(inner: &mut RelaySlotTableInner, idle_timeout: Duration, now: Instant) {
+        if now.duration_since(inner.last_swept) < SWEEP_AMORTIZATION_INTERVAL {
+            return;
+        }
+        inner
+            .slots
+            .retain(|_, arrived_at| now.duration_since(*arrived_at) < idle_timeout);
+        inner.last_swept = now;
+    }
+}
+
+impl std::fmt::Debug for RelaySlotTable {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt.debug_struct("RelaySlotTable")
+            .field("capacity", &self.capacity)
+            .field("idle_timeout", &self.idle_timeout)
+            .field(
+                "backpressure_refusals",
+                &self.backpressure_refusals.load(Ordering::Relaxed),
+            )
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn target(byte: u8) -> RelayTargetId {
+        let mut id = [0u8; 32];
+        id[0] = byte;
+        id
+    }
+
+    fn addr(port: u16) -> SocketAddr {
+        SocketAddr::from(([127, 0, 0, 1], port))
+    }
+
+    #[test]
+    fn under_capacity_acquires() {
+        let table = RelaySlotTable::new(4, Duration::from_secs(5));
+        let now = Instant::now();
+        assert!(table.try_acquire(addr(5000), target(0x01), now));
+        assert_eq!(table.active_count(), 1);
+        assert_eq!(table.backpressure_refusals(), 0);
+    }
+
+    #[test]
+    fn at_capacity_refuses_silently() {
+        let table = RelaySlotTable::new(2, Duration::from_secs(5));
+        let now = Instant::now();
+        assert!(table.try_acquire(addr(5000), target(0x01), now));
+        assert!(table.try_acquire(addr(5001), target(0x02), now));
+        assert!(!table.try_acquire(addr(5002), target(0x03), now));
+        assert_eq!(table.active_count(), 2);
+        assert_eq!(table.backpressure_refusals(), 1);
+    }
+
+    #[test]
+    fn re_arm_refreshes_without_consuming_capacity() {
+        let table = RelaySlotTable::new(2, Duration::from_secs(5));
+        let now = Instant::now();
+        assert!(table.try_acquire(addr(5000), target(0x01), now));
+        let later = now + Duration::from_millis(500);
+        assert!(table.try_acquire(addr(5000), target(0x01), later));
+        assert_eq!(
+            table.active_count(),
+            1,
+            "re-arm must not allocate a second slot"
+        );
+    }
+
+    #[test]
+    fn idle_sweep_reclaims_stale_slots() {
+        let timeout = Duration::from_secs(5);
+        let table = RelaySlotTable::new(2, timeout);
+        let now = Instant::now();
+        assert!(table.try_acquire(addr(5000), target(0x01), now));
+        assert!(table.try_acquire(addr(5001), target(0x02), now));
+        // Past idle timeout AND past sweep amortization interval.
+        let much_later = now + timeout + Duration::from_secs(1);
+        assert!(table.try_acquire(addr(5002), target(0x03), much_later));
+        assert_eq!(
+            table.active_count(),
+            1,
+            "stale slots reclaimed by inline sweep before the cap check"
+        );
+        assert_eq!(table.backpressure_refusals(), 0);
+    }
+
+    #[test]
+    fn release_for_initiator_drops_owned_slots_only() {
+        let table = RelaySlotTable::new(8, Duration::from_secs(5));
+        let now = Instant::now();
+        // Two distinct sessions for initiator A.
+        assert!(table.try_acquire(addr(5000), target(0x01), now));
+        assert!(table.try_acquire(addr(5000), target(0x02), now));
+        // One session for a different initiator B.
+        assert!(table.try_acquire(addr(5999), target(0x03), now));
+        assert_eq!(table.active_count(), 3);
+
+        table.release_for_initiator(addr(5000));
+        assert_eq!(
+            table.active_count(),
+            1,
+            "release must drop slots for the named initiator only"
+        );
+        // The B slot is still there.
+        let later = now + Duration::from_millis(50);
+        assert!(table.try_acquire(addr(5999), target(0x03), later));
+        assert_eq!(table.active_count(), 1);
+    }
+
+    #[test]
+    fn refusal_count_accumulates_across_distinct_targets() {
+        let table = RelaySlotTable::new(1, Duration::from_secs(5));
+        let now = Instant::now();
+        assert!(table.try_acquire(addr(5000), target(0x01), now));
+        // Three distinct refusals at the same instant — sweep won't fire.
+        assert!(!table.try_acquire(addr(5001), target(0x02), now));
+        assert!(!table.try_acquire(addr(5002), target(0x03), now));
+        assert!(!table.try_acquire(addr(5003), target(0x04), now));
+        assert_eq!(table.backpressure_refusals(), 3);
+    }
+}

--- a/src/unified_config.rs
+++ b/src/unified_config.rs
@@ -145,6 +145,29 @@ pub struct NatConfig {
     /// Default: `false`
     pub allow_loopback: bool,
 
+    /// Cap on simultaneous in-flight hole-punch coordinator sessions
+    /// **across the entire node** (Tier 4 lite back-pressure). When the
+    /// shared `RelaySlotTable` is at capacity, additional `PUNCH_ME_NOW`
+    /// relay frames are silently refused so the initiator's per-attempt
+    /// timeout (Tier 2 rotation) can advance to its next preferred
+    /// coordinator. See
+    /// [`crate::nat_traversal_api::NatTraversalConfig::coordinator_max_active_relays`]
+    /// for the full rationale.
+    ///
+    /// Default: 32.
+    pub coordinator_max_active_relays: usize,
+
+    /// Idle-release timeout for an in-flight coordinator relay session.
+    /// A slot lasts from the first `PUNCH_ME_NOW` until either the
+    /// owning connection closes (immediate release) or this many
+    /// seconds with no further rounds for the same
+    /// `(initiator_addr, target_peer_id)` pair. See
+    /// [`crate::nat_traversal_api::NatTraversalConfig::coordinator_relay_slot_idle_timeout`]
+    /// for the full rationale.
+    ///
+    /// Default: 5 seconds.
+    pub coordinator_relay_slot_idle_timeout: Duration,
+
     /// Best-effort UPnP IGD port mapping configuration. When enabled
     /// (default), the endpoint asks the local router to forward its UDP
     /// port and surfaces the resulting public address as a high-priority
@@ -163,6 +186,10 @@ impl Default for NatConfig {
             max_concurrent_attempts: 3,
             prefer_rfc_nat_traversal: true,
             allow_loopback: false,
+            coordinator_max_active_relays:
+                crate::nat_traversal_api::NatTraversalConfig::DEFAULT_COORDINATOR_MAX_ACTIVE_RELAYS,
+            coordinator_relay_slot_idle_timeout:
+                crate::nat_traversal_api::NatTraversalConfig::DEFAULT_COORDINATOR_RELAY_SLOT_IDLE_TIMEOUT,
             upnp: crate::upnp::UpnpConfig::default(),
         }
     }
@@ -317,10 +344,8 @@ impl P2pConfig {
             transport_registry: Some(Arc::new(self.transport_registry.clone())),
             max_message_size: self.max_message_size,
             allow_loopback: self.nat.allow_loopback,
-            coordinator_max_active_relays:
-                crate::nat_traversal_api::NatTraversalConfig::DEFAULT_COORDINATOR_MAX_ACTIVE_RELAYS,
-            coordinator_relay_slot_timeout:
-                crate::nat_traversal_api::NatTraversalConfig::DEFAULT_COORDINATOR_RELAY_SLOT_TIMEOUT,
+            coordinator_max_active_relays: self.nat.coordinator_max_active_relays,
+            coordinator_relay_slot_idle_timeout: self.nat.coordinator_relay_slot_idle_timeout,
             upnp: self.nat.upnp.clone(),
         }
     }

--- a/src/unified_config.rs
+++ b/src/unified_config.rs
@@ -317,6 +317,10 @@ impl P2pConfig {
             transport_registry: Some(Arc::new(self.transport_registry.clone())),
             max_message_size: self.max_message_size,
             allow_loopback: self.nat.allow_loopback,
+            coordinator_max_active_relays:
+                crate::nat_traversal_api::NatTraversalConfig::DEFAULT_COORDINATOR_MAX_ACTIVE_RELAYS,
+            coordinator_relay_slot_timeout:
+                crate::nat_traversal_api::NatTraversalConfig::DEFAULT_COORDINATOR_RELAY_SLOT_TIMEOUT,
             upnp: self.nat.upnp.clone(),
         }
     }

--- a/tests/relay_queue_tests.rs
+++ b/tests/relay_queue_tests.rs
@@ -56,7 +56,7 @@ mod nat_traversal_api_tests {
             max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
             allow_loopback: false,
             coordinator_max_active_relays: 32,
-            coordinator_relay_slot_timeout: Duration::from_secs(5),
+            coordinator_relay_slot_idle_timeout: Duration::from_secs(5),
             upnp: Default::default(),
         };
 
@@ -195,7 +195,7 @@ mod functional_tests {
             max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
             allow_loopback: false,
             coordinator_max_active_relays: 32,
-            coordinator_relay_slot_timeout: Duration::from_secs(5),
+            coordinator_relay_slot_idle_timeout: Duration::from_secs(5),
             upnp: Default::default(),
         };
 
@@ -224,7 +224,7 @@ mod functional_tests {
             max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
             allow_loopback: false,
             coordinator_max_active_relays: 32,
-            coordinator_relay_slot_timeout: Duration::from_secs(5),
+            coordinator_relay_slot_idle_timeout: Duration::from_secs(5),
             upnp: Default::default(),
         };
 
@@ -419,7 +419,7 @@ mod performance_tests {
                 max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
                 allow_loopback: false,
                 coordinator_max_active_relays: 32,
-                coordinator_relay_slot_timeout: Duration::from_secs(5),
+                coordinator_relay_slot_idle_timeout: Duration::from_secs(5),
                 upnp: Default::default(),
             };
 
@@ -492,7 +492,7 @@ mod relay_functionality_tests {
             max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
             allow_loopback: false,
             coordinator_max_active_relays: 32,
-            coordinator_relay_slot_timeout: Duration::from_secs(5),
+            coordinator_relay_slot_idle_timeout: Duration::from_secs(5),
             upnp: Default::default(),
         };
 

--- a/tests/relay_queue_tests.rs
+++ b/tests/relay_queue_tests.rs
@@ -55,6 +55,8 @@ mod nat_traversal_api_tests {
             transport_registry: None,
             max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
             allow_loopback: false,
+            coordinator_max_active_relays: 32,
+            coordinator_relay_slot_timeout: Duration::from_secs(5),
             upnp: Default::default(),
         };
 
@@ -192,6 +194,8 @@ mod functional_tests {
             transport_registry: None,
             max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
             allow_loopback: false,
+            coordinator_max_active_relays: 32,
+            coordinator_relay_slot_timeout: Duration::from_secs(5),
             upnp: Default::default(),
         };
 
@@ -219,6 +223,8 @@ mod functional_tests {
             transport_registry: None,
             max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
             allow_loopback: false,
+            coordinator_max_active_relays: 32,
+            coordinator_relay_slot_timeout: Duration::from_secs(5),
             upnp: Default::default(),
         };
 
@@ -412,6 +418,8 @@ mod performance_tests {
                 transport_registry: None,
                 max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
                 allow_loopback: false,
+                coordinator_max_active_relays: 32,
+                coordinator_relay_slot_timeout: Duration::from_secs(5),
                 upnp: Default::default(),
             };
 
@@ -483,6 +491,8 @@ mod relay_functionality_tests {
             transport_registry: None,
             max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
             allow_loopback: false,
+            coordinator_max_active_relays: 32,
+            coordinator_relay_slot_timeout: Duration::from_secs(5),
             upnp: Default::default(),
         };
 

--- a/tests/security_regression_tests.rs
+++ b/tests/security_regression_tests.rs
@@ -38,7 +38,7 @@ fn test_peer_config() -> NatTraversalConfig {
         max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
         allow_loopback: true,
         coordinator_max_active_relays: 32,
-        coordinator_relay_slot_timeout: Duration::from_secs(5),
+        coordinator_relay_slot_idle_timeout: Duration::from_secs(5),
         upnp: Default::default(),
     }
 }
@@ -65,7 +65,7 @@ fn test_server_config() -> NatTraversalConfig {
         max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
         allow_loopback: true,
         coordinator_max_active_relays: 32,
-        coordinator_relay_slot_timeout: Duration::from_secs(5),
+        coordinator_relay_slot_idle_timeout: Duration::from_secs(5),
         upnp: Default::default(),
     }
 }
@@ -115,7 +115,7 @@ async fn test_error_handling_no_panic() {
         max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
         allow_loopback: true,
         coordinator_max_active_relays: 32,
-        coordinator_relay_slot_timeout: Duration::from_secs(5),
+        coordinator_relay_slot_idle_timeout: Duration::from_secs(5),
         upnp: Default::default(),
     };
 
@@ -146,7 +146,7 @@ async fn test_error_handling_no_panic() {
         max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
         allow_loopback: true,
         coordinator_max_active_relays: 32,
-        coordinator_relay_slot_timeout: Duration::from_secs(5),
+        coordinator_relay_slot_idle_timeout: Duration::from_secs(5),
         upnp: Default::default(),
     };
 
@@ -240,7 +240,7 @@ async fn test_malformed_config_handling() {
         max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
         allow_loopback: true,
         coordinator_max_active_relays: 32,
-        coordinator_relay_slot_timeout: Duration::from_secs(5),
+        coordinator_relay_slot_idle_timeout: Duration::from_secs(5),
         upnp: Default::default(),
     };
 
@@ -272,7 +272,7 @@ async fn test_malformed_config_handling() {
         max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
         allow_loopback: true,
         coordinator_max_active_relays: 32,
-        coordinator_relay_slot_timeout: Duration::from_secs(5),
+        coordinator_relay_slot_idle_timeout: Duration::from_secs(5),
         upnp: Default::default(),
     };
 
@@ -311,7 +311,7 @@ async fn test_input_sanitization() {
         max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
         allow_loopback: true,
         coordinator_max_active_relays: 32,
-        coordinator_relay_slot_timeout: Duration::from_secs(5),
+        coordinator_relay_slot_idle_timeout: Duration::from_secs(5),
         upnp: Default::default(),
     };
 
@@ -385,7 +385,7 @@ mod specific_regression_tests {
             max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
             allow_loopback: true,
             coordinator_max_active_relays: 32,
-            coordinator_relay_slot_timeout: Duration::from_secs(5),
+            coordinator_relay_slot_idle_timeout: Duration::from_secs(5),
             upnp: Default::default(),
         };
 
@@ -439,7 +439,7 @@ mod specific_regression_tests {
             max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
             allow_loopback: true,
             coordinator_max_active_relays: 32,
-            coordinator_relay_slot_timeout: Duration::from_secs(5),
+            coordinator_relay_slot_idle_timeout: Duration::from_secs(5),
             upnp: Default::default(),
         };
 

--- a/tests/security_regression_tests.rs
+++ b/tests/security_regression_tests.rs
@@ -37,6 +37,8 @@ fn test_peer_config() -> NatTraversalConfig {
         transport_registry: None,
         max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
         allow_loopback: true,
+        coordinator_max_active_relays: 32,
+        coordinator_relay_slot_timeout: Duration::from_secs(5),
         upnp: Default::default(),
     }
 }
@@ -62,6 +64,8 @@ fn test_server_config() -> NatTraversalConfig {
         transport_registry: None,
         max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
         allow_loopback: true,
+        coordinator_max_active_relays: 32,
+        coordinator_relay_slot_timeout: Duration::from_secs(5),
         upnp: Default::default(),
     }
 }
@@ -110,6 +114,8 @@ async fn test_error_handling_no_panic() {
         transport_registry: None,
         max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
         allow_loopback: true,
+        coordinator_max_active_relays: 32,
+        coordinator_relay_slot_timeout: Duration::from_secs(5),
         upnp: Default::default(),
     };
 
@@ -139,6 +145,8 @@ async fn test_error_handling_no_panic() {
         transport_registry: None,
         max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
         allow_loopback: true,
+        coordinator_max_active_relays: 32,
+        coordinator_relay_slot_timeout: Duration::from_secs(5),
         upnp: Default::default(),
     };
 
@@ -231,6 +239,8 @@ async fn test_malformed_config_handling() {
         transport_registry: None,
         max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
         allow_loopback: true,
+        coordinator_max_active_relays: 32,
+        coordinator_relay_slot_timeout: Duration::from_secs(5),
         upnp: Default::default(),
     };
 
@@ -261,6 +271,8 @@ async fn test_malformed_config_handling() {
         transport_registry: None,
         max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
         allow_loopback: true,
+        coordinator_max_active_relays: 32,
+        coordinator_relay_slot_timeout: Duration::from_secs(5),
         upnp: Default::default(),
     };
 
@@ -298,6 +310,8 @@ async fn test_input_sanitization() {
         transport_registry: None,
         max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
         allow_loopback: true,
+        coordinator_max_active_relays: 32,
+        coordinator_relay_slot_timeout: Duration::from_secs(5),
         upnp: Default::default(),
     };
 
@@ -370,6 +384,8 @@ mod specific_regression_tests {
             transport_registry: None,
             max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
             allow_loopback: true,
+            coordinator_max_active_relays: 32,
+            coordinator_relay_slot_timeout: Duration::from_secs(5),
             upnp: Default::default(),
         };
 
@@ -422,6 +438,8 @@ mod specific_regression_tests {
             transport_registry: None,
             max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
             allow_loopback: true,
+            coordinator_max_active_relays: 32,
+            coordinator_relay_slot_timeout: Duration::from_secs(5),
             upnp: Default::default(),
         };
 


### PR DESCRIPTION
## Summary
- Replaces the single-coordinator hole-punch hint with a ranked list (Tier 2): callers supply best-first, the connect loop rotates through them with a short per-attempt timeout (1.5s) for non-final candidates and the strategy's full timeout for the last. Worst-case wait drops from `K * 8s` to `(K-1) * 1.5s + 8s`.
- Adds coordinator-side back-pressure (Tier 4 lite): `BootstrapCoordinator` tracks active relay slots keyed by `(initiator_peer_id, target_peer_id)` and silently refuses incoming `PUNCH_ME_NOW` relays once at capacity. Inline garbage-collection sweep reclaims stale slots so ghost sessions cannot leak the counter. Configurable via two new `NatTraversalConfig` fields: `coordinator_max_active_relays` (default 32) and `coordinator_relay_slot_timeout` (default 5s).
- No wire-protocol changes — back-pressure is purely timing-based (silent refusal triggers Tier 2 rotation on the initiator). Backwards-compatible with older peers.

## Why
Today every cold-starting peer pins one of the small set of bootstrap nodes (saorsa-2 / saorsa-3) as its hole-punch coordinator, concentrating active coordinator load on infrastructure that is already serving DHT traffic. With this change a single overloaded coordinator stops blocking the dial: the initiator times out fast (1.5s) and rotates to the next preferred candidate, and the coordinator itself sheds excess load by silently refusing relays once it has 32 in flight.

## Design choice
Considered an explicit \`HOLE_PUNCH_COORDINATOR_BUSY\` wire frame for instant initiator notification but the cost — new frame type, codec, parser dispatch, version compatibility — was not justified. Timing-based back-pressure wastes ~1.5s per busy coordinator but ships in roughly 1/3 the code with zero protocol surface and is fully backwards-compatible.

## Test plan
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --all-targets -- -D warnings -D clippy::unwrap_used -D clippy::expect_used\` clean
- [x] \`cargo test --lib\` passes (1480 tests, +10 new)
- [x] 5 new unit tests for \`P2pEndpoint::merge_preferred_coordinators\`: empty preferred no-op, front insertion in order, dedup of pre-existing entries, non-preferred entries keep their original order, empty candidate list
- [x] 5 new unit tests for \`BootstrapCoordinator\` back-pressure: under-capacity accept, at-capacity silent refuse with stat increment, slot re-arm without consuming additional capacity, sweep reclaims stale slots, non-relay frames do not consume slots
- [x] No breaking API changes — old \`set_hole_punch_preferred_coordinator\` is retained as a thin wrapper around the new list form

## Companion PR
Second of three PRs landing smarter hole-punch coordinator selection. The first (saorsa-labs/saorsa-core#TBD) added round-aware referrer ranking in the DHT layer and is independent of this one. The third will wire saorsa-core to call the new \`set_hole_punch_preferred_coordinators\` API once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements two back-pressure improvements to hole-punch coordinator selection: a ranked coordinator list with per-attempt rotation (Tier 2) where non-final candidates get a 1.5s quick timeout before advancing to the next, and a node-wide `RelaySlotTable` (Tier 4 lite) that caps simultaneous in-flight `(initiator_addr, target_peer_id)` relay sessions and silently refuses when at capacity. The implementation is correct, well-documented, and well-tested (10 new unit tests), and the previously flagged concern about `P2pConfig::to_nat_config()` not propagating the new fields has been addressed — both `coordinator_max_active_relays` and `coordinator_relay_slot_idle_timeout` flow correctly through `NatConfig` → `to_nat_config()` → `NatTraversalConfig` → `RelaySlotTable::new`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no P0 or P1 issues found; implementation is correct, well-tested, and well-documented.

All 10 changed/new files reviewed thoroughly. The relay slot table logic, rotation bounds, lock ordering, config propagation, and Drop-based cleanup are all correct. Prior review concerns about `to_nat_config()` propagation were addressed. Remaining observations (duplicate-preferred inefficiency, stale `relay_initiator_addr` on QUIC migration) are P2 edge cases bounded by the 5s idle timeout and do not affect correctness or reliability in normal operation.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/relay_slot_table.rs | New node-wide back-pressure table; lock-drop-before-warn pattern is correct, amortized sweep bounds per-frame cost, 6 focused inline tests cover all code paths |
| src/p2p_endpoint.rs | Adds `merge_preferred_coordinators` (O(N+M), correct dedup), rotation index arithmetic is bounds-safe, `debug_assert` guards sync between index and strategy coordinator, 5 new unit tests |
| src/connection/nat_traversal.rs | `BootstrapCoordinator` correctly threads `relay_slot_table` Arc; `Drop` releases initiator slots; `relay_initiator_addr` captured once (stale on migration, but bounded by 5s idle timeout) |
| src/nat_traversal_api.rs | New config fields with serde defaults and validation; single `RelaySlotTable` Arc shared via clone across both server and client `TransportConfig` — cap is correctly node-wide |
| src/unified_config.rs | `NatConfig` gains both new fields with correct defaults; `to_nat_config()` propagates them to `NatTraversalConfig` (addresses prior review concern) |
| src/config/transport.rs | `relay_slot_table: Option<Arc<RelaySlotTable>>` added to `TransportConfig`; defaults to `None` for Quinn-style fixtures that bypass `P2pEndpoint` |
| src/connection/mod.rs | Both `NatTraversalState::new` call sites correctly thread `self.config.relay_slot_table.clone()` from the frozen config |
| src/lib.rs | Exposes `pub mod relay_slot_table`; no other changes |
| tests/relay_queue_tests.rs | Existing test struct literals updated with new `NatTraversalConfig` fields; no logic changes |
| tests/security_regression_tests.rs | Existing test helpers updated with new `NatTraversalConfig` fields; no logic changes |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant I as Initiator
    participant C1 as Coordinator 1 (preferred)
    participant C2 as Coordinator 2 (preferred)
    participant C3 as Coordinator 3 (fallback)
    participant T as Target

    Note over I: set_hole_punch_preferred_coordinators([C1, C2])
    Note over I: preferred_coordinator_count = 2

    I->>C1: PUNCH_ME_NOW (attempt 1)
    Note over C1: try_acquire slot → capacity check
    alt C1 at capacity (Tier 4 back-pressure)
        C1-->>I: silent drop (no reply)
        Note over I: PER_COORDINATOR_QUICK_HOLEPUNCH_TIMEOUT (1.5s)
    else C1 available
        C1->>T: PUNCH_ME_NOW relay
        T-->>I: QUIC connection attempt
    end

    Note over I: Timeout after 1.5s → rotate
    Note over I: current_preferred_coordinator_idx = 0 → 1
    Note over I: is_final_rotation_attempt = true (1+1 >= 2)

    I->>C2: PUNCH_ME_NOW (attempt 2, full strategy timeout ~8s)
    alt C2 available
        C2->>T: PUNCH_ME_NOW relay
        T->>I: QUIC connection (success)
    else C2 fails / times out
        Note over I: should_retry_holepunch()?
        alt retry budget remaining
            I->>C2: retry with C2
        else exhausted
            I->>C3: MASQUE relay fallback
        end
    end
```

<sub>**[Greploops](https://www.greptile.com/docs/mcp-v2/skills#greploop)** — Automatically fix all review issues by running `/greploops` in [Claude Code](https://claude.ai/download). It iterates: fix, push, re-review, repeat until 5/5 confidence.<br>Use the **[Greptile plugin for Claude Code](https://www.greptile.com/docs/integrations/claude-code#claude-code-plugin)** to query reviews, search comments, and manage custom context directly from your terminal.</sub>

<sub>Reviews (2): Last reviewed commit: ["refactor!(nat): node-wide coordinator ba..."](https://github.com/saorsa-labs/saorsa-transport/commit/7f2887e8a667ba5b8e60babdd58d0f71da6631ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27517702)</sub>

<!-- /greptile_comment -->