### PR TITLE
fix(reachability): replace has_public_ip with scope-aware peer-verified direct reachability

### DIFF
--- a/examples/simple_p2p.rs
+++ b/examples/simple_p2p.rs
@@ -39,6 +39,7 @@ async fn main() -> anyhow::Result<()> {
                     addr,
                     public_key,
                     side,
+                    ..
                 } => {
                     println!(
                         "Connected to peer at {} (side: {:?}, has key: {})",

--- a/src/bin/e2e-test-node.rs
+++ b/src/bin/e2e-test-node.rs
@@ -713,6 +713,7 @@ async fn handle_event(
             addr,
             public_key: _,
             side,
+            traversal_method: _,
         } => {
             let direction = if side.is_client() {
                 "outbound"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,8 +203,8 @@ pub mod tracing;
 /// Best-effort UPnP IGD port mapping for NAT traversal assistance.
 ///
 /// This module is feature-gated behind `upnp` (enabled by default). When
-/// disabled, [`UpnpMappingService`] is still present but is a no-op stub
-/// that always reports [`UpnpState::Unavailable`].
+/// disabled, [`upnp::UpnpMappingService`] is still present but is a no-op stub
+/// that always reports [`upnp::UpnpState::Unavailable`].
 pub mod upnp;
 
 // Public modules with new structure

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,6 +168,9 @@ pub mod node_status;
 /// Unified events for P2P nodes
 pub mod node_event;
 
+/// Reachability scope and traversal metadata shared across APIs
+pub mod reachability;
+
 // Core implementation modules
 /// Configuration structures and validation
 pub mod config;
@@ -333,6 +336,7 @@ pub use nat_traversal_api::{
     BootstrapNode, CandidateAddress, NatTraversalConfig, NatTraversalEndpoint, NatTraversalError,
     NatTraversalEvent, NatTraversalStatistics,
 };
+pub use reachability::{ReachabilityScope, TraversalMethod};
 
 // ============================================================================
 // SIMPLE API EXPORTS - Zero Configuration P2P (RECOMMENDED)
@@ -348,7 +352,7 @@ pub use node_config::{NodeConfig, NodeConfigBuilder};
 pub use node_status::{NatType, NodeStatus};
 
 /// Unified events for P2P nodes
-pub use node_event::{DisconnectReason as NodeDisconnectReason, NodeEvent, TraversalMethod};
+pub use node_event::{DisconnectReason as NodeDisconnectReason, NodeEvent};
 
 // ============================================================================
 // P2P API EXPORTS (for advanced use)

--- a/src/link_transport.rs
+++ b/src/link_transport.rs
@@ -1030,7 +1030,7 @@ pub type BoxStream<'a, T> = Pin<Box<dyn futures_util::Stream<Item = T> + Send + 
 ///
 /// This trait abstracts a single QUIC connection, providing methods to
 /// open streams and send/receive datagrams. Connections are obtained via
-/// [`LinkTransport::dial`] or [`LinkTransport::accept`].
+/// [`LinkTransport::dial_addr`] or [`LinkTransport::accept`].
 ///
 /// # Stream Types
 ///

--- a/src/link_transport.rs
+++ b/src/link_transport.rs
@@ -624,6 +624,9 @@ pub struct Capabilities {
     /// Observed external addresses for this peer.
     pub observed_addrs: Vec<SocketAddr>,
 
+    /// Broadest direct reachability scope verified for this connected peer.
+    pub direct_reachability_scope: Option<crate::reachability::ReachabilityScope>,
+
     /// Protocols this peer advertises support for.
     pub protocols: Vec<ProtocolId>,
 
@@ -661,6 +664,7 @@ impl Default for Capabilities {
             supports_relay: false,
             supports_coordination: false,
             observed_addrs: Vec::new(),
+            direct_reachability_scope: None,
             protocols: Vec::new(),
             last_seen: SystemTime::UNIX_EPOCH,
             rtt_ms_p50: 0,

--- a/src/link_transport_impl.rs
+++ b/src/link_transport_impl.rs
@@ -489,7 +489,7 @@ impl P2pLinkTransport {
                         P2pEvent::PeerConnected {
                             addr,
                             public_key,
-                            side: _,
+                            side,
                             traversal_method,
                         } => {
                             // Extract SocketAddr (currently UDP-only)
@@ -498,7 +498,12 @@ impl P2pLinkTransport {
                                 SocketAddr::from(([0, 0, 0, 0], 0))
                             });
                             let mut caps = Capabilities::new_connected(socket_addr);
-                            if traversal_method.is_direct() {
+                            // Only promote relay/coordinator when we connected to
+                            // them directly (Client side), proving they accept
+                            // inbound connections. A peer that connected to us
+                            // (Server side) only proves they can make outbound
+                            // connections, not that they are reachable by others.
+                            if traversal_method.is_direct() && side.is_client() {
                                 caps.supports_relay = true;
                                 caps.supports_coordination = true;
                                 caps.direct_reachability_scope =

--- a/src/link_transport_impl.rs
+++ b/src/link_transport_impl.rs
@@ -490,13 +490,20 @@ impl P2pLinkTransport {
                             addr,
                             public_key,
                             side: _,
+                            traversal_method,
                         } => {
                             // Extract SocketAddr (currently UDP-only)
                             let socket_addr = addr.as_socket_addr().unwrap_or_else(|| {
                                 // Fallback for non-UDP transports - use unspecified address
                                 SocketAddr::from(([0, 0, 0, 0], 0))
                             });
-                            let caps = Capabilities::new_connected(socket_addr);
+                            let mut caps = Capabilities::new_connected(socket_addr);
+                            if traversal_method.is_direct() {
+                                caps.supports_relay = true;
+                                caps.supports_coordination = true;
+                                caps.direct_reachability_scope =
+                                    crate::reachability::socket_addr_scope(socket_addr);
+                            }
                             // Update capabilities cache keyed by address
                             if let Ok(mut state) = state.write() {
                                 state.capabilities.insert(socket_addr, caps.clone());
@@ -537,6 +544,9 @@ impl P2pLinkTransport {
                             if let Ok(mut state) = state.write() {
                                 if let Some(caps) = state.capabilities.get_mut(&socket_addr) {
                                     caps.is_connected = false;
+                                    caps.supports_relay = false;
+                                    caps.supports_coordination = false;
+                                    caps.direct_reachability_scope = None;
                                 }
                             }
                             Some(LinkEvent::PeerDisconnected {

--- a/src/masque/relay_server.rs
+++ b/src/masque/relay_server.rs
@@ -868,7 +868,7 @@ impl MasqueRelayServer {
     /// of unreliable QUIC datagrams. This avoids the MTU limitation that causes
     /// "datagram too large" errors for QUIC Initial packets (1200+ bytes).
     ///
-    /// Protocol: each forwarded packet is framed as [4-byte BE length][payload].
+    /// Protocol: each forwarded packet is framed as \[4-byte BE length\]\[payload\].
     pub async fn run_stream_forwarding_loop(
         self: &Arc<Self>,
         session_id: u64,

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -479,7 +479,7 @@ pub struct NatTraversalConfig {
     /// Internally tunes the QUIC per-stream receive window so that a single
     /// message of this size can be transmitted without flow-control rejection.
     ///
-    /// Default: [`P2pConfig::DEFAULT_MAX_MESSAGE_SIZE`] (1 MiB).
+    /// Default: [`crate::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE`] (1 MiB).
     #[serde(default = "default_max_message_size")]
     pub max_message_size: usize,
 

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -15,6 +15,7 @@
 use std::{fmt, net::SocketAddr, sync::Arc, time::Duration};
 
 use crate::constrained::{ConstrainedEngine, EngineConfig, EngineEvent};
+use crate::reachability::TraversalMethod;
 use crate::transport::TransportRegistry;
 
 use crate::SHUTDOWN_DRAIN_TIMEOUT;
@@ -1042,6 +1043,8 @@ pub enum NatTraversalEvent {
         remote_address: SocketAddr,
         /// Who initiated the connection (Client = we connected, Server = they connected)
         side: Side,
+        /// Whether the connection was direct, hole-punched, or relayed.
+        traversal_method: TraversalMethod,
         /// ML-DSA-65 public key extracted from the TLS identity, if available
         public_key: Option<Vec<u8>>,
     },
@@ -2976,6 +2979,7 @@ impl NatTraversalEndpoint {
                                         event_tx.send(NatTraversalEvent::ConnectionEstablished {
                                             remote_address,
                                             side: Side::Server,
+                                            traversal_method: TraversalMethod::Direct,
                                             public_key,
                                         });
                                     incoming_notify.notify_one();
@@ -3346,6 +3350,7 @@ impl NatTraversalEndpoint {
             let _ = event_tx.send(NatTraversalEvent::ConnectionEstablished {
                 remote_address: remote_addr,
                 side: Side::Client,
+                traversal_method: TraversalMethod::Direct,
                 public_key,
             });
             self.incoming_notify.notify_one();
@@ -3961,11 +3966,13 @@ impl NatTraversalEndpoint {
     /// * `addr` - The remote address of the connection
     /// * `connection` - The established QUIC connection
     /// * `side` - Who initiated the connection (Client = we connected, Server = they connected)
+    /// * `traversal_method` - Whether the path is direct, hole-punched, or relayed
     pub fn spawn_connection_handler(
         &self,
         addr: SocketAddr,
         connection: InnerConnection,
         side: Side,
+        traversal_method: TraversalMethod,
     ) -> Result<(), NatTraversalError> {
         let event_tx = self.event_tx.as_ref().cloned().ok_or_else(|| {
             NatTraversalError::ConfigError("NAT traversal event channel not configured".to_string())
@@ -3982,6 +3989,7 @@ impl NatTraversalEndpoint {
             let _ = event_tx.send(NatTraversalEvent::ConnectionEstablished {
                 remote_address,
                 side,
+                traversal_method,
                 public_key,
             });
             self.incoming_notify.notify_one();
@@ -4917,6 +4925,7 @@ impl NatTraversalEndpoint {
                                         event_tx.send(NatTraversalEvent::ConnectionEstablished {
                                             remote_address: remote,
                                             side: Side::Client,
+                                            traversal_method: TraversalMethod::HolePunch,
                                             public_key,
                                         });
                                     incoming_notify.notify_one();
@@ -6631,6 +6640,7 @@ impl NatTraversalEndpoint {
             callback(NatTraversalEvent::ConnectionEstablished {
                 remote_address: candidate_address,
                 side: Side::Client,
+                traversal_method: TraversalMethod::HolePunch,
                 public_key,
             });
         }
@@ -6717,26 +6727,6 @@ impl NatTraversalEndpoint {
         } else {
             Err(NatTraversalError::PeerNotConnected)
         }
-    }
-
-    /// Get NAT traversal statistics
-    #[allow(clippy::panic)]
-    pub fn get_nat_stats(
-        &self,
-    ) -> Result<NatTraversalStatistics, Box<dyn std::error::Error + Send + Sync>> {
-        // Return default statistics for now
-        // In a real implementation, this would collect actual stats from the endpoint
-        Ok(NatTraversalStatistics {
-            active_sessions: self.active_sessions.len(),
-            // parking_lot::RwLock doesn't poison - always succeeds
-            total_bootstrap_nodes: self.bootstrap_nodes.read().len(),
-            successful_coordinations: 7,
-            average_coordination_time: self.timeout_config.nat_traversal.retry_interval,
-            total_attempts: 10,
-            successful_connections: 7,
-            direct_connections: 5,
-            relayed_connections: 2,
-        })
     }
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -56,6 +56,7 @@ use crate::node_config::NodeConfig;
 use crate::node_event::NodeEvent;
 use crate::node_status::{NatType, NodeStatus};
 use crate::p2p_endpoint::{EndpointError, P2pEndpoint, P2pEvent, PeerConnection};
+use crate::reachability::{DIRECT_REACHABILITY_TTL, socket_addr_scope};
 use crate::unified_config::P2pConfig;
 use crate::unified_config::load_or_generate_endpoint_keypair;
 
@@ -328,10 +329,12 @@ impl Node {
                 addr,
                 public_key,
                 side: _,
+                traversal_method,
             } => Some(NodeEvent::PeerConnected {
                 addr,
                 public_key,
-                direct: true, // P2pEvent doesn't distinguish, assume direct
+                method: traversal_method,
+                direct: traversal_method.is_direct(),
             }),
             P2pEvent::PeerDisconnected { addr, reason } => Some(NodeEvent::PeerDisconnected {
                 addr: addr.to_synthetic_socket_addr(),
@@ -502,22 +505,15 @@ impl Node {
     /// ```
     pub async fn status(&self) -> NodeStatus {
         let stats = self.inner.stats().await;
-        let nat_stats = self.inner.nat_stats().ok();
         let connected_peers = self.inner.connected_peers().await;
 
-        // Determine NAT type from stats
-        let nat_type = self.detect_nat_type(&stats, nat_stats.as_ref());
+        // Determine NAT type from observed connection outcomes only.
+        let nat_type = self.detect_nat_type(&stats);
 
-        // Check if we have public IP
+        // Address knowledge and reachability are separate concepts.
+        // A global address is not proof of direct reachability.
         let local_addr = self.local_addr();
         let external_addr = self.external_addr();
-        let has_public_ip = match (local_addr, external_addr) {
-            (Some(local), Some(external)) => {
-                // Public if external matches local (ignoring port differences)
-                local.ip() == external.ip()
-            }
-            _ => false,
-        };
 
         // Collect external addresses
         let mut external_addrs = Vec::new();
@@ -532,34 +528,48 @@ impl Node {
             0.0
         };
 
-        // Determine if we can help with traversal
-        let can_receive_direct =
-            has_public_ip || nat_type == NatType::FullCone || nat_type == NatType::None;
+        let has_global_address = external_addrs
+            .iter()
+            .copied()
+            .chain(local_addr)
+            .any(|addr| {
+                socket_addr_scope(addr)
+                    .is_some_and(|scope| scope == crate::ReachabilityScope::Global)
+            });
 
-        // Check relay status from NAT stats
-        // Currently, relay status is indicated by having relayed_connections > 0
-        // and active sessions that may be acting as relays
-        let (is_relaying, relay_sessions, relay_bytes_forwarded) = if let Some(ref nat) = nat_stats
-        {
-            // If we have any active sessions and are accepting connections,
-            // we're potentially relaying
-            let relaying = nat.relayed_connections > 0 && can_receive_direct;
+        // A node is directly reachable only after fresh, peer-verified direct
+        // inbound evidence. Scope is freshness-aware too, so an old global
+        // observation cannot keep inflating current reachability.
+        let fresh_scope = [
             (
-                relaying,
-                if relaying { nat.active_sessions } else { 0 },
-                0u64, // Not tracked yet - future enhancement
-            )
-        } else {
-            (false, 0, 0)
-        };
+                crate::ReachabilityScope::Global,
+                stats.last_direct_global_at,
+            ),
+            (
+                crate::ReachabilityScope::LocalNetwork,
+                stats.last_direct_local_at,
+            ),
+            (
+                crate::ReachabilityScope::Loopback,
+                stats.last_direct_loopback_at,
+            ),
+        ]
+        .into_iter()
+        .find_map(|(scope, seen)| {
+            seen.filter(|instant| instant.elapsed() <= DIRECT_REACHABILITY_TTL)
+                .map(|_| scope)
+        });
+        let can_receive_direct =
+            stats.active_direct_incoming_connections > 0 || fresh_scope.is_some();
+        let direct_reachability_scope = fresh_scope;
 
-        // Check coordination status
-        // Any node with active sessions is acting as a coordinator
-        let (is_coordinating, coordination_sessions) = if let Some(ref nat) = nat_stats {
-            (nat.active_sessions > 0, nat.active_sessions)
-        } else {
-            (false, 0)
-        };
+        // Relay/coordinator activity must be backed by real runtime metrics.
+        // The NAT stats path is still placeholder-ish, so stay conservative here.
+        let is_relaying = false;
+        let relay_sessions = 0;
+        let relay_bytes_forwarded = 0u64;
+        let is_coordinating = false;
+        let coordination_sessions = 0;
 
         // Calculate average RTT from connected peers
         let mut total_rtt = Duration::ZERO;
@@ -589,7 +599,8 @@ impl Node {
             external_addrs,
             nat_type,
             can_receive_direct,
-            has_public_ip,
+            direct_reachability_scope,
+            has_global_address,
             connected_peers: connected_peers.len(),
             active_connections: stats.active_connections,
             pending_connections: 0, // Not tracked yet
@@ -655,51 +666,21 @@ impl Node {
     // === Private Helpers ===
 
     /// Detect NAT type from statistics
-    fn detect_nat_type(
-        &self,
-        stats: &crate::p2p_endpoint::EndpointStats,
-        nat_stats: Option<&crate::nat_traversal_api::NatTraversalStatistics>,
-    ) -> NatType {
-        // If we have lots of direct connections and no relayed, likely no/easy NAT
+    fn detect_nat_type(&self, stats: &crate::p2p_endpoint::EndpointStats) -> NatType {
+        // This remains a soft debug hint only. Do not treat it as direct
+        // reachability evidence.
         if stats.direct_connections > 0 && stats.relayed_connections == 0 {
-            if let Some(nat) = nat_stats {
-                // Calculate direct connection rate
-                let total = nat.direct_connections + nat.relayed_connections;
-                if total > 0 {
-                    let direct_rate = nat.direct_connections as f64 / total as f64;
-                    if direct_rate > 0.9 {
-                        return NatType::FullCone;
-                    }
-                }
-            }
-            return NatType::FullCone; // Assume easy NAT if all direct
+            return NatType::FullCone;
         }
 
-        // If we have mixed connections, harder NAT
         if stats.direct_connections > 0 && stats.relayed_connections > 0 {
-            if let Some(nat) = nat_stats {
-                // Calculate success rate from total attempts vs successful connections
-                let success_rate = if nat.total_attempts > 0 {
-                    nat.successful_connections as f64 / nat.total_attempts as f64
-                } else {
-                    0.0
-                };
-
-                if success_rate > 0.7 {
-                    return NatType::PortRestricted;
-                } else if success_rate > 0.3 {
-                    return NatType::AddressRestricted;
-                }
-            }
             return NatType::PortRestricted;
         }
 
-        // If mostly relayed, likely symmetric NAT
         if stats.relayed_connections > stats.direct_connections {
             return NatType::Symmetric;
         }
 
-        // Not enough data yet
         NatType::Unknown
     }
 }

--- a/src/node_event.rs
+++ b/src/node_event.rs
@@ -37,6 +37,7 @@
 use std::net::SocketAddr;
 
 use crate::node_status::NatType;
+pub use crate::reachability::TraversalMethod;
 use crate::transport::TransportAddr;
 
 /// Reason for peer disconnection
@@ -85,7 +86,9 @@ pub enum NodeEvent {
         addr: TransportAddr,
         /// The peer's public key bytes (ML-DSA-65 SPKI), if available from TLS handshake
         public_key: Option<Vec<u8>>,
-        /// Whether this is a direct connection (vs relayed)
+        /// How the connection was established.
+        method: TraversalMethod,
+        /// Whether this is a direct connection (vs relayed or assisted)
         direct: bool,
     },
 
@@ -186,30 +189,6 @@ pub enum NodeEvent {
     },
 }
 
-/// Method used for NAT traversal
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum TraversalMethod {
-    /// Direct connection (no NAT or easy NAT)
-    Direct,
-    /// Hole punching succeeded
-    HolePunch,
-    /// Connection via relay
-    Relay,
-    /// Port prediction for symmetric NAT
-    PortPrediction,
-}
-
-impl std::fmt::Display for TraversalMethod {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Direct => write!(f, "direct"),
-            Self::HolePunch => write!(f, "hole punch"),
-            Self::Relay => write!(f, "relay"),
-            Self::PortPrediction => write!(f, "port prediction"),
-        }
-    }
-}
-
 impl NodeEvent {
     /// Check if this is a connection event
     pub fn is_connection_event(&self) -> bool {
@@ -305,6 +284,7 @@ mod tests {
         let event = NodeEvent::PeerConnected {
             addr: TransportAddr::Udp(test_addr()),
             public_key: None,
+            method: TraversalMethod::Direct,
             direct: true,
         };
 
@@ -417,6 +397,7 @@ mod tests {
         let event = NodeEvent::PeerConnected {
             addr: TransportAddr::Udp(test_addr()),
             public_key: None,
+            method: TraversalMethod::Direct,
             direct: true,
         };
 

--- a/src/node_status.rs
+++ b/src/node_status.rs
@@ -28,15 +28,18 @@
 use std::net::SocketAddr;
 use std::time::Duration;
 
+pub use crate::reachability::ReachabilityScope;
+
 /// Detected NAT type for the node
 ///
 /// NAT type affects connectivity - some types are easier to traverse than others.
 /// The node automatically detects its NAT type and adjusts traversal strategies.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum NatType {
-    /// No NAT detected - direct public connectivity
+    /// No NAT detected.
     ///
-    /// The node has a public IP address and can accept connections directly.
+    /// This indicates the observed path did not require NAT traversal. It does
+    /// not, by itself, prove current direct reachability to other peers.
     None,
 
     /// Full cone NAT - easiest to traverse
@@ -73,7 +76,7 @@ pub enum NatType {
 impl std::fmt::Display for NatType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::None => write!(f, "None (Public IP)"),
+            Self::None => write!(f, "None (No NAT detected)"),
             Self::FullCone => write!(f, "Full Cone"),
             Self::AddressRestricted => write!(f, "Address Restricted"),
             Self::PortRestricted => write!(f, "Port Restricted"),
@@ -91,7 +94,7 @@ impl std::fmt::Display for NatType {
 /// # Status Categories
 ///
 /// - **Identity**: peer_id, local_addr, external_addrs
-/// - **NAT Status**: nat_type, can_receive_direct, has_public_ip
+/// - **NAT Status**: nat_type, can_receive_direct, direct_reachability_scope, has_global_address
 /// - **Connections**: connected_peers, active_connections, pending_connections
 /// - **NAT Traversal**: direct_connections, relayed_connections, hole_punch_success_rate
 /// - **Relay**: is_relaying, relay_sessions, relay_bytes_forwarded
@@ -118,13 +121,17 @@ pub struct NodeStatus {
 
     /// Whether this node can receive direct connections
     ///
-    /// `true` if the node has a public IP or is behind a traversable NAT.
+    /// `true` only after this node has peer-verified evidence that another
+    /// node reached it directly without coordinator or relay assistance.
     pub can_receive_direct: bool,
 
-    /// Whether this node has a public IP
+    /// Broadest scope in which direct inbound reachability has been verified.
+    pub direct_reachability_scope: Option<ReachabilityScope>,
+
+    /// Whether this node has a globally routable address candidate.
     ///
-    /// `true` if local_addr matches an external_addr (no NAT).
-    pub has_public_ip: bool,
+    /// This is an address property, not proof of reachability.
+    pub has_global_address: bool,
 
     // --- Connections ---
     /// Number of connected peers
@@ -151,8 +158,8 @@ pub struct NodeStatus {
     // --- Relay Status (NEW - key visibility) ---
     /// Whether this node is currently acting as a relay for others
     ///
-    /// `true` if this node has public connectivity and is forwarding
-    /// traffic for peers behind restrictive NATs.
+    /// `true` if this node has fresh peer-verified direct reachability and is
+    /// forwarding traffic for peers behind restrictive NATs.
     pub is_relaying: bool,
 
     /// Number of active relay sessions
@@ -165,7 +172,8 @@ pub struct NodeStatus {
     /// Whether this node is coordinating NAT traversal
     ///
     /// `true` if this node is helping peers coordinate hole punching.
-    /// All nodes with public connectivity act as coordinators.
+    /// Fresh peer-verified direct reachability is the signal other peers should
+    /// use when deciding whether this node is a viable coordinator.
     pub is_coordinating: bool,
 
     /// Number of active coordination sessions
@@ -189,7 +197,8 @@ impl Default for NodeStatus {
             external_addrs: Vec::new(),
             nat_type: NatType::Unknown,
             can_receive_direct: false,
-            has_public_ip: false,
+            direct_reachability_scope: None,
+            has_global_address: false,
             connected_peers: 0,
             active_connections: 0,
             pending_connections: 0,
@@ -215,10 +224,10 @@ impl NodeStatus {
 
     /// Check if node can help with NAT traversal
     ///
-    /// Returns true if the node has public connectivity and can
+    /// Returns true if the node has peer-verified direct reachability and can
     /// act as coordinator/relay for other peers.
     pub fn can_help_traversal(&self) -> bool {
-        self.has_public_ip || self.can_receive_direct
+        self.can_receive_direct
     }
 
     /// Get the total number of connections (direct + relayed)
@@ -245,7 +254,7 @@ mod tests {
 
     #[test]
     fn test_nat_type_display() {
-        assert_eq!(format!("{}", NatType::None), "None (Public IP)");
+        assert_eq!(format!("{}", NatType::None), "None (No NAT detected)");
         assert_eq!(format!("{}", NatType::FullCone), "Full Cone");
         assert_eq!(
             format!("{}", NatType::AddressRestricted),
@@ -266,7 +275,8 @@ mod tests {
         let status = NodeStatus::default();
         assert_eq!(status.nat_type, NatType::Unknown);
         assert!(!status.can_receive_direct);
-        assert!(!status.has_public_ip);
+        assert_eq!(status.direct_reachability_scope, None);
+        assert!(!status.has_global_address);
         assert_eq!(status.connected_peers, 0);
         assert!(!status.is_relaying);
         assert!(!status.is_coordinating);
@@ -286,12 +296,27 @@ mod tests {
         let mut status = NodeStatus::default();
         assert!(!status.can_help_traversal());
 
-        status.has_public_ip = true;
-        assert!(status.can_help_traversal());
+        status.has_global_address = true;
+        assert!(
+            !status.can_help_traversal(),
+            "Global address alone must not imply direct reachability"
+        );
 
-        status.has_public_ip = false;
         status.can_receive_direct = true;
+        status.direct_reachability_scope = Some(ReachabilityScope::Global);
         assert!(status.can_help_traversal());
+    }
+
+    #[test]
+    fn test_direct_reachability_scope_tracks_observer_scope() {
+        let mut status = NodeStatus::default();
+        status.can_receive_direct = true;
+        status.direct_reachability_scope = Some(ReachabilityScope::LocalNetwork);
+
+        assert_eq!(
+            status.direct_reachability_scope,
+            Some(ReachabilityScope::LocalNetwork)
+        );
     }
 
     #[test]

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -2329,28 +2329,11 @@ impl P2pEndpoint {
         Ok(peer_conn)
     }
 
-    /// Check if we're connected to a specific address
-    async fn record_direct_incoming_stats(&self, remote_addr: SocketAddr) {
-        let mut stats = self.stats.write().await;
-        stats.active_connections += 1;
-        stats.successful_connections += 1;
-        stats.direct_connections += 1;
-        stats.active_direct_incoming_connections += 1;
-        let now = Instant::now();
-
-        match socket_addr_scope(remote_addr) {
-            Some(ReachabilityScope::Loopback) => {
-                stats.last_direct_loopback_at = Some(now);
-            }
-            Some(ReachabilityScope::LocalNetwork) => {
-                stats.last_direct_local_at = Some(now);
-            }
-            Some(ReachabilityScope::Global) => {
-                stats.last_direct_global_at = Some(now);
-            }
-            None => {}
-        }
-    }
+    // NOTE: direct incoming stats (active_direct_incoming_connections and
+    // scope timestamps) are recorded exclusively in the event_callback
+    // closure when NatTraversalEvent::ConnectionEstablished is emitted by
+    // spawn_connection_handler. No separate increment here to avoid
+    // double-counting.
 
     async fn is_connected_to_addr(&self, addr: SocketAddr) -> bool {
         let transport_addr = TransportAddr::Quic(addr);
@@ -2426,7 +2409,8 @@ impl P2pEndpoint {
                     .await
                     .insert(remote_addr, peer_conn.clone());
 
-                self.record_direct_incoming_stats(remote_addr).await;
+                // Stats are recorded by the event_callback when
+                // spawn_connection_handler emits ConnectionEstablished.
 
                 // They initiated the connection to us = Server side
                 let _ = self.event_tx.send(P2pEvent::PeerConnected {

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -71,9 +71,8 @@ use crate::constrained::EngineEvent;
 use crate::crypto::raw_public_keys::key_utils::generate_ml_dsa_keypair;
 use crate::happy_eyeballs::{self, HappyEyeballsConfig};
 pub use crate::nat_traversal_api::TraversalPhase;
-use crate::nat_traversal_api::{
-    NatTraversalEndpoint, NatTraversalError, NatTraversalEvent, NatTraversalStatistics,
-};
+use crate::nat_traversal_api::{NatTraversalEndpoint, NatTraversalError, NatTraversalEvent};
+use crate::reachability::{ReachabilityScope, TraversalMethod, socket_addr_scope};
 use crate::transport::{ProtocolEngine, TransportAddr, TransportRegistry};
 use crate::unified_config::P2pConfig;
 use rustls;
@@ -251,6 +250,12 @@ pub struct PeerConnection {
     /// Remote address (supports all transport types)
     pub remote_addr: TransportAddr,
 
+    /// How this connection was established.
+    pub traversal_method: TraversalMethod,
+
+    /// Who initiated the connection.
+    pub side: Side,
+
     /// Whether peer is authenticated
     pub authenticated: bool,
 
@@ -298,8 +303,20 @@ pub struct EndpointStats {
     /// Successful NAT traversals
     pub nat_traversal_successes: u64,
 
-    /// Direct connections (no NAT traversal needed)
+    /// Direct connections (no coordinator or relay needed)
     pub direct_connections: u64,
+
+    /// Currently active direct inbound connections from peers.
+    pub active_direct_incoming_connections: u64,
+
+    /// Most recent loopback-scoped direct inbound observation.
+    pub last_direct_loopback_at: Option<Instant>,
+
+    /// Most recent LAN-scoped direct inbound observation.
+    pub last_direct_local_at: Option<Instant>,
+
+    /// Most recent globally scoped direct inbound observation.
+    pub last_direct_global_at: Option<Instant>,
 
     /// Relayed connections
     pub relayed_connections: u64,
@@ -326,6 +343,10 @@ impl Default for EndpointStats {
             nat_traversal_attempts: 0,
             nat_traversal_successes: 0,
             direct_connections: 0,
+            active_direct_incoming_connections: 0,
+            last_direct_loopback_at: None,
+            last_direct_local_at: None,
+            last_direct_global_at: None,
             relayed_connections: 0,
             total_bootstrap_nodes: 0,
             connected_bootstrap_nodes: 0,
@@ -349,7 +370,7 @@ impl Default for EndpointStats {
 ///
 /// while let Ok(event) = events.recv().await {
 ///     match event {
-///         P2pEvent::PeerConnected { peer_id, addr, side } => {
+///         P2pEvent::PeerConnected { addr, public_key, side, traversal_method } => {
 ///             // Handle different transport types
 ///             match addr {
 ///                 TransportAddr::Quic(socket_addr) => {
@@ -403,6 +424,8 @@ pub enum P2pEvent {
         public_key: Option<Vec<u8>>,
         /// Who initiated the connection (Client = we connected, Server = they connected)
         side: Side,
+        /// Whether the connection was direct, hole-punched, or relayed.
+        traversal_method: TraversalMethod,
     },
 
     /// A peer has disconnected.
@@ -586,6 +609,10 @@ async fn do_cleanup_connection(
         {
             let mut s = stats.write().await;
             s.active_connections = s.active_connections.saturating_sub(1);
+            if peer_conn.traversal_method.is_direct() && peer_conn.side.is_server() {
+                s.active_direct_incoming_connections =
+                    s.active_direct_incoming_connections.saturating_sub(1);
+            }
         }
 
         let _ = event_tx.send(P2pEvent::PeerDisconnected {
@@ -650,17 +677,45 @@ impl P2pEndpoint {
                     NatTraversalEvent::ConnectionEstablished {
                         remote_address,
                         side,
+                        traversal_method,
                         public_key,
                     } => {
                         stats_guard.nat_traversal_successes += 1;
                         stats_guard.active_connections += 1;
                         stats_guard.successful_connections += 1;
 
+                        match traversal_method {
+                            TraversalMethod::Direct => {
+                                stats_guard.direct_connections += 1;
+                                if side.is_server() {
+                                    stats_guard.active_direct_incoming_connections += 1;
+                                    let now = Instant::now();
+                                    match socket_addr_scope(*remote_address) {
+                                        Some(ReachabilityScope::Loopback) => {
+                                            stats_guard.last_direct_loopback_at = Some(now);
+                                        }
+                                        Some(ReachabilityScope::LocalNetwork) => {
+                                            stats_guard.last_direct_local_at = Some(now);
+                                        }
+                                        Some(ReachabilityScope::Global) => {
+                                            stats_guard.last_direct_global_at = Some(now);
+                                        }
+                                        None => {}
+                                    }
+                                }
+                            }
+                            TraversalMethod::Relay => {
+                                stats_guard.relayed_connections += 1;
+                            }
+                            TraversalMethod::HolePunch | TraversalMethod::PortPrediction => {}
+                        }
+
                         // Broadcast event with connection direction
                         let _ = event_tx.send(P2pEvent::PeerConnected {
                             addr: TransportAddr::Quic(*remote_address),
                             public_key: public_key.clone(),
                             side: *side,
+                            traversal_method: *traversal_method,
                         });
                     }
                     NatTraversalEvent::TraversalFailed { remote_address, .. } => {
@@ -960,7 +1015,7 @@ impl P2pEndpoint {
 
         // Spawn handler (we initiated the connection = Client side)
         self.inner
-            .spawn_connection_handler(addr, connection, Side::Client)
+            .spawn_connection_handler(addr, connection, Side::Client, TraversalMethod::Direct)
             .map_err(EndpointError::NatTraversal)?;
 
         // Create peer connection record
@@ -968,6 +1023,8 @@ impl P2pEndpoint {
         let peer_conn = PeerConnection {
             public_key: remote_public_key.clone(),
             remote_addr: TransportAddr::Quic(addr),
+            traversal_method: TraversalMethod::Direct,
+            side: Side::Client,
             authenticated: true, // TLS handles authentication
             connected_at: Instant::now(),
             last_activity: Instant::now(),
@@ -999,6 +1056,7 @@ impl P2pEndpoint {
             addr: TransportAddr::Quic(addr),
             public_key: remote_public_key,
             side: Side::Client,
+            traversal_method: TraversalMethod::Direct,
         });
 
         Ok(peer_conn)
@@ -1074,6 +1132,8 @@ impl P2pEndpoint {
                 let peer_conn = PeerConnection {
                     public_key: None, // Constrained connections don't have TLS auth yet
                     remote_addr: addr.clone(),
+                    traversal_method: TraversalMethod::Direct,
+                    side: Side::Client,
                     authenticated: false,
                     connected_at: Instant::now(),
                     last_activity: Instant::now(),
@@ -1096,6 +1156,7 @@ impl P2pEndpoint {
                     addr: addr.clone(),
                     public_key: None,
                     side: Side::Client,
+                    traversal_method: TraversalMethod::Direct,
                 });
 
                 Ok(peer_conn)
@@ -1570,6 +1631,8 @@ impl P2pEndpoint {
                     let peer_conn = PeerConnection {
                         public_key: None,
                         remote_addr: TransportAddr::Quic(target_addr),
+                        traversal_method: TraversalMethod::HolePunch,
+                        side: Side::Client,
                         authenticated: true,
                         connected_at: Instant::now(),
                         last_activity: Instant::now(),
@@ -1589,6 +1652,7 @@ impl P2pEndpoint {
                         addr: TransportAddr::Quic(target_addr),
                         public_key: peer_conn.public_key.clone(),
                         side: Side::Client,
+                        traversal_method: TraversalMethod::HolePunch,
                     });
 
                     return Ok((
@@ -1964,12 +2028,14 @@ impl P2pEndpoint {
 
         // Spawn connection handler (Client side - we initiated)
         self.inner
-            .spawn_connection_handler(addr, connection, Side::Client)
+            .spawn_connection_handler(addr, connection, Side::Client, TraversalMethod::Direct)
             .map_err(EndpointError::NatTraversal)?;
 
         let peer_conn = PeerConnection {
             public_key: remote_public_key.clone(),
             remote_addr: TransportAddr::Quic(addr),
+            traversal_method: TraversalMethod::Direct,
+            side: Side::Client,
             authenticated: true,
             connected_at: Instant::now(),
             last_activity: Instant::now(),
@@ -1996,6 +2062,7 @@ impl P2pEndpoint {
             addr: TransportAddr::Quic(addr),
             public_key: remote_public_key,
             side: Side::Client,
+            traversal_method: TraversalMethod::Direct,
         });
 
         Ok(peer_conn)
@@ -2104,6 +2171,8 @@ impl P2pEndpoint {
                 let peer_conn = PeerConnection {
                     public_key: None,
                     remote_addr: TransportAddr::Quic(actual_addr),
+                    traversal_method: TraversalMethod::HolePunch,
+                    side: Side::Client,
                     authenticated: true,
                     connected_at: Instant::now(),
                     last_activity: Instant::now(),
@@ -2228,12 +2297,14 @@ impl P2pEndpoint {
             .map_err(EndpointError::NatTraversal)?;
 
         self.inner
-            .spawn_connection_handler(target, connection, Side::Client)
+            .spawn_connection_handler(target, connection, Side::Client, TraversalMethod::Relay)
             .map_err(EndpointError::NatTraversal)?;
 
         let peer_conn = PeerConnection {
             public_key: remote_public_key,
             remote_addr: TransportAddr::Quic(target),
+            traversal_method: TraversalMethod::Relay,
+            side: Side::Client,
             authenticated: true,
             connected_at: Instant::now(),
             last_activity: Instant::now(),
@@ -2259,6 +2330,28 @@ impl P2pEndpoint {
     }
 
     /// Check if we're connected to a specific address
+    async fn record_direct_incoming_stats(&self, remote_addr: SocketAddr) {
+        let mut stats = self.stats.write().await;
+        stats.active_connections += 1;
+        stats.successful_connections += 1;
+        stats.direct_connections += 1;
+        stats.active_direct_incoming_connections += 1;
+        let now = Instant::now();
+
+        match socket_addr_scope(remote_addr) {
+            Some(ReachabilityScope::Loopback) => {
+                stats.last_direct_loopback_at = Some(now);
+            }
+            Some(ReachabilityScope::LocalNetwork) => {
+                stats.last_direct_local_at = Some(now);
+            }
+            Some(ReachabilityScope::Global) => {
+                stats.last_direct_global_at = Some(now);
+            }
+            None => {}
+        }
+    }
+
     async fn is_connected_to_addr(&self, addr: SocketAddr) -> bool {
         let transport_addr = TransportAddr::Quic(addr);
         let peers = self.connected_peers.read().await;
@@ -2286,10 +2379,12 @@ impl P2pEndpoint {
                 let remote_public_key = extract_public_key_bytes_from_connection(&connection);
 
                 // They initiated the connection to us = Server side
-                if let Err(e) =
-                    self.inner
-                        .spawn_connection_handler(remote_addr, connection, Side::Server)
-                {
+                if let Err(e) = self.inner.spawn_connection_handler(
+                    remote_addr,
+                    connection,
+                    Side::Server,
+                    TraversalMethod::Direct,
+                ) {
                     error!("Failed to spawn connection handler: {}", e);
                     return None;
                 }
@@ -2298,6 +2393,8 @@ impl P2pEndpoint {
                 let peer_conn = PeerConnection {
                     public_key: remote_public_key.clone(),
                     remote_addr: TransportAddr::Quic(remote_addr),
+                    traversal_method: TraversalMethod::Direct,
+                    side: Side::Server,
                     authenticated: true, // TLS handles authentication
                     connected_at: Instant::now(),
                     last_activity: Instant::now(),
@@ -2329,17 +2426,14 @@ impl P2pEndpoint {
                     .await
                     .insert(remote_addr, peer_conn.clone());
 
-                {
-                    let mut stats = self.stats.write().await;
-                    stats.active_connections += 1;
-                    stats.successful_connections += 1;
-                }
+                self.record_direct_incoming_stats(remote_addr).await;
 
                 // They initiated the connection to us = Server side
                 let _ = self.event_tx.send(P2pEvent::PeerConnected {
                     addr: TransportAddr::Quic(remote_addr),
                     public_key: remote_public_key,
                     side: Side::Server,
+                    traversal_method: TraversalMethod::Direct,
                 });
 
                 Some(peer_conn)
@@ -2459,6 +2553,8 @@ impl P2pEndpoint {
                     let peer_conn = PeerConnection {
                         public_key: None,
                         remote_addr: TransportAddr::Quic(*addr),
+                        traversal_method: TraversalMethod::HolePunch,
+                        side: Side::Server,
                         authenticated: true,
                         connected_at: Instant::now(),
                         last_activity: Instant::now(),
@@ -2468,6 +2564,7 @@ impl P2pEndpoint {
                         addr: TransportAddr::Quic(*addr),
                         public_key: None,
                         side: Side::Server,
+                        traversal_method: TraversalMethod::HolePunch,
                     });
                     (TransportAddr::Quic(*addr), Some(conn))
                 } else {
@@ -2678,13 +2775,6 @@ impl P2pEndpoint {
                 / (stats.path.sent_packets + stats.path.lost_packets).max(1) as f64,
             last_activity,
         })
-    }
-
-    /// Get NAT traversal statistics
-    pub fn nat_stats(&self) -> Result<NatTraversalStatistics, EndpointError> {
-        self.inner
-            .get_nat_stats()
-            .map_err(|e| EndpointError::Connection(e.to_string()))
     }
 
     // === Known Peers ===
@@ -3012,6 +3102,8 @@ impl P2pEndpoint {
                 PeerConnection {
                     public_key: None,
                     remote_addr: addr.clone(),
+                    traversal_method: TraversalMethod::Direct,
+                    side,
                     authenticated: false,
                     connected_at: Instant::now(),
                     last_activity: Instant::now(),
@@ -3021,6 +3113,7 @@ impl P2pEndpoint {
                 addr: addr.clone(),
                 public_key: None,
                 side,
+                traversal_method: TraversalMethod::Direct,
             });
         }
 
@@ -3387,6 +3480,8 @@ impl P2pEndpoint {
                 let peer_conn = PeerConnection {
                     public_key: None,
                     remote_addr: TransportAddr::Quic(addr),
+                    traversal_method: TraversalMethod::HolePunch,
+                    side: Side::Server,
                     authenticated: true,
                     connected_at: Instant::now(),
                     last_activity: Instant::now(),
@@ -3457,6 +3552,7 @@ impl P2pEndpoint {
                     addr: TransportAddr::Quic(addr),
                     public_key: None,
                     side: Side::Server,
+                    traversal_method: TraversalMethod::HolePunch,
                 });
 
                 // Spawn a reader task for the connection so incoming streams
@@ -3585,6 +3681,8 @@ mod tests {
         let conn = PeerConnection {
             public_key: None,
             remote_addr: TransportAddr::Quic(socket_addr),
+            traversal_method: TraversalMethod::Direct,
+            side: Side::Client,
             authenticated: false,
             connected_at: Instant::now(),
             last_activity: Instant::now(),
@@ -3696,6 +3794,7 @@ mod tests {
             addr: TransportAddr::Quic(socket_addr),
             public_key: None,
             side: Side::Client,
+            traversal_method: TraversalMethod::Direct,
         };
 
         // Verify event fields
@@ -3703,11 +3802,13 @@ mod tests {
             addr,
             public_key,
             side,
+            traversal_method,
         } = event
         {
             assert!(public_key.is_none());
             assert_eq!(addr, TransportAddr::Quic(socket_addr));
             assert!(side.is_client());
+            assert_eq!(traversal_method, TraversalMethod::Direct);
 
             // Verify as_socket_addr() works
             let extracted = addr.as_socket_addr();
@@ -3728,6 +3829,7 @@ mod tests {
             },
             public_key: None,
             side: Side::Server,
+            traversal_method: TraversalMethod::Direct,
         };
 
         // Verify event fields
@@ -3735,10 +3837,12 @@ mod tests {
             addr,
             public_key,
             side,
+            traversal_method,
         } = event
         {
             assert!(public_key.is_none());
             assert!(side.is_server());
+            assert_eq!(traversal_method, TraversalMethod::Direct);
 
             // Verify as_socket_addr() returns None for BLE
             assert!(addr.as_socket_addr().is_none());
@@ -3775,6 +3879,7 @@ mod tests {
             addr: TransportAddr::Quic(socket_addr),
             public_key: Some(vec![0x11; 32]),
             side: Side::Client,
+            traversal_method: TraversalMethod::Direct,
         };
 
         // Verify events are Clone
@@ -3804,6 +3909,8 @@ mod tests {
         let udp_conn = PeerConnection {
             public_key: None,
             remote_addr: TransportAddr::Quic(udp_addr),
+            traversal_method: TraversalMethod::Direct,
+            side: Side::Client,
             authenticated: true,
             connected_at: Instant::now(),
             last_activity: Instant::now(),
@@ -3822,6 +3929,8 @@ mod tests {
                 mac: mac_addr,
                 psm: 128,
             },
+            traversal_method: TraversalMethod::Direct,
+            side: Side::Client,
             authenticated: true,
             connected_at: Instant::now(),
             last_activity: Instant::now(),
@@ -3839,6 +3948,7 @@ mod tests {
             addr: TransportAddr::Quic(socket_addr),
             public_key: None,
             side: Side::Client,
+            traversal_method: TraversalMethod::Direct,
         };
 
         // Verify display formatting works for logging
@@ -3868,6 +3978,8 @@ mod tests {
         let conn = PeerConnection {
             public_key: None,
             remote_addr: TransportAddr::Quic(socket_addr),
+            traversal_method: TraversalMethod::Direct,
+            side: Side::Client,
             authenticated: true,
             connected_at: Instant::now(),
             last_activity: Instant::now(),
@@ -3898,6 +4010,8 @@ mod tests {
             PeerConnection {
                 public_key: None,
                 remote_addr: TransportAddr::Quic(udp_addr),
+                traversal_method: TraversalMethod::Direct,
+                side: Side::Client,
                 authenticated: true,
                 connected_at: Instant::now(),
                 last_activity: Instant::now(),
@@ -3916,6 +4030,8 @@ mod tests {
             PeerConnection {
                 public_key: None,
                 remote_addr: ble_addr,
+                traversal_method: TraversalMethod::Direct,
+                side: Side::Client,
                 authenticated: true,
                 connected_at: Instant::now(),
                 last_activity: Instant::now(),
@@ -3958,6 +4074,8 @@ mod tests {
                 PeerConnection {
                     public_key: None,
                     remote_addr: TransportAddr::Quic(socket_addr),
+                    traversal_method: TraversalMethod::Direct,
+                    side: Side::Client,
                     authenticated: true,
                     connected_at: Instant::now(),
                     last_activity: Instant::now(),
@@ -4007,6 +4125,8 @@ mod tests {
         let mut conn = PeerConnection {
             public_key: None,
             remote_addr: TransportAddr::Quic(socket_addr),
+            traversal_method: TraversalMethod::Direct,
+            side: Side::Client,
             authenticated: false,
             connected_at: Instant::now(),
             last_activity: Instant::now(),

--- a/src/reachability.rs
+++ b/src/reachability.rs
@@ -172,5 +172,6 @@ mod tests {
         assert!(TraversalMethod::Direct.is_direct());
         assert!(!TraversalMethod::HolePunch.is_direct());
         assert!(!TraversalMethod::Relay.is_direct());
+        assert!(!TraversalMethod::PortPrediction.is_direct());
     }
 }

--- a/src/reachability.rs
+++ b/src/reachability.rs
@@ -1,0 +1,176 @@
+// Copyright 2024 Saorsa Labs Ltd.
+//
+// This Saorsa Network Software is licensed under the General Public License (GPL), version 3.
+// Please see the file LICENSE-GPL, or visit <http://www.gnu.org/licenses/> for the full text.
+//
+// Full details available at https://saorsalabs.com/licenses
+
+//! Reachability and connection path helpers.
+//!
+//! This module separates address classification from actual reachability.
+//! A node may know that an address is globally routable without knowing whether
+//! other peers can reach it directly. Direct reachability is only learned from
+//! successful peer-observed direct connections.
+
+use std::net::{IpAddr, SocketAddr};
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+/// Default freshness window for peer-verified direct reachability.
+///
+/// Direct reachability is inherently time-sensitive, especially for NAT-backed
+/// addresses whose mappings may expire. Evidence older than this should no
+/// longer be treated as current relay/coordinator capability.
+pub const DIRECT_REACHABILITY_TTL: Duration = Duration::from_secs(15 * 60);
+
+/// Scope in which a socket address is directly reachable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum ReachabilityScope {
+    /// Reachable only from the same host.
+    Loopback,
+    /// Reachable on the local network, including RFC1918/ULA/link-local space.
+    LocalNetwork,
+    /// Reachable using a globally routable address.
+    Global,
+}
+
+impl std::fmt::Display for ReachabilityScope {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Loopback => write!(f, "loopback"),
+            Self::LocalNetwork => write!(f, "local-network"),
+            Self::Global => write!(f, "global"),
+        }
+    }
+}
+
+impl ReachabilityScope {
+    /// Returns the broader of two scopes.
+    pub fn broaden(self, other: Self) -> Self {
+        self.max(other)
+    }
+}
+
+/// Method used to establish a connection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TraversalMethod {
+    /// Direct connection, no coordinator or relay involved.
+    Direct,
+    /// Coordinated hole punching.
+    HolePunch,
+    /// Connection established via relay.
+    Relay,
+    /// Port prediction for symmetric NATs.
+    PortPrediction,
+}
+
+impl TraversalMethod {
+    /// Whether this connection path is directly reachable without assistance.
+    pub const fn is_direct(self) -> bool {
+        matches!(self, Self::Direct)
+    }
+}
+
+impl std::fmt::Display for TraversalMethod {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Direct => write!(f, "direct"),
+            Self::HolePunch => write!(f, "hole punch"),
+            Self::Relay => write!(f, "relay"),
+            Self::PortPrediction => write!(f, "port prediction"),
+        }
+    }
+}
+
+/// Classify the reachability scope implied by an address.
+///
+/// Returns `None` for unspecified or multicast addresses, which are not useful
+/// as direct reachability evidence.
+pub fn socket_addr_scope(addr: SocketAddr) -> Option<ReachabilityScope> {
+    match addr.ip() {
+        IpAddr::V4(ipv4) => {
+            if ipv4.is_unspecified() || ipv4.is_multicast() {
+                None
+            } else if ipv4.is_loopback() {
+                Some(ReachabilityScope::Loopback)
+            } else if ipv4.is_private() || ipv4.is_link_local() {
+                Some(ReachabilityScope::LocalNetwork)
+            } else {
+                Some(ReachabilityScope::Global)
+            }
+        }
+        IpAddr::V6(ipv6) => {
+            if ipv6.is_unspecified() || ipv6.is_multicast() {
+                None
+            } else if ipv6.is_loopback() {
+                Some(ReachabilityScope::Loopback)
+            } else if ipv6.is_unique_local() || ipv6.is_unicast_link_local() {
+                Some(ReachabilityScope::LocalNetwork)
+            } else {
+                Some(ReachabilityScope::Global)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    #[test]
+    fn test_socket_addr_scope_ipv4() {
+        assert_eq!(
+            socket_addr_scope(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 9000)),
+            Some(ReachabilityScope::Loopback)
+        );
+        assert_eq!(
+            socket_addr_scope(SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::new(192, 168, 1, 10)),
+                9000
+            )),
+            Some(ReachabilityScope::LocalNetwork)
+        );
+        assert_eq!(
+            socket_addr_scope(SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::new(203, 0, 113, 10)),
+                9000
+            )),
+            Some(ReachabilityScope::Global)
+        );
+        assert_eq!(
+            socket_addr_scope(SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 9000)),
+            None
+        );
+    }
+
+    #[test]
+    fn test_socket_addr_scope_ipv6() {
+        assert_eq!(
+            socket_addr_scope(SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 9000)),
+            Some(ReachabilityScope::Loopback)
+        );
+        assert_eq!(
+            socket_addr_scope(SocketAddr::new(
+                IpAddr::V6("fd00::1".parse::<Ipv6Addr>().expect("valid ULA")),
+                9000,
+            )),
+            Some(ReachabilityScope::LocalNetwork)
+        );
+        assert_eq!(
+            socket_addr_scope(SocketAddr::new(
+                IpAddr::V6("2001:db8::1".parse::<Ipv6Addr>().expect("valid global v6")),
+                9000,
+            )),
+            Some(ReachabilityScope::Global)
+        );
+    }
+
+    #[test]
+    fn test_traversal_method_direct_flag() {
+        assert!(TraversalMethod::Direct.is_direct());
+        assert!(!TraversalMethod::HolePunch.is_direct());
+        assert!(!TraversalMethod::Relay.is_direct());
+    }
+}

--- a/src/relay_slot_table.rs
+++ b/src/relay_slot_table.rs
@@ -8,7 +8,7 @@
 //! Node-wide hole-punch coordinator back-pressure (Tier 4 lite).
 //!
 //! Every connection that lands at a node and acts as a hole-punch coordinator
-//! shares one [`RelaySlotTable`]. The table caps the number of in-flight
+//! shares one [`RelaySlotTable`](crate::relay_slot_table::RelaySlotTable). The table caps the number of in-flight
 //! `(initiator, target)` relay sessions across the entire node, so a storm
 //! of cold-starting peers cannot pile up unbounded coordination work on a
 //! single bootstrap. When the cap is reached, additional `PUNCH_ME_NOW`
@@ -24,12 +24,12 @@
 //! (the punch traffic flows initiator↔target, bypassing the coordinator),
 //! so slot release happens via three mechanisms:
 //!
-//! 1. **Inactivity timeout** ([`RelaySlotTable::idle_timeout`]). If no new
+//! 1. **Inactivity timeout** ([`RelaySlotTable::idle_timeout`](crate::relay_slot_table::RelaySlotTable::idle_timeout)). If no new
 //!    rounds for the same key arrive within this window the session is
 //!    considered done — either the punch succeeded (no more rounds needed)
 //!    or it definitively failed (the initiator rotated away). Default 5s.
 //!
-//! 2. **Connection close** via [`RelaySlotTable::release_for_initiator`].
+//! 2. **Connection close** via `RelaySlotTable::release_for_initiator`.
 //!    When the initiator's connection drops, every slot it owned is
 //!    reclaimed immediately rather than waiting for the inactivity timeout.
 //!    Called from `BootstrapCoordinator::Drop`.

--- a/src/upnp.rs
+++ b/src/upnp.rs
@@ -24,7 +24,7 @@
 //!
 //! Concretely this means:
 //!
-//! 1. [`UpnpMappingService::start`] never returns an error and never blocks
+//! 1. [`UpnpMappingService::start`](crate::upnp::UpnpMappingService::start) never returns an error and never blocks
 //!    on network I/O — it spawns a background task and returns immediately.
 //! 2. All failures are swallowed and logged at `debug` level. The only
 //!    `info` log line is the success path.
@@ -34,7 +34,7 @@
 //! 4. The lease is finite (one hour by default), so a crashed process
 //!    cannot leak a permanent mapping on the gateway.
 //!
-//! Callers consume the service by polling [`UpnpMappingService::current`]
+//! Callers consume the service by polling [`UpnpMappingService::current`](crate::upnp::UpnpMappingService::current)
 //! when they want the most recent state. The poll is a lock-free atomic
 //! load on the underlying `tokio::sync::watch` channel, so it is cheap to
 //! call from the candidate discovery hot path.

--- a/tests/connection_lifecycle_tests.rs
+++ b/tests/connection_lifecycle_tests.rs
@@ -283,15 +283,16 @@ mod connection_lifecycle {
 
     /// Test NAT statistics
     #[tokio::test]
-    async fn test_nat_statistics() {
+    async fn test_endpoint_stats() {
         let config = test_node_config(vec![]);
         let node = P2pEndpoint::new(config)
             .await
             .expect("Failed to create node");
 
-        // Get NAT stats - synchronous call
-        let _nat_stats = node.nat_stats();
-        println!("NAT stats received");
+        // Get endpoint stats
+        let stats = node.stats().await;
+        assert_eq!(stats.active_connections, 0);
+        println!("Endpoint stats received");
 
         shutdown_with_timeout(node).await;
     }

--- a/tests/constrained_integration.rs
+++ b/tests/constrained_integration.rs
@@ -753,6 +753,8 @@ fn test_peer_connection_transport_addr() {
     let peer_conn_udp = PeerConnection {
         public_key: Some(vec![0x11; 32]),
         remote_addr: udp_addr.clone(),
+        traversal_method: saorsa_transport::TraversalMethod::Direct,
+        side: saorsa_transport::Side::Client,
         authenticated: true,
         connected_at: Instant::now(),
         last_activity: Instant::now(),
@@ -771,6 +773,8 @@ fn test_peer_connection_transport_addr() {
     let peer_conn_ble = PeerConnection {
         public_key: None,
         remote_addr: ble_addr.clone(),
+        traversal_method: saorsa_transport::TraversalMethod::Direct,
+        side: saorsa_transport::Side::Client,
         authenticated: false,
         connected_at: Instant::now(),
         last_activity: Instant::now(),

--- a/tests/event_migration.rs
+++ b/tests/event_migration.rs
@@ -76,6 +76,7 @@ fn test_peer_connected_event_construction_udp() {
         addr: TransportAddr::Udp(socket_addr),
         public_key: Some(test_public_key.clone()),
         side: saorsa_transport::Side::Client,
+        traversal_method: saorsa_transport::TraversalMethod::Direct,
     };
 
     // Verify we can destructure it correctly
@@ -83,6 +84,7 @@ fn test_peer_connected_event_construction_udp() {
         addr,
         public_key,
         side,
+        ..
     } = event
     {
         assert_eq!(public_key.unwrap(), test_public_key);
@@ -128,6 +130,7 @@ fn test_event_clone_for_broadcast() {
         addr: TransportAddr::Udp(socket_addr),
         public_key: Some(vec![0xaa; 32]),
         side: saorsa_transport::Side::Server,
+        traversal_method: saorsa_transport::TraversalMethod::Direct,
     };
 
     // Clone is required for broadcast channel
@@ -140,11 +143,13 @@ fn test_event_clone_for_broadcast() {
                 addr: a1,
                 public_key: pk1,
                 side: s1,
+                ..
             },
             P2pEvent::PeerConnected {
                 addr: a2,
                 public_key: pk2,
                 side: s2,
+                ..
             },
         ) => {
             assert_eq!(pk1, pk2);
@@ -166,6 +171,7 @@ fn test_multi_transport_events() {
         addr: TransportAddr::Udp(udp_addr),
         public_key: Some(vec![0x01; 32]),
         side: saorsa_transport::Side::Client,
+        traversal_method: saorsa_transport::TraversalMethod::Direct,
     };
 
     // BLE event
@@ -176,6 +182,7 @@ fn test_multi_transport_events() {
         },
         public_key: Some(vec![0x02; 32]),
         side: saorsa_transport::Side::Server,
+        traversal_method: saorsa_transport::TraversalMethod::Direct,
     };
 
     // Verify we can distinguish between them
@@ -202,6 +209,7 @@ fn test_transport_aware_event_handling() {
             addr: TransportAddr::Udp("10.0.0.1:8080".parse().expect("valid")),
             public_key: Some(vec![0x01; 32]),
             side: saorsa_transport::Side::Client,
+            traversal_method: saorsa_transport::TraversalMethod::Direct,
         },
         P2pEvent::PeerConnected {
             addr: TransportAddr::Ble {
@@ -210,6 +218,7 @@ fn test_transport_aware_event_handling() {
             },
             public_key: Some(vec![0x02; 32]),
             side: saorsa_transport::Side::Server,
+            traversal_method: saorsa_transport::TraversalMethod::Direct,
         },
         P2pEvent::ExternalAddressDiscovered {
             addr: TransportAddr::Udp("203.0.113.1:9000".parse().expect("valid")),
@@ -248,6 +257,7 @@ fn test_backward_compatibility_with_as_socket_addr() {
         addr: TransportAddr::Udp(socket_addr),
         public_key: Some(vec![0xff; 32]),
         side: saorsa_transport::Side::Client,
+        traversal_method: saorsa_transport::TraversalMethod::Direct,
     };
 
     // Simulate legacy code that expects SocketAddr
@@ -291,6 +301,7 @@ fn test_event_debug_formatting() {
         addr: TransportAddr::Udp("192.168.0.100:9001".parse().expect("valid")),
         public_key: Some(vec![0x55; 32]),
         side: saorsa_transport::Side::Client,
+        traversal_method: saorsa_transport::TraversalMethod::Direct,
     };
 
     let debug = format!("{:?}", event);


### PR DESCRIPTION
## Summary

Ports David Irvine's reachability fix from ant-quic (commits `a5b9db46` and `359f58f8` on `dirvine/ant-quic`) to saorsa-transport.

### The bug

`has_public_ip` in `src/node.rs:514-537` conflates three distinct concepts:
1. **Address class** — whether local IP matches external IP
2. **NAT topology guess** — heuristic NatType detection
3. **Actual direct reachability** — whether peers can reach this node

This causes:
- Full-cone NAT nodes incorrectly marked as NOT directly connectable (excessive coordination requests)
- Public-IP nodes behind firewalls incorrectly marked as reachable
- Full-cone NAT nodes excluded from the coordinator pool, hammering bootstrap nodes instead

### The fix

- **New `src/reachability.rs` module** with `ReachabilityScope` (Loopback/LocalNetwork/Global), `TraversalMethod` (moved from node_event.rs), and `socket_addr_scope()` classifier
- **`has_public_ip` → `has_global_address`** — an address property, not proof of reachability
- **`can_receive_direct`** now requires actual peer-verified direct inbound connection evidence, with freshness TTL (15 minutes)
- **`direct_reachability_scope`** tracks the broadest verified scope
- **`can_help_traversal()`** simplified to just `can_receive_direct` (global address alone is not enough)
- **Connection provenance** threaded through: `PeerConnection`, `P2pEvent`, `NodeEvent` all carry `TraversalMethod`
- **Scope-aware timestamps** in `EndpointStats` for tracking last direct inbound observation per scope
- **`detect_nat_type()`** simplified to a soft debug hint, no longer driving reachability decisions

### Impact on NAT traversal

This directly addresses the rate-limit pressure Chris observed (50% PUNCH_ME_NOW rejection on 52-node testnet). By correctly identifying full-cone NAT nodes as directly reachable, the coordinator pool expands and coordination load distributes more evenly.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean  
- [x] `cargo test --lib` — 1489 passed, 0 failed

## Context

- David's Slack analysis: https://maidsafe.slack.com/archives/C0ABF9DMDUJ/p1775511002850009
- Discussed in #02_network on 2026-04-07
- Only the first commit (reachability model) is ported here; the second (bootstrap cache scope-aware selection) can follow as a separate PR

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the flawed `has_public_ip` heuristic with a scope-aware, peer-verified `can_receive_direct` signal backed by freshness TTLs, correctly separating address classification from actual reachability. The new `reachability.rs` module and scope-stamped `EndpointStats` fields are well-designed, but there is a stats double-count bug: each inbound direct connection increments `active_direct_incoming_connections` twice (once via the `NatTraversalEvent` callback and once via `record_direct_incoming_stats`) while `do_cleanup_connection` decrements only once, permanently inflating the counter and keeping `can_receive_direct` stuck at `true` after the first peer disconnects.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the active_direct_incoming_connections double-count which permanently misreports can_receive_direct

One P1 logic bug: active_direct_incoming_connections is incremented by both the event_callback (line 691) and record_direct_incoming_stats (line 2338) for the same inbound connection, but decremented only once in do_cleanup_connection. After the first disconnect the counter is stuck at 1, making can_receive_direct permanently true. Core reachability model design (ReachabilityScope, TTL freshness) is correct and the 1489 passing tests validate the broad structure.

src/p2p_endpoint.rs — the active_direct_incoming_connections double-increment between the event_callback (line 691) and record_direct_incoming_stats (line 2338)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/reachability.rs | New module cleanly separates address classification (ReachabilityScope) from actual reachability evidence; well-tested with IPv4/IPv6 unit tests |
| src/p2p_endpoint.rs | Introduces active_direct_incoming_connections counter but double-increments it via both the event_callback and record_direct_incoming_stats; cleanup decrements only once, permanently inflating can_receive_direct |
| src/node.rs | Replaces has_public_ip heuristic with freshness-aware peer-verified can_receive_direct; logic is sound once the double-count in p2p_endpoint is resolved |
| src/node_status.rs | Clean field rename has_public_ip→has_global_address; new test correctly validates that a global address alone does not imply direct reachability |
| src/link_transport_impl.rs | Correctly clears relay/coordination capabilities on disconnect; sets supports_relay on all direct connections without checking connection direction |
| src/nat_traversal_api.rs | TraversalMethod correctly threaded through spawn_connection_handler and hole-punch paths; stub get_nat_stats removal is a clean-up |
| src/node_event.rs | TraversalMethod moved to reachability module; new method field on PeerConnected event is correct |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant AL as P2pEndpoint Accept Loop
    participant Inner as NatTraversalEndpoint
    participant CB as event_callback (tokio task)
    participant Stats as EndpointStats
    participant CL as do_cleanup_connection

    AL->>Inner: spawn_connection_handler(Direct, Server)
    Inner-->>CB: NatTraversalEvent::ConnectionEstablished (async)
    AL->>Stats: record_direct_incoming_stats() +1
    Note over Stats: active_direct_incoming = 1
    CB->>Stats: active_direct_incoming_connections += 1
    Note over Stats: active_direct_incoming = 2 (double-count!)
    Note right of Stats: can_receive_direct = true ✓ correct
    Note over AL: peer disconnects
    CL->>Stats: saturating_sub(1)
    Note over Stats: active_direct_incoming = 1 (stuck > 0)
    Note right of Stats: can_receive_direct = true ✗ no active connections
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/p2p_endpoint.rs
Line: 2333-2352

Comment:
**Double-counted `active_direct_incoming_connections` per inbound connection**

For every direct inbound QUIC connection accepted by the raw accept loop, two independent code paths both increment this counter: (1) the `event_callback` closure (line 691) fires when `spawn_connection_handler` sends `NatTraversalEvent::ConnectionEstablished`, and (2) `record_direct_incoming_stats` increments `stats.active_direct_incoming_connections` here. `do_cleanup_connection` only decrements once (line 613). After the first inbound peer disconnects the counter is permanently stuck at 1, causing `can_receive_direct` in `node.rs` to report `true` indefinitely even with no active connections.

Fix: route the stat write through a single path — either remove the `active_direct_incoming_connections` increment from `record_direct_incoming_stats` (keeping only the callback path) or prevent the callback from counting connections already counted by the accept loop.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/link_transport_impl.rs
Line: 492-506

Comment:
**`supports_relay` set for inbound connections regardless of their reachability**

The `side` field is dropped (`side: _`) before the `traversal_method.is_direct()` check, so `supports_relay = true` is applied both when we connected to the peer (proving they accept inbound connections) and when the peer connected to us (proving only they can make outbound connections, not that they can receive). `bootstrap_cache/selection.rs` uses `supports_relay` to pick relay/coordinator candidates, so a port-restricted-NAT peer that reached us inbound could be incorrectly promoted as a coordinator and waste connection attempts from other nodes.

Consider only setting `supports_relay` when `side.is_client()` (we connected to them, so they demonstrably accepted an inbound connection).

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(reachability): replace has\_public\_ip..."](https://github.com/saorsa-labs/saorsa-transport/commit/f358ca5bf71fe66975da8bdf8ccf73dafca28732) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27548667)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->