### PR TITLE
fix(relay): rotate through all relay candidates instead of failing on first

### DIFF
--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -1875,12 +1875,12 @@ impl P2pEndpoint {
                             return Ok((conn, ConnectionMethod::Relayed { relay: relay_addr }));
                         }
                         Ok(Err(e)) => {
-                            debug!("Relay connection failed: {}", e);
-                            strategy.transition_to_failed(e.to_string());
+                            debug!("Relay connection failed: {e}");
+                            strategy.transition_to_next_relay(e.to_string());
                         }
                         Err(_) => {
                             debug!("Relay connection timed out");
-                            strategy.transition_to_failed("Timeout");
+                            strategy.transition_to_next_relay("Timeout");
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

- **Bug**: The `connect_with_fallback_inner` method in `p2p_endpoint.rs` called `strategy.transition_to_failed()` when a relay connection attempt failed (both error and timeout cases). This immediately transitioned to the `Failed` state, meaning only the first relay candidate was ever tried -- even when multiple relay addresses were configured.
- **Fix**: Changed both the error and timeout cases in the Relay stage to call `strategy.transition_to_next_relay()` instead. This method tries the next relay candidate in order, and only transitions to `Failed` once all relay candidates are exhausted.
- **Context**: David observed that relay fallback breaks when the coordinator disconnects. The root cause was that `ConnectionStrategy` already supported multi-relay rotation via `transition_to_next_relay`, but `p2p_endpoint.rs` was not using it.

## Test plan

- [x] `cargo fmt --all` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --lib` passes (1485 tests, 0 failures)
- [x] Existing `test_multi_relay_fallback` test in `connection_strategy.rs` validates the rotation logic

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a relay rotation bug where `connect_with_fallback_inner` called `strategy.transition_to_failed()` on both relay error and timeout, causing the strategy to jump directly to `Failed` after the very first relay attempt — even when additional relay candidates were configured. Both call sites in the `ConnectionStage::Relay` match arm are replaced with `strategy.transition_to_next_relay()`, which advances `relay_index` through the candidate list and only calls `transition_to_failed` internally once all relays are exhausted.

<h3>Confidence Score: 5/5</h3>

Safe to merge — minimal two-line fix with correct behavior and existing test coverage

Only two call sites changed inside the ConnectionStage::Relay arm. transition_to_next_relay correctly increments relay_index, resets the per-relay timer via Instant::now(), and falls through to Failed only when all candidates are exhausted. The existing test_multi_relay_fallback unit test in connection_strategy.rs already validates the full rotation + exhaustion path. No P0 or P1 findings.

No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/p2p_endpoint.rs | Two transition_to_failed calls in the Relay match arm replaced with transition_to_next_relay — correct fix that enables rotation through all configured relay candidates before failing |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[connect_with_fallback_inner loop] --> B{strategy.current_stage}
    B -->|Relay| C[try_relay_connection\nwith relay_timeout]
    C -->|Ok success| D[return Ok\nConnectionMethod::Relayed]
    C -->|Err error| E[transition_to_next_relay\nerror message]
    C -->|Timeout| F[transition_to_next_relay\nTimeout]
    E --> G{relay_index + 1\n< relay_addrs.len?}
    F --> G
    G -->|yes| H[stage = Relay\nrelay_index + 1\nstarted = now]
    G -->|no| I[stage = Failed\nall errors collected]
    H -->|next loop iteration| A
    I -->|next loop iteration| A
    B -->|Failed| J[return Err\nAllStrategiesFailed]
```

<sub>Reviews (1): Last reviewed commit: ["fix(relay): rotate through all relay can..."](https://github.com/saorsa-labs/saorsa-transport/commit/145f982e7d9a83adf27344dd8e257971210fc888) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27555334)</sub>

<!-- /greptile_comment -->