### PR TITLE
fix: remove panic sites in NAT traversal and connection handling

### DIFF
--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -4841,16 +4841,15 @@ impl Connection {
                 let punch_me_now_clone = punch_me_now.clone();
                 drop(nat_state); // Release the borrow
 
-                match self
-                    .nat_traversal
-                    .as_mut()
-                    .unwrap()
-                    .handle_punch_me_now_frame(
-                        from_peer_id,
-                        self.path.remote,
-                        &punch_me_now_clone,
-                        now,
-                    ) {
+                let Some(nat) = self.nat_traversal.as_mut() else {
+                    return Ok(());
+                };
+                match nat.handle_punch_me_now_frame(
+                    from_peer_id,
+                    self.path.remote,
+                    &punch_me_now_clone,
+                    now,
+                ) {
                     Ok(Some(coordination_frame)) => {
                         trace!("Node coordinating PUNCH_ME_NOW between peers");
 

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -5421,7 +5421,12 @@ impl NatTraversalEndpoint {
                     );
 
                     let mut connection = None;
-                    let mut bootstrap = relay_candidates[0]; // default, overwritten on success
+                    let Some(&first_candidate) = relay_candidates.first() else {
+                        warn!("No relay candidates available for symmetric NAT setup");
+                        relay_setup_attempted.store(false, std::sync::atomic::Ordering::Relaxed);
+                        return;
+                    };
+                    let mut bootstrap = first_candidate; // default, overwritten on success
 
                     for candidate in &relay_candidates {
                         match connections.get(candidate) {
@@ -6208,13 +6213,12 @@ impl NatTraversalEndpoint {
             }
 
             // For testing: if we're in punching phase and have candidates, simulate success with the first one
-            if session.phase == TraversalPhase::Punching && !session.candidates.is_empty() {
-                let candidate_addr = session.candidates[0].address;
-                info!(
-                    "Simulating successful punch for testing: {} at {}",
-                    addr, candidate_addr
-                );
-                return Some(candidate_addr);
+            if session.phase == TraversalPhase::Punching {
+                if let Some(first_candidate) = session.candidates.first() {
+                    let candidate_addr = first_candidate.address;
+                    info!("Simulating successful punch for testing: {addr} at {candidate_addr}",);
+                    return Some(candidate_addr);
+                }
             }
 
             // No validated candidates, return first candidate as fallback

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -1895,8 +1895,9 @@ impl P2pEndpoint {
                 }
 
                 ConnectionStage::Connected { via } => {
-                    // This shouldn't happen in the loop, but handle it
-                    unreachable!("Connected stage reached in loop: {:?}", via);
+                    return Err(EndpointError::Connection(format!(
+                        "unexpected Connected stage reached in loop: {via:?}"
+                    )));
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Replace `.unwrap()` on `self.nat_traversal` in `connection/mod.rs` with a `let-else` guard that returns `Ok(())` when NAT state is unexpectedly `None`
- Replace `relay_candidates[0]` direct indexing in `nat_traversal_api.rs` with `.first()` and a `let-else` guard that logs a warning and resets the retry flag
- Replace `session.candidates[0]` direct indexing in `nat_traversal_api.rs` with `.first()` via `if let Some(...)`
- Replace `unreachable!()` in `p2p_endpoint.rs` with `return Err(EndpointError::Connection(...))` so the caller gets a proper error instead of a process crash

## Test plan
- [x] `cargo fmt --all` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes (zero warnings)
- [x] `cargo test --lib` passes (1485 passed, 0 failed)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes four latent panic sites across NAT traversal and connection handling. The `p2p_endpoint.rs` fix is the highest-value change, converting a `unreachable!()` process abort on the `ConnectionStage::Connected` arm into a graceful `return Err(...)`. The two `.first()` guards in `nat_traversal_api.rs` at lines 6217/6225 replacing `[0]` direct indexing are clean and correct. The `connection/mod.rs` change eliminates an `.unwrap()` with a `let-else` guard.

One P2 concern: the `let-else` on `relay_candidates.first()` at line 5424 of `nat_traversal_api.rs` is unreachable dead code — it sits inside the `else` branch of `if relay_candidates.is_empty()` (line 5405), so the retry-flag rollback inside the guard can never execute."

<h3>Confidence Score: 5/5</h3>

Safe to merge — all panic sites are correctly removed and no behavioral regressions introduced.

All remaining findings are P2. The only issue is a dead-code guard that is harmless but misleading. No P0 or P1 issues were found.

src/nat_traversal_api.rs lines 5424-5428 — dead-code let-else guard worth cleaning up but not blocking.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/connection/mod.rs | Replaces .unwrap() on self.nat_traversal with a let-else guard returning Ok(()); the outer if let Some at line 4835 already guarantees Some, making this a clean defensive fix with no behavioral change. |
| src/nat_traversal_api.rs | Two .first() guards replacing [0] direct indexing at lines 6217/6225 are correct; the relay_candidates.first() guard at line 5424 is unreachable dead code inside the else branch of if relay_candidates.is_empty(). |
| src/p2p_endpoint.rs | Replaces unreachable!() on ConnectionStage::Connected arm with return Err(EndpointError::Connection(...)), converting a guaranteed process abort into a graceful, diagnosable error. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[poll NAT traversal] --> B{is_symmetric_nat?}
    B -- No --> C[continue]
    B -- Yes --> D{relay_setup_attempted?}
    D -- true --> C
    D -- false --> E[collect relay_candidates]
    E --> F{relay_candidates.is_empty?}
    F -- Yes --> G[debug log, return]
    F -- No --> H[store relay_setup_attempted=true]
    H --> I[tokio::spawn async task]
    I --> J[relay_candidates.first\nDEAD guard — always Some]
    J --> K[iterate candidates for active conn]
    K --> L{active conn found?}
    L -- No --> M[warn, store false, return]
    L -- Yes --> N[setup relay session]
    N --> O[advertise via ADD_ADDRESS frame]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/nat_traversal_api.rs
Line: 5424-5428

Comment:
**Dead-code guard — `let-else` inside a guaranteed non-empty branch**

The outer `if relay_candidates.is_empty()` check at line 5405 ensures the vector is non-empty before the `else` block is entered and the task is spawned. `relay_candidates.first()` therefore can never return `None` here — the `warn!`, the `relay_setup_attempted.store(false, …)` rollback, and the early `return` are unreachable dead code. The retry-flag reset that looks like a safety valve will never actually fire.

```suggestion
                    let first_candidate = relay_candidates[0]; // non-empty: guaranteed by check above
                    let mut bootstrap = first_candidate; // default, overwritten on success
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: remove panic sites in NAT traversal..."](https://github.com/saorsa-labs/saorsa-transport/commit/25633258d0e73097a8af8fe7e5dcc21d7ff01785) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27557238)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->