### PR TITLE
fix(nat): implement coordination table cleanup to prevent memory leak

### DIFF
--- a/src/connection/nat_traversal.rs
+++ b/src/connection/nat_traversal.rs
@@ -3885,7 +3885,7 @@ impl BootstrapCoordinator {
         self.cleanup_completed_sessions(now);
 
         // Track coordination entry minimally
-        let _entry = self
+        let entry = self
             .coordination_table
             .entry(frame.round)
             .or_insert(CoordinationEntry {
@@ -3896,10 +3896,10 @@ impl BootstrapCoordinator {
             });
         // Update target if provided later
         if let Some(peer_b) = frame.target_peer_id {
-            if _entry.peer_b.is_none() {
-                _entry.peer_b = Some(peer_b);
+            if entry.peer_b.is_none() {
+                entry.peer_b = Some(peer_b);
             }
-            _entry.address_hint = frame.address;
+            entry.address_hint = frame.address;
         }
 
         // If we have a target, echo back with swapped target to coordinate
@@ -3914,7 +3914,7 @@ impl BootstrapCoordinator {
             Ok(Some(coordination_frame))
         } else {
             // Response path: mark entry completed and increment success metric
-            _entry.completed = true;
+            entry.completed = true;
             self.stats.successful_coordinations += 1;
             Ok(None)
         }

--- a/src/connection/nat_traversal.rs
+++ b/src/connection/nat_traversal.rs
@@ -3603,11 +3603,19 @@ struct ObservedPeer {
     observed_addr: SocketAddr,
 }
 
+/// How long a coordination entry is kept before being reaped. Coordination
+/// should complete within a few seconds; 60 s is a generous upper bound.
+const COORDINATION_ENTRY_TTL: Duration = Duration::from_secs(60);
+
 /// Minimal coordination record linking two peers for a round
 #[derive(Debug, Clone)]
 struct CoordinationEntry {
     peer_b: Option<PeerId>,
     address_hint: SocketAddr,
+    /// When this entry was created (used for expiry).
+    created_at: Instant,
+    /// Set to `true` once the response/echo path has been reached.
+    completed: bool,
 }
 /// Record of observed peer information
 #[derive(Debug, Clone)]
@@ -3871,6 +3879,11 @@ impl BootstrapCoordinator {
             }
         }
 
+        // Periodic housekeeping: reap stale / completed entries so the
+        // table cannot grow without bound.
+        self.cleanup_expired_sessions(now);
+        self.cleanup_completed_sessions(now);
+
         // Track coordination entry minimally
         let _entry = self
             .coordination_table
@@ -3878,6 +3891,8 @@ impl BootstrapCoordinator {
             .or_insert(CoordinationEntry {
                 peer_b: frame.target_peer_id,
                 address_hint: frame.address,
+                created_at: now,
+                completed: false,
             });
         // Update target if provided later
         if let Some(peer_b) = frame.target_peer_id {
@@ -3898,7 +3913,8 @@ impl BootstrapCoordinator {
             self.stats.total_coordinations += 1;
             Ok(Some(coordination_frame))
         } else {
-            // Response path: increment success metric
+            // Response path: mark entry completed and increment success metric
+            _entry.completed = true;
             self.stats.successful_coordinations += 1;
             Ok(None)
         }
@@ -3909,8 +3925,11 @@ impl BootstrapCoordinator {
 
     // Perform comprehensive security validation for coordination requests (legacy removed)
 
-    #[allow(dead_code)]
-    pub(crate) fn cleanup_expired_sessions(&mut self, _now: Instant) {}
+    /// Remove coordination entries that have exceeded the TTL.
+    pub(crate) fn cleanup_expired_sessions(&mut self, now: Instant) {
+        self.coordination_table
+            .retain(|_round, entry| now.duration_since(entry.created_at) < COORDINATION_ENTRY_TTL);
+    }
 
     // Get bootstrap statistics (legacy removed)
 
@@ -3925,8 +3944,12 @@ impl BootstrapCoordinator {
     // Check if a session should advance its state (legacy removed)
     // Advance session state based on event (legacy removed)
 
-    #[allow(dead_code)]
-    fn cleanup_completed_sessions(&mut self, _now: Instant) {}
+    /// Remove coordination entries that have already completed (response
+    /// path reached). Called opportunistically so the table stays compact.
+    fn cleanup_completed_sessions(&mut self, _now: Instant) {
+        self.coordination_table
+            .retain(|_round, entry| !entry.completed);
+    }
 
     // Legacy retry mechanism removed
 


### PR DESCRIPTION
## Summary

- The `coordination_table` HashMap in `BootstrapCoordinator` grew unboundedly on every PUNCH_ME_NOW relay because `cleanup_expired_sessions()` and `cleanup_completed_sessions()` had empty bodies
- Added `created_at` (Instant) and `completed` (bool) fields to `CoordinationEntry`
- Implemented `cleanup_expired_sessions`: retains only entries younger than 60 seconds
- Implemented `cleanup_completed_sessions`: retains only entries not yet marked complete
- Both cleanup methods are called at the start of `process_punch_me_now_frame` before inserting new entries
- Entries are marked `completed = true` on the response/echo path

## Test plan

- [x] `cargo fmt --all` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes (zero warnings)
- [x] `cargo test --lib` passes (1485 tests, 0 failures)
- [ ] Verify on a long-running testnet node that coordination_table size stays bounded

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses a real memory leak where `coordination_table` in `BootstrapCoordinator` grew unboundedly because both cleanup methods had empty bodies. The fix adds `created_at: Instant` and `completed: bool` to `CoordinationEntry`, implements a 60-second TTL eviction, and wires both cleanups into `process_punch_me_now_frame`.

- The `completed` flag is set only in the `else` branch (when `frame.target_peer_id.is_none()`), meaning relay entries — the dominant case when `target_peer_id.is_some()` — are **never** marked completed and are exclusively cleaned up by the 60-second TTL. `cleanup_completed_sessions` provides no benefit for typical relay traffic; consider either marking entries completed on the relay path or removing the `completed` field and relying solely on TTL eviction.


<h3>Confidence Score: 4/5</h3>

Safe to merge — the leak is bounded and the fix is correct, but the `completed` cleanup path is inert for relay traffic

All findings are P2 style/design observations. The one design concern worth a second look is that `cleanup_completed_sessions` never fires for the dominant relay path, making it dead code in practice. This is a reliability/design observation, not a correctness bug, but it warrants author awareness before merge.

`src/connection/nat_traversal.rs` — specifically the `process_punch_me_now_frame` relay vs. response branching logic

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/connection/nat_traversal.rs | Implements coordination table cleanup via TTL and completed-flag; completed flag is only set on the non-relay path, leaving relay entries to rely solely on TTL for eviction |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant PA as Peer A
    participant C as BootstrapCoordinator
    participant PB as Peer B

    Note over C: process_punch_me_now_frame called
    C->>C: cleanup_expired_sessions(now)
    C->>C: cleanup_completed_sessions(now)
    C->>C: coordination_table.entry(round).or_insert(...)

    PA->>C: PUNCH_ME_NOW(round, target=PeerB)
    Note over C: target_peer_id.is_some() → relay path
    C->>C: stats.total_coordinations += 1
    C-->>PA: Ok(Some(coordination_frame))
    Note over C: completed NOT set → entry lives until 60s TTL

    PB->>C: PUNCH_ME_NOW(round, target=None)
    Note over C: target_peer_id.is_none() → response path
    C->>C: _entry.completed = true
    C->>C: stats.successful_coordinations += 1
    C-->>PB: Ok(None)
    Note over C: Next frame will reap this entry via cleanup_completed_sessions
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/connection/nat_traversal.rs`, line 3905-3920 ([link](https://github.com/saorsa-labs/saorsa-transport/blob/09b62727a51d3e84d434446745f43cb132068b2d/src/connection/nat_traversal.rs#L3905-L3920)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`cleanup_completed_sessions` is effectively dead code for relay traffic**

   The `completed` flag is only set to `true` in the `else` branch (line 3917), which is reached when `frame.target_peer_id.is_none()`. The typical relay flow has `target_peer_id.is_some()`, so it always takes the `if` branch and returns `Ok(Some(...))` without ever setting `completed = true`. Every relay entry therefore lives in the table for the full 60-second TTL regardless of whether the relay already completed successfully.

   Either mark entries completed on the relay path as well, or drop the `completed` field and rely solely on `cleanup_expired_sessions` (TTL). The current mixed approach adds field overhead without bounding relay entries faster.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/connection/nat_traversal.rs
   Line: 3905-3920

   Comment:
   **`cleanup_completed_sessions` is effectively dead code for relay traffic**

   The `completed` flag is only set to `true` in the `else` branch (line 3917), which is reached when `frame.target_peer_id.is_none()`. The typical relay flow has `target_peer_id.is_some()`, so it always takes the `if` branch and returns `Ok(Some(...))` without ever setting `completed = true`. Every relay entry therefore lives in the table for the full 60-second TTL regardless of whether the relay already completed successfully.

   Either mark entries completed on the relay path as well, or drop the `completed` field and rely solely on `cleanup_expired_sessions` (TTL). The current mixed approach adds field overhead without bounding relay entries faster.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/connection/nat_traversal.rs
Line: 3905-3920

Comment:
**`cleanup_completed_sessions` is effectively dead code for relay traffic**

The `completed` flag is only set to `true` in the `else` branch (line 3917), which is reached when `frame.target_peer_id.is_none()`. The typical relay flow has `target_peer_id.is_some()`, so it always takes the `if` branch and returns `Ok(Some(...))` without ever setting `completed = true`. Every relay entry therefore lives in the table for the full 60-second TTL regardless of whether the relay already completed successfully.

Either mark entries completed on the relay path as well, or drop the `completed` field and rely solely on `cleanup_expired_sessions` (TTL). The current mixed approach adds field overhead without bounding relay entries faster.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/connection/nat_traversal.rs
Line: 3949-3952

Comment:
**Vestigial `_now` parameter**

The `_now: Instant` parameter is accepted but unused — the `_` prefix was added to suppress the compiler warning rather than removing the parameter. Since `cleanup_completed_sessions` has no time-based logic and is a private function, the parameter can be dropped to keep the signature honest.

```suggestion
    fn cleanup_completed_sessions(&mut self) {
        self.coordination_table
            .retain(|_round, entry| !entry.completed);
    }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/connection/nat_traversal.rs
Line: 3885

Comment:
**Call-site update if `_now` parameter is removed**

If the `_now` parameter of `cleanup_completed_sessions` is dropped (see suggestion above), this call site should be updated accordingly.

```suggestion
        self.cleanup_completed_sessions();
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/connection/nat_traversal.rs
Line: 3888-3896

Comment:
**Misleading `_entry` naming**

The `_` prefix conventionally signals an intentionally unused binding, but `_entry` is actively read and mutated on lines 3899–3902 and 3917. Using `_entry` suppresses the unused-variable lint by accident rather than design. Renaming to `entry` makes the intent clear and won't introduce any warnings since the variable is always used on at least one branch.

```suggestion
        let entry = self
            .coordination_table
            .entry(frame.round)
            .or_insert(CoordinationEntry {
                peer_b: frame.target_peer_id,
                address_hint: frame.address,
                created_at: now,
                completed: false,
            });
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(nat): implement coordination table c..."](https://github.com/saorsa-labs/saorsa-transport/commit/09b62727a51d3e84d434446745f43cb132068b2d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27557399)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->