### PR TITLE
fix(nat): drop per-rotation direct probe and dedup connections by TLS key

### DIFF
--- a/examples/simple_p2p.rs
+++ b/examples/simple_p2p.rs
@@ -39,6 +39,7 @@ async fn main() -> anyhow::Result<()> {
                     addr,
                     public_key,
                     side,
+                    ..
                 } => {
                     println!(
                         "Connected to peer at {} (side: {:?}, has key: {})",

--- a/src/bin/e2e-test-node.rs
+++ b/src/bin/e2e-test-node.rs
@@ -713,6 +713,7 @@ async fn handle_event(
             addr,
             public_key: _,
             side,
+            traversal_method: _,
         } => {
             let direction = if side.is_client() {
                 "outbound"

--- a/src/config/transport.rs
+++ b/src/config/transport.rs
@@ -66,18 +66,17 @@ pub struct TransportConfig {
     /// Allow loopback addresses as valid NAT traversal candidates
     pub(crate) allow_loopback: bool,
 
-    /// Maximum number of concurrent hole-punch relay slots this node will
-    /// service when acting as a coordinator (Tier 4 lite back-pressure).
-    /// When the active count reaches this cap, incoming `PUNCH_ME_NOW`
-    /// frames that would otherwise be relayed are silently refused so the
-    /// initiator advances to its next preferred coordinator.
-    pub(crate) coordinator_max_active_relays: usize,
-
-    /// Reclamation timeout for stale coordinator relay slots. Acts as a
-    /// safety net so a relay slot cannot leak forever if a peer crashes
-    /// mid-coordination, a NAT rebind silently drops the session, or a
-    /// follow-up signal is lost.
-    pub(crate) coordinator_relay_slot_timeout: Duration,
+    /// Shared, node-wide hole-punch coordinator back-pressure table
+    /// (Tier 4 lite). When this is `Some`, every connection that lands
+    /// at this node and acts as a coordinator gates incoming
+    /// `PUNCH_ME_NOW` relay frames against the shared table — the cap
+    /// is enforced *across* connections, not per-connection. When `None`
+    /// (low-level test fixtures, internal Quinn-style use), back-pressure
+    /// is disabled and the coordinator behaves as in pre-Tier-4 builds.
+    ///
+    /// Owned and instantiated by `P2pEndpoint::new`; injected into
+    /// `TransportConfig` before the config is frozen behind `Arc`.
+    pub(crate) relay_slot_table: Option<Arc<crate::relay_slot_table::RelaySlotTable>>,
 }
 
 impl TransportConfig {
@@ -484,18 +483,16 @@ impl TransportConfig {
         self
     }
 
-    /// Cap on simultaneous hole-punch relay slots when this node acts as a
-    /// coordinator. Higher = more concurrency capacity, lower = stricter
-    /// back-pressure shedding under storm load. Default: 32.
-    pub fn coordinator_max_active_relays(&mut self, max: usize) -> &mut Self {
-        self.coordinator_max_active_relays = max;
-        self
-    }
-
-    /// Maximum lifetime of a coordinator relay slot before it is reclaimed
-    /// by the inline garbage-collection sweep. Default: 5 seconds.
-    pub fn coordinator_relay_slot_timeout(&mut self, timeout: Duration) -> &mut Self {
-        self.coordinator_relay_slot_timeout = timeout;
+    /// Inject the node-wide hole-punch coordinator back-pressure table
+    /// (Tier 4 lite). Called from `P2pEndpoint::new` so that every QUIC
+    /// connection spawned from this transport config shares one table.
+    /// `None` disables back-pressure (used by Quinn-style low-level
+    /// fixtures that do not run a coordinator).
+    pub fn relay_slot_table(
+        &mut self,
+        table: Option<Arc<crate::relay_slot_table::RelaySlotTable>>,
+    ) -> &mut Self {
+        self.relay_slot_table = table;
         self
     }
 }
@@ -551,11 +548,12 @@ impl Default for TransportConfig {
                 ml_dsa_65: false,
             }),
             allow_loopback: false,
-            // Tier 4 (lite) coordinator back-pressure defaults. See
-            // `coordinator_max_active_relays`/`coordinator_relay_slot_timeout`
-            // setters for the rationale behind these numbers.
-            coordinator_max_active_relays: 32,
-            coordinator_relay_slot_timeout: Duration::from_secs(5),
+            // No back-pressure table by default — `P2pEndpoint::new`
+            // injects one before connections are spawned. Quinn-style
+            // fixtures that bypass `P2pEndpoint` opt out of coordinator
+            // back-pressure entirely, which matches the pre-Tier-4
+            // behaviour they were originally written against.
+            relay_slot_table: None,
         }
     }
 }
@@ -592,8 +590,7 @@ impl fmt::Debug for TransportConfig {
             address_discovery_config,
             pqc_algorithms,
             allow_loopback,
-            coordinator_max_active_relays,
-            coordinator_relay_slot_timeout,
+            relay_slot_table,
         } = self;
         fmt.debug_struct("TransportConfig")
             .field("max_concurrent_bidi_streams", max_concurrent_bidi_streams)
@@ -626,14 +623,7 @@ impl fmt::Debug for TransportConfig {
             .field("address_discovery_config", address_discovery_config)
             .field("pqc_algorithms", pqc_algorithms)
             .field("allow_loopback", allow_loopback)
-            .field(
-                "coordinator_max_active_relays",
-                coordinator_max_active_relays,
-            )
-            .field(
-                "coordinator_relay_slot_timeout",
-                coordinator_relay_slot_timeout,
-            )
+            .field("relay_slot_table", relay_slot_table)
             .finish_non_exhaustive()
     }
 }

--- a/src/config/transport.rs
+++ b/src/config/transport.rs
@@ -65,6 +65,19 @@ pub struct TransportConfig {
 
     /// Allow loopback addresses as valid NAT traversal candidates
     pub(crate) allow_loopback: bool,
+
+    /// Maximum number of concurrent hole-punch relay slots this node will
+    /// service when acting as a coordinator (Tier 4 lite back-pressure).
+    /// When the active count reaches this cap, incoming `PUNCH_ME_NOW`
+    /// frames that would otherwise be relayed are silently refused so the
+    /// initiator advances to its next preferred coordinator.
+    pub(crate) coordinator_max_active_relays: usize,
+
+    /// Reclamation timeout for stale coordinator relay slots. Acts as a
+    /// safety net so a relay slot cannot leak forever if a peer crashes
+    /// mid-coordination, a NAT rebind silently drops the session, or a
+    /// follow-up signal is lost.
+    pub(crate) coordinator_relay_slot_timeout: Duration,
 }
 
 impl TransportConfig {
@@ -470,6 +483,21 @@ impl TransportConfig {
         self.allow_loopback = allow;
         self
     }
+
+    /// Cap on simultaneous hole-punch relay slots when this node acts as a
+    /// coordinator. Higher = more concurrency capacity, lower = stricter
+    /// back-pressure shedding under storm load. Default: 32.
+    pub fn coordinator_max_active_relays(&mut self, max: usize) -> &mut Self {
+        self.coordinator_max_active_relays = max;
+        self
+    }
+
+    /// Maximum lifetime of a coordinator relay slot before it is reclaimed
+    /// by the inline garbage-collection sweep. Default: 5 seconds.
+    pub fn coordinator_relay_slot_timeout(&mut self, timeout: Duration) -> &mut Self {
+        self.coordinator_relay_slot_timeout = timeout;
+        self
+    }
 }
 
 impl Default for TransportConfig {
@@ -523,6 +551,11 @@ impl Default for TransportConfig {
                 ml_dsa_65: false,
             }),
             allow_loopback: false,
+            // Tier 4 (lite) coordinator back-pressure defaults. See
+            // `coordinator_max_active_relays`/`coordinator_relay_slot_timeout`
+            // setters for the rationale behind these numbers.
+            coordinator_max_active_relays: 32,
+            coordinator_relay_slot_timeout: Duration::from_secs(5),
         }
     }
 }
@@ -559,6 +592,8 @@ impl fmt::Debug for TransportConfig {
             address_discovery_config,
             pqc_algorithms,
             allow_loopback,
+            coordinator_max_active_relays,
+            coordinator_relay_slot_timeout,
         } = self;
         fmt.debug_struct("TransportConfig")
             .field("max_concurrent_bidi_streams", max_concurrent_bidi_streams)
@@ -591,6 +626,14 @@ impl fmt::Debug for TransportConfig {
             .field("address_discovery_config", address_discovery_config)
             .field("pqc_algorithms", pqc_algorithms)
             .field("allow_loopback", allow_loopback)
+            .field(
+                "coordinator_max_active_relays",
+                coordinator_max_active_relays,
+            )
+            .field(
+                "coordinator_relay_slot_timeout",
+                coordinator_relay_slot_timeout,
+            )
             .finish_non_exhaustive()
     }
 }

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -4535,8 +4535,7 @@ impl Connection {
             max_candidates,
             coordination_timeout,
             self.config.allow_loopback,
-            self.config.coordinator_max_active_relays,
-            self.config.coordinator_relay_slot_timeout,
+            self.config.relay_slot_table.clone(),
         ));
 
         trace!("NAT traversal initialized for symmetric P2P node");
@@ -4735,8 +4734,7 @@ impl Connection {
             8,
             Duration::from_secs(10),
             self.config.allow_loopback,
-            self.config.coordinator_max_active_relays,
-            self.config.coordinator_relay_slot_timeout,
+            self.config.relay_slot_table.clone(),
         ));
     }
 
@@ -4870,7 +4868,13 @@ impl Connection {
                         return Ok(());
                     }
                     Ok(None) => {
-                        trace!("Coordination completed or no action needed");
+                        // Reaching this branch with `target_peer_id.is_some()`
+                        // (the only branch that calls this) means the
+                        // shared back-pressure table refused the relay.
+                        // The table itself logs and counts the refusal —
+                        // we drop silently so the initiator falls back
+                        // to the per-attempt timeout (Tier 2 rotation).
+                        trace!("PUNCH_ME_NOW relay refused by node-wide back-pressure");
                         return Ok(());
                     }
                     Err(e) => {

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -4841,16 +4841,15 @@ impl Connection {
                 let punch_me_now_clone = punch_me_now.clone();
                 drop(nat_state); // Release the borrow
 
-                match self
-                    .nat_traversal
-                    .as_mut()
-                    .unwrap()
-                    .handle_punch_me_now_frame(
-                        from_peer_id,
-                        self.path.remote,
-                        &punch_me_now_clone,
-                        now,
-                    ) {
+                let Some(nat) = self.nat_traversal.as_mut() else {
+                    return Ok(());
+                };
+                match nat.handle_punch_me_now_frame(
+                    from_peer_id,
+                    self.path.remote,
+                    &punch_me_now_clone,
+                    now,
+                ) {
                     Ok(Some(coordination_frame)) => {
                         trace!("Node coordinating PUNCH_ME_NOW between peers");
 

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -4535,6 +4535,8 @@ impl Connection {
             max_candidates,
             coordination_timeout,
             self.config.allow_loopback,
+            self.config.coordinator_max_active_relays,
+            self.config.coordinator_relay_slot_timeout,
         ));
 
         trace!("NAT traversal initialized for symmetric P2P node");
@@ -4733,6 +4735,8 @@ impl Connection {
             8,
             Duration::from_secs(10),
             self.config.allow_loopback,
+            self.config.coordinator_max_active_relays,
+            self.config.coordinator_relay_slot_timeout,
         ));
     }
 

--- a/src/connection/nat_traversal.rs
+++ b/src/connection/nat_traversal.rs
@@ -8,6 +8,7 @@
 use std::{
     collections::{HashMap, VecDeque},
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    sync::Arc,
     time::Duration,
 };
 
@@ -1821,24 +1822,23 @@ impl NatTraversalState {
     /// v0.13.0: Role parameter removed - all nodes are symmetric P2P nodes.
     /// Every node can initiate, accept, and coordinate NAT traversal.
     ///
-    /// `coordinator_max_active_relays` and `coordinator_relay_slot_timeout`
-    /// configure Tier 4 (lite) coordinator-side back-pressure: when this
-    /// node acts as a hole-punch coordinator, it will silently refuse new
-    /// `PUNCH_ME_NOW` relays once `coordinator_max_active_relays` slots are
-    /// in flight, and reclaim stale slots that exceed the timeout.
+    /// `relay_slot_table` is the shared, node-wide back-pressure table
+    /// (Tier 4 lite). When `Some`, the bootstrap coordinator embedded in
+    /// this state gates incoming `PUNCH_ME_NOW` relay frames against the
+    /// shared table — the cap is enforced across *all* connections at
+    /// this node, not per-connection. Pass `None` in low-level fixtures
+    /// that do not run a coordinator.
     pub(super) fn new(
         max_candidates: u32,
         coordination_timeout: Duration,
         allow_loopback: bool,
-        coordinator_max_active_relays: usize,
-        coordinator_relay_slot_timeout: Duration,
+        relay_slot_table: Option<Arc<crate::relay_slot_table::RelaySlotTable>>,
     ) -> Self {
         // v0.13.0: All nodes can coordinate - always create coordinator
         let bootstrap_coordinator = Some(BootstrapCoordinator::new(
             BootstrapConfig::default(),
             allow_loopback,
-            coordinator_max_active_relays,
-            coordinator_relay_slot_timeout,
+            relay_slot_table,
         ));
 
         Self {
@@ -3566,22 +3566,33 @@ pub(crate) struct BootstrapCoordinator {
     security_validator: SecurityValidationState,
     /// Statistics for bootstrap operations
     stats: BootstrapStats,
-    /// Active hole-punch relay slots indexed by `(initiator_peer_id,
-    /// target_peer_id)`. Each entry records the wall-clock arrival time of
-    /// the `PUNCH_ME_NOW` frame that opened the slot. Slots are reclaimed
-    /// either implicitly (when a follow-up frame from the same pair lands)
-    /// or by the inline garbage-collection sweep run on every incoming
-    /// frame: any slot older than `coordinator_relay_slot_timeout` is
-    /// evicted before the back-pressure check, which keeps the active
-    /// count from leaking on ghost sessions where the initiator crashed
-    /// or the target became unreachable mid-coordination.
-    relay_slots: HashMap<(PeerId, PeerId), Instant>,
-    /// Cap on simultaneous relay slots (Tier 4 lite back-pressure).
-    /// Plumbed from [`crate::config::TransportConfig::coordinator_max_active_relays`].
-    relay_slot_capacity: usize,
-    /// Reclamation timeout for stale relay slots. Plumbed from
-    /// [`crate::config::TransportConfig::coordinator_relay_slot_timeout`].
-    relay_slot_timeout: Duration,
+    /// Shared, node-wide back-pressure table (Tier 4 lite). When `Some`,
+    /// every incoming `PUNCH_ME_NOW` relay frame must acquire a slot in
+    /// this table before being relayed; the cap is enforced *across all*
+    /// connections at this node, not per-connection.
+    ///
+    /// On `Drop` (i.e. when the connection that hosts this coordinator
+    /// closes) all slots whose initiator address matches the connection's
+    /// remote address are released — the explicit-completion path that
+    /// reclaims capacity ahead of the idle-timeout safety net.
+    relay_slot_table: Option<Arc<crate::relay_slot_table::RelaySlotTable>>,
+    /// Remote address of the connection that owns this coordinator.
+    /// Captured the first time we relay a frame; used as the slot key's
+    /// initiator-side identifier and as the argument to
+    /// `release_for_initiator` in [`Drop`]. `None` until the first
+    /// `PUNCH_ME_NOW` arrives.
+    relay_initiator_addr: Option<SocketAddr>,
+}
+
+impl Drop for BootstrapCoordinator {
+    fn drop(&mut self) {
+        // Explicitly release every slot we opened so the shared table
+        // doesn't have to wait out the idle timeout for a connection
+        // that has just closed.
+        if let (Some(table), Some(addr)) = (&self.relay_slot_table, self.relay_initiator_addr) {
+            table.release_for_initiator(addr);
+        }
+    }
 }
 // Removed legacy CoordinationSessionId type
 /// Peer identifier for bootstrap coordination
@@ -3667,25 +3678,21 @@ pub(crate) struct BootstrapStats {
     successful_coordinations: u64,
     /// Security rejections
     security_rejections: u64,
-    /// Refusals due to active-relay back-pressure (Tier 4 lite). Tracks the
-    /// number of `PUNCH_ME_NOW` frames silently dropped because the
-    /// coordinator was at `relay_slot_capacity` when they arrived.
-    backpressure_refusals: u64,
 }
 // Removed session state machine enums and recovery actions
 impl BootstrapCoordinator {
     /// Create a new bootstrap coordinator.
     ///
-    /// `relay_slot_capacity` and `relay_slot_timeout` configure the
-    /// Tier 4 (lite) back-pressure: incoming `PUNCH_ME_NOW` relay frames
-    /// are silently refused once `relay_slot_capacity` slots are in
-    /// flight, and any slot older than `relay_slot_timeout` is reclaimed
-    /// by the inline garbage-collection sweep on every incoming frame.
+    /// `relay_slot_table` is the shared, node-wide back-pressure table
+    /// (Tier 4 lite). When `Some`, incoming `PUNCH_ME_NOW` relay frames
+    /// must acquire a slot from the table before being relayed; the cap
+    /// is enforced across all connections at this node. Pass `None` in
+    /// low-level test fixtures that exercise the connection state machine
+    /// without a P2pEndpoint.
     pub(crate) fn new(
         _config: BootstrapConfig,
         allow_loopback: bool,
-        relay_slot_capacity: usize,
-        relay_slot_timeout: Duration,
+        relay_slot_table: Option<Arc<crate::relay_slot_table::RelaySlotTable>>,
     ) -> Self {
         Self {
             address_observations: HashMap::new(),
@@ -3693,21 +3700,11 @@ impl BootstrapCoordinator {
             coordination_table: HashMap::new(),
             security_validator: SecurityValidationState::new(allow_loopback),
             stats: BootstrapStats::default(),
-            relay_slots: HashMap::new(),
-            relay_slot_capacity,
-            relay_slot_timeout,
+            relay_slot_table,
+            relay_initiator_addr: None,
         }
     }
 
-    /// Reclaim relay slots whose arrival timestamp is older than the
-    /// configured `relay_slot_timeout`. Called inline at the start of
-    /// every `PUNCH_ME_NOW` frame so that ghost slots from crashed peers
-    /// or dropped sessions cannot leak the active-relay counter.
-    fn sweep_stale_relay_slots(&mut self, now: Instant) {
-        let timeout = self.relay_slot_timeout;
-        self.relay_slots
-            .retain(|_, &mut arrived_at| now.duration_since(arrived_at) < timeout);
-    }
     /// Observe a peer's address from an incoming connection
     ///
     /// This is called when a peer connects to this bootstrap node,
@@ -3844,34 +3841,34 @@ impl BootstrapCoordinator {
             })?;
 
         // Tier 4 (lite) back-pressure: only the relay branch (where the
-        // frame carries an explicit `target_peer_id`) consumes a slot. If
-        // we are at capacity for active relays, silently drop the frame —
-        // the initiator's per-attempt timeout (Tier 2 rotation) will move
-        // it on to its next preferred coordinator.
+        // frame carries an explicit `target_peer_id`) consumes a slot.
+        // The shared `RelaySlotTable` enforces the cap *across all
+        // connections* at this node — when full, the relay is silently
+        // refused and the initiator's per-attempt timeout (Tier 2
+        // rotation) drives it to its next preferred coordinator.
         //
-        // Inline garbage-collection sweep first so any stale slots from
-        // crashed peers are reclaimed before the cap check.
+        // Slots are keyed by `(initiator_addr, target_peer_id)`. The
+        // initiator address is the connection's remote socket address
+        // (constant for the lifetime of this BootstrapCoordinator), so
+        // multi-round coordination from the same peer naturally re-arms
+        // the same slot without consuming additional capacity.
         if let Some(target_peer_id) = frame.target_peer_id {
-            self.sweep_stale_relay_slots(now);
-            let slot_key = (from_peer, target_peer_id);
-            // Re-arming an existing slot for the same (initiator, target)
-            // pair does not consume an additional slot — common during
-            // multi-round coordination where the same pair re-sends.
-            let already_active = self.relay_slots.contains_key(&slot_key);
-            if !already_active && self.relay_slots.len() >= self.relay_slot_capacity {
-                self.stats.backpressure_refusals =
-                    self.stats.backpressure_refusals.saturating_add(1);
-                debug!(
-                    "PUNCH_ME_NOW relay refused: coordinator at capacity ({}/{}) — initiator {:?} → target {:?}",
-                    self.relay_slots.len(),
-                    self.relay_slot_capacity,
-                    hex::encode(&from_peer[..8]),
-                    hex::encode(&target_peer_id[..8])
-                );
+            // Cache the initiator addr the first time we see it so
+            // `Drop` can release every slot we opened, even if the
+            // connection closes mid-session.
+            if self.relay_initiator_addr.is_none() {
+                self.relay_initiator_addr = Some(source_addr);
+            }
+            if let Some(table) = &self.relay_slot_table
+                && !table.try_acquire(source_addr, target_peer_id, now)
+            {
+                // Refused. The table itself logs/counts the event;
+                // returning `Ok(None)` means "no coordination frame
+                // produced" and is dispatched at the call site as a
+                // silent drop, surfacing to the initiator only as a
+                // per-attempt timeout.
                 return Ok(None);
             }
-            // Accept: insert/refresh the slot timestamp.
-            self.relay_slots.insert(slot_key, now);
         }
 
         // Track coordination entry minimally
@@ -3986,14 +3983,23 @@ impl BootstrapCoordinator {
 mod tests {
     use super::*;
 
+    /// Build a test fixture `RelaySlotTable` so the BootstrapCoordinator
+    /// embedded in `NatTraversalState` can exercise the back-pressure
+    /// path. Production code obtains the table from `P2pEndpoint`.
+    fn make_test_relay_slot_table() -> Arc<crate::relay_slot_table::RelaySlotTable> {
+        Arc::new(crate::relay_slot_table::RelaySlotTable::new(
+            32,
+            Duration::from_secs(5),
+        ))
+    }
+
     // v0.13.0: Role parameter removed - all nodes are symmetric P2P nodes
     fn create_test_state() -> NatTraversalState {
         NatTraversalState::new(
             10,                      // max_candidates
             Duration::from_secs(30), // coordination_timeout
             true,                    // allow_loopback for tests
-            32,                      // coordinator_max_active_relays
-            Duration::from_secs(5),  // coordinator_relay_slot_timeout
+            Some(make_test_relay_slot_table()),
         )
     }
 
@@ -4376,8 +4382,7 @@ mod tests {
             100, // max_candidates (high enough to not limit)
             Duration::from_secs(30),
             true, // allow_loopback for tests
-            32,
-            Duration::from_secs(5),
+            Some(make_test_relay_slot_table()),
         );
         let now = Instant::now();
 
@@ -4412,8 +4417,7 @@ mod tests {
             100,
             Duration::from_secs(30),
             true,
-            32,
-            Duration::from_secs(5),
+            Some(make_test_relay_slot_table()),
         );
         let now = Instant::now();
 
@@ -4498,8 +4502,7 @@ mod tests {
             100,
             Duration::from_secs(30),
             true,
-            32,
-            Duration::from_secs(5),
+            Some(make_test_relay_slot_table()),
         );
         let now = Instant::now();
 
@@ -4534,22 +4537,40 @@ mod tests {
     }
 
     // ---- Tier 4 (lite): coordinator-side back-pressure ----
+    //
+    // The pure data-structure tests live next to the table itself in
+    // `crate::relay_slot_table::tests`. The tests below verify the
+    // *integration* between `BootstrapCoordinator` and the shared
+    // `RelaySlotTable`: that the relay branch consumes a slot, the
+    // non-relay (echo) branch does not, and that the coordinator
+    // releases its slots in `Drop` so a closed connection reclaims
+    // capacity ahead of the idle-timeout safety net.
 
-    /// Helper: build a `BootstrapCoordinator` with controllable cap and
-    /// timeout for back-pressure tests.
-    fn make_bp_coordinator(capacity: usize, timeout: Duration) -> BootstrapCoordinator {
-        BootstrapCoordinator::new(
+    /// Build a `BootstrapCoordinator` wired to a fresh shared
+    /// `RelaySlotTable` with the given capacity. Returns both so tests
+    /// can inspect the table directly.
+    fn make_coord_with_table(
+        capacity: usize,
+        timeout: Duration,
+    ) -> (
+        BootstrapCoordinator,
+        Arc<crate::relay_slot_table::RelaySlotTable>,
+    ) {
+        let table = Arc::new(crate::relay_slot_table::RelaySlotTable::new(
+            capacity, timeout,
+        ));
+        let coord = BootstrapCoordinator::new(
             BootstrapConfig::default(),
-            true, // allow_loopback so test addrs aren't rejected
-            capacity,
-            timeout,
-        )
+            true, // allow_loopback for test addrs
+            Some(Arc::clone(&table)),
+        );
+        (coord, table)
     }
 
-    /// Helper: build a `PunchMeNow` frame for the relay path (with target).
-    fn make_relay_frame(round: u64, target_peer_id: [u8; 32]) -> crate::frame::PunchMeNow {
+    /// `PunchMeNow` frame for the relay path (with target).
+    fn relay_frame(round: u32, target_peer_id: [u8; 32]) -> crate::frame::PunchMeNow {
         crate::frame::PunchMeNow {
-            round: VarInt::from_u64(round).unwrap_or(VarInt::from_u32(0)),
+            round: VarInt::from_u32(round),
             paired_with_sequence_number: VarInt::from_u32(0),
             address: SocketAddr::from(([127, 0, 0, 1], 9000)),
             target_peer_id: Some(target_peer_id),
@@ -4563,151 +4584,52 @@ mod tests {
     }
 
     #[test]
-    fn coordinator_accepts_relay_under_capacity() {
-        let mut coord = make_bp_coordinator(4, Duration::from_secs(5));
+    fn coordinator_relay_consumes_shared_slot() {
+        let (mut coord, table) = make_coord_with_table(4, Duration::from_secs(5));
         let now = Instant::now();
         let from = peer_id_with_byte(0x01);
         let target = peer_id_with_byte(0x02);
-        let frame = make_relay_frame(1, target);
         let source_addr = SocketAddr::from(([127, 0, 0, 1], 5000));
 
         let result = coord
-            .process_punch_me_now_frame(from, source_addr, &frame, now)
+            .process_punch_me_now_frame(from, source_addr, &relay_frame(1, target), now)
             .expect("relay under cap should not error");
 
         assert!(
             result.is_some(),
             "relay under capacity should produce a coordination frame"
         );
-        assert_eq!(coord.relay_slots.len(), 1, "one slot should be allocated");
-        assert_eq!(
-            coord.stats.backpressure_refusals, 0,
-            "no refusal stat increment expected when under cap"
-        );
+        assert_eq!(table.active_count(), 1);
+        assert_eq!(table.backpressure_refusals(), 0);
     }
 
     #[test]
-    fn coordinator_refuses_silently_at_capacity() {
-        let capacity = 2;
-        let mut coord = make_bp_coordinator(capacity, Duration::from_secs(5));
+    fn coordinator_refuses_silently_when_table_at_capacity() {
+        // Pre-fill the shared table from outside the coordinator. The
+        // coordinator's relay attempt then sees the cap and silently
+        // refuses, returning Ok(None).
+        let (mut coord, table) = make_coord_with_table(1, Duration::from_secs(5));
         let now = Instant::now();
+        let other_initiator = SocketAddr::from(([127, 0, 0, 1], 9999));
+        assert!(table.try_acquire(other_initiator, peer_id_with_byte(0xAB), now));
+        assert_eq!(table.active_count(), 1);
+
+        let from = peer_id_with_byte(0x01);
+        let target = peer_id_with_byte(0x02);
         let source_addr = SocketAddr::from(([127, 0, 0, 1], 5000));
-
-        // Fill capacity with two distinct (initiator, target) pairs.
-        for i in 0..capacity {
-            let from = peer_id_with_byte(0x10 + i as u8);
-            let target = peer_id_with_byte(0x20 + i as u8);
-            let frame = make_relay_frame(i as u64 + 1, target);
-            let result = coord
-                .process_punch_me_now_frame(from, source_addr, &frame, now)
-                .expect("under-cap relay should not error");
-            assert!(result.is_some(), "slot {} should be accepted", i);
-        }
-        assert_eq!(coord.relay_slots.len(), capacity);
-
-        // The next distinct pair must be silently refused: Ok(None).
-        let overflow_from = peer_id_with_byte(0xFE);
-        let overflow_target = peer_id_with_byte(0xFD);
-        let overflow_frame = make_relay_frame(99, overflow_target);
         let result = coord
-            .process_punch_me_now_frame(overflow_from, source_addr, &overflow_frame, now)
-            .expect("at-cap refusal must be silent (no error)");
+            .process_punch_me_now_frame(from, source_addr, &relay_frame(1, target), now)
+            .expect("refusal must be silent (Ok)");
 
         assert!(
             result.is_none(),
             "at-cap refusal must produce no coordination frame"
         );
+        assert_eq!(table.active_count(), 1, "refused frame must not insert");
         assert_eq!(
-            coord.relay_slots.len(),
-            capacity,
-            "refused frame must not consume a slot"
-        );
-        assert_eq!(
-            coord.stats.backpressure_refusals, 1,
-            "back-pressure stat must increment on refusal"
-        );
-    }
-
-    #[test]
-    fn coordinator_re_arms_existing_slot_without_consuming_capacity() {
-        let mut coord = make_bp_coordinator(2, Duration::from_secs(5));
-        let now = Instant::now();
-        let source_addr = SocketAddr::from(([127, 0, 0, 1], 5000));
-        let from = peer_id_with_byte(0x01);
-        let target = peer_id_with_byte(0x02);
-        let frame = make_relay_frame(1, target);
-
-        // Fill the first slot.
-        coord
-            .process_punch_me_now_frame(from, source_addr, &frame, now)
-            .expect("first frame ok");
-        assert_eq!(coord.relay_slots.len(), 1);
-
-        // Re-send for the same (from, target) pair: must not consume an
-        // additional slot, must still be accepted.
-        let later = now + Duration::from_millis(500);
-        let result = coord
-            .process_punch_me_now_frame(from, source_addr, &frame, later)
-            .expect("re-arm ok");
-        assert!(result.is_some(), "re-armed slot should still be relayed");
-        assert_eq!(
-            coord.relay_slots.len(),
+            table.backpressure_refusals(),
             1,
-            "re-arming the same pair must not allocate a second slot"
-        );
-        // Slot timestamp should refresh to the later instant.
-        let slot_arrived = coord
-            .relay_slots
-            .get(&(from, target))
-            .copied()
-            .expect("slot present");
-        assert_eq!(
-            slot_arrived, later,
-            "re-arm must refresh the slot timestamp"
-        );
-    }
-
-    #[test]
-    fn coordinator_sweep_reclaims_stale_slots() {
-        let timeout = Duration::from_secs(5);
-        let mut coord = make_bp_coordinator(2, timeout);
-        let now = Instant::now();
-        let source_addr = SocketAddr::from(([127, 0, 0, 1], 5000));
-
-        // Fill capacity.
-        for i in 0..2u8 {
-            let from = peer_id_with_byte(0x10 + i);
-            let target = peer_id_with_byte(0x20 + i);
-            let frame = make_relay_frame(i as u64 + 1, target);
-            coord
-                .process_punch_me_now_frame(from, source_addr, &frame, now)
-                .expect("under-cap ok");
-        }
-        assert_eq!(coord.relay_slots.len(), 2);
-
-        // Advance well past the slot timeout. The next incoming frame's
-        // inline sweep must reclaim both stale slots before applying the
-        // back-pressure check.
-        let much_later = now + timeout + Duration::from_secs(1);
-        let new_from = peer_id_with_byte(0xAA);
-        let new_target = peer_id_with_byte(0xBB);
-        let new_frame = make_relay_frame(42, new_target);
-        let result = coord
-            .process_punch_me_now_frame(new_from, source_addr, &new_frame, much_later)
-            .expect("post-sweep frame should succeed");
-
-        assert!(
-            result.is_some(),
-            "frame after sweep must be accepted (capacity reclaimed)"
-        );
-        assert_eq!(
-            coord.relay_slots.len(),
-            1,
-            "stale slots must be reclaimed; only the new one remains"
-        );
-        assert_eq!(
-            coord.stats.backpressure_refusals, 0,
-            "no refusal expected because sweep freed capacity in time"
+            "table refusal stat must increment"
         );
     }
 
@@ -4715,7 +4637,7 @@ mod tests {
     fn coordinator_non_relay_frame_does_not_consume_slot() {
         // PUNCH_ME_NOW without a target_peer_id is the response/echo path,
         // not a relay request — it must NOT consume a back-pressure slot.
-        let mut coord = make_bp_coordinator(1, Duration::from_secs(5));
+        let (mut coord, table) = make_coord_with_table(1, Duration::from_secs(5));
         let now = Instant::now();
         let source_addr = SocketAddr::from(([127, 0, 0, 1], 5000));
         let from = peer_id_with_byte(0x01);
@@ -4730,9 +4652,47 @@ mod tests {
             .process_punch_me_now_frame(from, source_addr, &frame, now)
             .expect("non-relay frame ok");
         assert_eq!(
-            coord.relay_slots.len(),
+            table.active_count(),
             0,
             "non-relay frame must not consume a slot"
+        );
+    }
+
+    #[test]
+    fn coordinator_drop_releases_owned_slots() {
+        // This is the "explicit completion" path that fixes H2 — when
+        // the connection that hosts a coordinator drops, every slot it
+        // opened must be reclaimed without waiting out the idle timeout.
+        let (mut coord, table) = make_coord_with_table(8, Duration::from_secs(5));
+        let now = Instant::now();
+        let from = peer_id_with_byte(0x01);
+        let source_addr = SocketAddr::from(([127, 0, 0, 1], 5000));
+
+        // Open three slots from this coordinator (three distinct targets).
+        for t in [0xAA, 0xBB, 0xCC] {
+            let _ = coord
+                .process_punch_me_now_frame(
+                    from,
+                    source_addr,
+                    &relay_frame(1, peer_id_with_byte(t)),
+                    now,
+                )
+                .expect("relay under cap ok");
+        }
+        // And one slot from a *different* initiator (a different
+        // BootstrapCoordinator instance would normally own this; we
+        // simulate by acquiring directly).
+        let other_initiator = SocketAddr::from(([10, 0, 0, 1], 7777));
+        assert!(table.try_acquire(other_initiator, peer_id_with_byte(0xDD), now));
+        assert_eq!(table.active_count(), 4);
+
+        // Drop the coordinator. Its three slots must be released; the
+        // other initiator's slot must remain.
+        drop(coord);
+        assert_eq!(
+            table.active_count(),
+            1,
+            "Drop must release every slot owned by this initiator address"
         );
     }
 }

--- a/src/connection/nat_traversal.rs
+++ b/src/connection/nat_traversal.rs
@@ -480,7 +480,7 @@ impl SecurityValidationState {
             max_candidates_per_window: 20, // Max 20 candidates per 60 seconds
             rate_window: Duration::from_secs(60),
             coordination_requests: VecDeque::new(),
-            max_coordination_per_window: 5, // Max 5 coordination requests per 60 seconds
+            max_coordination_per_window: 50, // Max 50 coordination requests per 60 seconds
             address_validation_cache: HashMap::new(),
             validation_cache_timeout: Duration::from_secs(300), // 5 minute cache
             allow_loopback,

--- a/src/connection/nat_traversal.rs
+++ b/src/connection/nat_traversal.rs
@@ -1820,15 +1820,25 @@ impl NatTraversalState {
     ///
     /// v0.13.0: Role parameter removed - all nodes are symmetric P2P nodes.
     /// Every node can initiate, accept, and coordinate NAT traversal.
+    ///
+    /// `coordinator_max_active_relays` and `coordinator_relay_slot_timeout`
+    /// configure Tier 4 (lite) coordinator-side back-pressure: when this
+    /// node acts as a hole-punch coordinator, it will silently refuse new
+    /// `PUNCH_ME_NOW` relays once `coordinator_max_active_relays` slots are
+    /// in flight, and reclaim stale slots that exceed the timeout.
     pub(super) fn new(
         max_candidates: u32,
         coordination_timeout: Duration,
         allow_loopback: bool,
+        coordinator_max_active_relays: usize,
+        coordinator_relay_slot_timeout: Duration,
     ) -> Self {
         // v0.13.0: All nodes can coordinate - always create coordinator
         let bootstrap_coordinator = Some(BootstrapCoordinator::new(
             BootstrapConfig::default(),
             allow_loopback,
+            coordinator_max_active_relays,
+            coordinator_relay_slot_timeout,
         ));
 
         Self {
@@ -3556,6 +3566,22 @@ pub(crate) struct BootstrapCoordinator {
     security_validator: SecurityValidationState,
     /// Statistics for bootstrap operations
     stats: BootstrapStats,
+    /// Active hole-punch relay slots indexed by `(initiator_peer_id,
+    /// target_peer_id)`. Each entry records the wall-clock arrival time of
+    /// the `PUNCH_ME_NOW` frame that opened the slot. Slots are reclaimed
+    /// either implicitly (when a follow-up frame from the same pair lands)
+    /// or by the inline garbage-collection sweep run on every incoming
+    /// frame: any slot older than `coordinator_relay_slot_timeout` is
+    /// evicted before the back-pressure check, which keeps the active
+    /// count from leaking on ghost sessions where the initiator crashed
+    /// or the target became unreachable mid-coordination.
+    relay_slots: HashMap<(PeerId, PeerId), Instant>,
+    /// Cap on simultaneous relay slots (Tier 4 lite back-pressure).
+    /// Plumbed from [`crate::config::TransportConfig::coordinator_max_active_relays`].
+    relay_slot_capacity: usize,
+    /// Reclamation timeout for stale relay slots. Plumbed from
+    /// [`crate::config::TransportConfig::coordinator_relay_slot_timeout`].
+    relay_slot_timeout: Duration,
 }
 // Removed legacy CoordinationSessionId type
 /// Peer identifier for bootstrap coordination
@@ -3641,18 +3667,46 @@ pub(crate) struct BootstrapStats {
     successful_coordinations: u64,
     /// Security rejections
     security_rejections: u64,
+    /// Refusals due to active-relay back-pressure (Tier 4 lite). Tracks the
+    /// number of `PUNCH_ME_NOW` frames silently dropped because the
+    /// coordinator was at `relay_slot_capacity` when they arrived.
+    backpressure_refusals: u64,
 }
 // Removed session state machine enums and recovery actions
 impl BootstrapCoordinator {
-    /// Create a new bootstrap coordinator
-    pub(crate) fn new(_config: BootstrapConfig, allow_loopback: bool) -> Self {
+    /// Create a new bootstrap coordinator.
+    ///
+    /// `relay_slot_capacity` and `relay_slot_timeout` configure the
+    /// Tier 4 (lite) back-pressure: incoming `PUNCH_ME_NOW` relay frames
+    /// are silently refused once `relay_slot_capacity` slots are in
+    /// flight, and any slot older than `relay_slot_timeout` is reclaimed
+    /// by the inline garbage-collection sweep on every incoming frame.
+    pub(crate) fn new(
+        _config: BootstrapConfig,
+        allow_loopback: bool,
+        relay_slot_capacity: usize,
+        relay_slot_timeout: Duration,
+    ) -> Self {
         Self {
             address_observations: HashMap::new(),
             peer_index: HashMap::new(),
             coordination_table: HashMap::new(),
             security_validator: SecurityValidationState::new(allow_loopback),
             stats: BootstrapStats::default(),
+            relay_slots: HashMap::new(),
+            relay_slot_capacity,
+            relay_slot_timeout,
         }
+    }
+
+    /// Reclaim relay slots whose arrival timestamp is older than the
+    /// configured `relay_slot_timeout`. Called inline at the start of
+    /// every `PUNCH_ME_NOW` frame so that ghost slots from crashed peers
+    /// or dropped sessions cannot leak the active-relay counter.
+    fn sweep_stale_relay_slots(&mut self, now: Instant) {
+        let timeout = self.relay_slot_timeout;
+        self.relay_slots
+            .retain(|_, &mut arrived_at| now.duration_since(arrived_at) < timeout);
     }
     /// Observe a peer's address from an incoming connection
     ///
@@ -3789,6 +3843,37 @@ impl BootstrapCoordinator {
                 );
             })?;
 
+        // Tier 4 (lite) back-pressure: only the relay branch (where the
+        // frame carries an explicit `target_peer_id`) consumes a slot. If
+        // we are at capacity for active relays, silently drop the frame —
+        // the initiator's per-attempt timeout (Tier 2 rotation) will move
+        // it on to its next preferred coordinator.
+        //
+        // Inline garbage-collection sweep first so any stale slots from
+        // crashed peers are reclaimed before the cap check.
+        if let Some(target_peer_id) = frame.target_peer_id {
+            self.sweep_stale_relay_slots(now);
+            let slot_key = (from_peer, target_peer_id);
+            // Re-arming an existing slot for the same (initiator, target)
+            // pair does not consume an additional slot — common during
+            // multi-round coordination where the same pair re-sends.
+            let already_active = self.relay_slots.contains_key(&slot_key);
+            if !already_active && self.relay_slots.len() >= self.relay_slot_capacity {
+                self.stats.backpressure_refusals =
+                    self.stats.backpressure_refusals.saturating_add(1);
+                debug!(
+                    "PUNCH_ME_NOW relay refused: coordinator at capacity ({}/{}) — initiator {:?} → target {:?}",
+                    self.relay_slots.len(),
+                    self.relay_slot_capacity,
+                    hex::encode(&from_peer[..8]),
+                    hex::encode(&target_peer_id[..8])
+                );
+                return Ok(None);
+            }
+            // Accept: insert/refresh the slot timestamp.
+            self.relay_slots.insert(slot_key, now);
+        }
+
         // Track coordination entry minimally
         let _entry = self
             .coordination_table
@@ -3907,6 +3992,8 @@ mod tests {
             10,                      // max_candidates
             Duration::from_secs(30), // coordination_timeout
             true,                    // allow_loopback for tests
+            32,                      // coordinator_max_active_relays
+            Duration::from_secs(5),  // coordinator_relay_slot_timeout
         )
     }
 
@@ -4289,6 +4376,8 @@ mod tests {
             100, // max_candidates (high enough to not limit)
             Duration::from_secs(30),
             true, // allow_loopback for tests
+            32,
+            Duration::from_secs(5),
         );
         let now = Instant::now();
 
@@ -4319,7 +4408,13 @@ mod tests {
     #[test]
     fn test_add_pairs_at_exact_limit() {
         // Test behavior when exactly at the limit
-        let mut state = NatTraversalState::new(100, Duration::from_secs(30), true);
+        let mut state = NatTraversalState::new(
+            100,
+            Duration::from_secs(30),
+            true,
+            32,
+            Duration::from_secs(5),
+        );
         let now = Instant::now();
 
         // Add candidates to get close to limit (14 × 14 = 196 pairs)
@@ -4399,7 +4494,13 @@ mod tests {
     #[test]
     fn test_incremental_add_with_zero_remaining_capacity() {
         // Test that incremental add gracefully handles zero capacity
-        let mut state = NatTraversalState::new(100, Duration::from_secs(30), true);
+        let mut state = NatTraversalState::new(
+            100,
+            Duration::from_secs(30),
+            true,
+            32,
+            Duration::from_secs(5),
+        );
         let now = Instant::now();
 
         // Fill up to the limit
@@ -4429,6 +4530,209 @@ mod tests {
         assert!(
             state.candidate_pairs.len() <= 200,
             "Should handle limit gracefully without panic"
+        );
+    }
+
+    // ---- Tier 4 (lite): coordinator-side back-pressure ----
+
+    /// Helper: build a `BootstrapCoordinator` with controllable cap and
+    /// timeout for back-pressure tests.
+    fn make_bp_coordinator(capacity: usize, timeout: Duration) -> BootstrapCoordinator {
+        BootstrapCoordinator::new(
+            BootstrapConfig::default(),
+            true, // allow_loopback so test addrs aren't rejected
+            capacity,
+            timeout,
+        )
+    }
+
+    /// Helper: build a `PunchMeNow` frame for the relay path (with target).
+    fn make_relay_frame(round: u64, target_peer_id: [u8; 32]) -> crate::frame::PunchMeNow {
+        crate::frame::PunchMeNow {
+            round: VarInt::from_u64(round).unwrap_or(VarInt::from_u32(0)),
+            paired_with_sequence_number: VarInt::from_u32(0),
+            address: SocketAddr::from(([127, 0, 0, 1], 9000)),
+            target_peer_id: Some(target_peer_id),
+        }
+    }
+
+    fn peer_id_with_byte(byte: u8) -> [u8; 32] {
+        let mut id = [0u8; 32];
+        id[0] = byte;
+        id
+    }
+
+    #[test]
+    fn coordinator_accepts_relay_under_capacity() {
+        let mut coord = make_bp_coordinator(4, Duration::from_secs(5));
+        let now = Instant::now();
+        let from = peer_id_with_byte(0x01);
+        let target = peer_id_with_byte(0x02);
+        let frame = make_relay_frame(1, target);
+        let source_addr = SocketAddr::from(([127, 0, 0, 1], 5000));
+
+        let result = coord
+            .process_punch_me_now_frame(from, source_addr, &frame, now)
+            .expect("relay under cap should not error");
+
+        assert!(
+            result.is_some(),
+            "relay under capacity should produce a coordination frame"
+        );
+        assert_eq!(coord.relay_slots.len(), 1, "one slot should be allocated");
+        assert_eq!(
+            coord.stats.backpressure_refusals, 0,
+            "no refusal stat increment expected when under cap"
+        );
+    }
+
+    #[test]
+    fn coordinator_refuses_silently_at_capacity() {
+        let capacity = 2;
+        let mut coord = make_bp_coordinator(capacity, Duration::from_secs(5));
+        let now = Instant::now();
+        let source_addr = SocketAddr::from(([127, 0, 0, 1], 5000));
+
+        // Fill capacity with two distinct (initiator, target) pairs.
+        for i in 0..capacity {
+            let from = peer_id_with_byte(0x10 + i as u8);
+            let target = peer_id_with_byte(0x20 + i as u8);
+            let frame = make_relay_frame(i as u64 + 1, target);
+            let result = coord
+                .process_punch_me_now_frame(from, source_addr, &frame, now)
+                .expect("under-cap relay should not error");
+            assert!(result.is_some(), "slot {} should be accepted", i);
+        }
+        assert_eq!(coord.relay_slots.len(), capacity);
+
+        // The next distinct pair must be silently refused: Ok(None).
+        let overflow_from = peer_id_with_byte(0xFE);
+        let overflow_target = peer_id_with_byte(0xFD);
+        let overflow_frame = make_relay_frame(99, overflow_target);
+        let result = coord
+            .process_punch_me_now_frame(overflow_from, source_addr, &overflow_frame, now)
+            .expect("at-cap refusal must be silent (no error)");
+
+        assert!(
+            result.is_none(),
+            "at-cap refusal must produce no coordination frame"
+        );
+        assert_eq!(
+            coord.relay_slots.len(),
+            capacity,
+            "refused frame must not consume a slot"
+        );
+        assert_eq!(
+            coord.stats.backpressure_refusals, 1,
+            "back-pressure stat must increment on refusal"
+        );
+    }
+
+    #[test]
+    fn coordinator_re_arms_existing_slot_without_consuming_capacity() {
+        let mut coord = make_bp_coordinator(2, Duration::from_secs(5));
+        let now = Instant::now();
+        let source_addr = SocketAddr::from(([127, 0, 0, 1], 5000));
+        let from = peer_id_with_byte(0x01);
+        let target = peer_id_with_byte(0x02);
+        let frame = make_relay_frame(1, target);
+
+        // Fill the first slot.
+        coord
+            .process_punch_me_now_frame(from, source_addr, &frame, now)
+            .expect("first frame ok");
+        assert_eq!(coord.relay_slots.len(), 1);
+
+        // Re-send for the same (from, target) pair: must not consume an
+        // additional slot, must still be accepted.
+        let later = now + Duration::from_millis(500);
+        let result = coord
+            .process_punch_me_now_frame(from, source_addr, &frame, later)
+            .expect("re-arm ok");
+        assert!(result.is_some(), "re-armed slot should still be relayed");
+        assert_eq!(
+            coord.relay_slots.len(),
+            1,
+            "re-arming the same pair must not allocate a second slot"
+        );
+        // Slot timestamp should refresh to the later instant.
+        let slot_arrived = coord
+            .relay_slots
+            .get(&(from, target))
+            .copied()
+            .expect("slot present");
+        assert_eq!(
+            slot_arrived, later,
+            "re-arm must refresh the slot timestamp"
+        );
+    }
+
+    #[test]
+    fn coordinator_sweep_reclaims_stale_slots() {
+        let timeout = Duration::from_secs(5);
+        let mut coord = make_bp_coordinator(2, timeout);
+        let now = Instant::now();
+        let source_addr = SocketAddr::from(([127, 0, 0, 1], 5000));
+
+        // Fill capacity.
+        for i in 0..2u8 {
+            let from = peer_id_with_byte(0x10 + i);
+            let target = peer_id_with_byte(0x20 + i);
+            let frame = make_relay_frame(i as u64 + 1, target);
+            coord
+                .process_punch_me_now_frame(from, source_addr, &frame, now)
+                .expect("under-cap ok");
+        }
+        assert_eq!(coord.relay_slots.len(), 2);
+
+        // Advance well past the slot timeout. The next incoming frame's
+        // inline sweep must reclaim both stale slots before applying the
+        // back-pressure check.
+        let much_later = now + timeout + Duration::from_secs(1);
+        let new_from = peer_id_with_byte(0xAA);
+        let new_target = peer_id_with_byte(0xBB);
+        let new_frame = make_relay_frame(42, new_target);
+        let result = coord
+            .process_punch_me_now_frame(new_from, source_addr, &new_frame, much_later)
+            .expect("post-sweep frame should succeed");
+
+        assert!(
+            result.is_some(),
+            "frame after sweep must be accepted (capacity reclaimed)"
+        );
+        assert_eq!(
+            coord.relay_slots.len(),
+            1,
+            "stale slots must be reclaimed; only the new one remains"
+        );
+        assert_eq!(
+            coord.stats.backpressure_refusals, 0,
+            "no refusal expected because sweep freed capacity in time"
+        );
+    }
+
+    #[test]
+    fn coordinator_non_relay_frame_does_not_consume_slot() {
+        // PUNCH_ME_NOW without a target_peer_id is the response/echo path,
+        // not a relay request — it must NOT consume a back-pressure slot.
+        let mut coord = make_bp_coordinator(1, Duration::from_secs(5));
+        let now = Instant::now();
+        let source_addr = SocketAddr::from(([127, 0, 0, 1], 5000));
+        let from = peer_id_with_byte(0x01);
+
+        let frame = crate::frame::PunchMeNow {
+            round: VarInt::from_u32(1),
+            paired_with_sequence_number: VarInt::from_u32(0),
+            address: SocketAddr::from(([127, 0, 0, 1], 9000)),
+            target_peer_id: None,
+        };
+        let _ = coord
+            .process_punch_me_now_frame(from, source_addr, &frame, now)
+            .expect("non-relay frame ok");
+        assert_eq!(
+            coord.relay_slots.len(),
+            0,
+            "non-relay frame must not consume a slot"
         );
     }
 }

--- a/src/connection/nat_traversal.rs
+++ b/src/connection/nat_traversal.rs
@@ -3885,7 +3885,7 @@ impl BootstrapCoordinator {
         self.cleanup_completed_sessions(now);
 
         // Track coordination entry minimally
-        let _entry = self
+        let entry = self
             .coordination_table
             .entry(frame.round)
             .or_insert(CoordinationEntry {
@@ -3896,10 +3896,10 @@ impl BootstrapCoordinator {
             });
         // Update target if provided later
         if let Some(peer_b) = frame.target_peer_id {
-            if _entry.peer_b.is_none() {
-                _entry.peer_b = Some(peer_b);
+            if entry.peer_b.is_none() {
+                entry.peer_b = Some(peer_b);
             }
-            _entry.address_hint = frame.address;
+            entry.address_hint = frame.address;
         }
 
         // If we have a target, echo back with swapped target to coordinate
@@ -3914,7 +3914,7 @@ impl BootstrapCoordinator {
             Ok(Some(coordination_frame))
         } else {
             // Response path: mark entry completed and increment success metric
-            _entry.completed = true;
+            entry.completed = true;
             self.stats.successful_coordinations += 1;
             Ok(None)
         }

--- a/src/connection/nat_traversal.rs
+++ b/src/connection/nat_traversal.rs
@@ -481,7 +481,7 @@ impl SecurityValidationState {
             max_candidates_per_window: 20, // Max 20 candidates per 60 seconds
             rate_window: Duration::from_secs(60),
             coordination_requests: VecDeque::new(),
-            max_coordination_per_window: 50, // Max 50 coordination requests per 60 seconds
+            max_coordination_per_window: 300, // Max 300 coordination requests per 60 seconds
             address_validation_cache: HashMap::new(),
             validation_cache_timeout: Duration::from_secs(300), // 5 minute cache
             allow_loopback,

--- a/src/connection/nat_traversal.rs
+++ b/src/connection/nat_traversal.rs
@@ -3603,11 +3603,19 @@ struct ObservedPeer {
     observed_addr: SocketAddr,
 }
 
+/// How long a coordination entry is kept before being reaped. Coordination
+/// should complete within a few seconds; 60 s is a generous upper bound.
+const COORDINATION_ENTRY_TTL: Duration = Duration::from_secs(60);
+
 /// Minimal coordination record linking two peers for a round
 #[derive(Debug, Clone)]
 struct CoordinationEntry {
     peer_b: Option<PeerId>,
     address_hint: SocketAddr,
+    /// When this entry was created (used for expiry).
+    created_at: Instant,
+    /// Set to `true` once the response/echo path has been reached.
+    completed: bool,
 }
 /// Record of observed peer information
 #[derive(Debug, Clone)]
@@ -3871,6 +3879,11 @@ impl BootstrapCoordinator {
             }
         }
 
+        // Periodic housekeeping: reap stale / completed entries so the
+        // table cannot grow without bound.
+        self.cleanup_expired_sessions(now);
+        self.cleanup_completed_sessions(now);
+
         // Track coordination entry minimally
         let _entry = self
             .coordination_table
@@ -3878,6 +3891,8 @@ impl BootstrapCoordinator {
             .or_insert(CoordinationEntry {
                 peer_b: frame.target_peer_id,
                 address_hint: frame.address,
+                created_at: now,
+                completed: false,
             });
         // Update target if provided later
         if let Some(peer_b) = frame.target_peer_id {
@@ -3898,7 +3913,8 @@ impl BootstrapCoordinator {
             self.stats.total_coordinations += 1;
             Ok(Some(coordination_frame))
         } else {
-            // Response path: increment success metric
+            // Response path: mark entry completed and increment success metric
+            _entry.completed = true;
             self.stats.successful_coordinations += 1;
             Ok(None)
         }
@@ -3909,8 +3925,11 @@ impl BootstrapCoordinator {
 
     // Perform comprehensive security validation for coordination requests (legacy removed)
 
-    #[allow(dead_code)]
-    pub(crate) fn cleanup_expired_sessions(&mut self, _now: Instant) {}
+    /// Remove coordination entries that have exceeded the TTL.
+    pub(crate) fn cleanup_expired_sessions(&mut self, now: Instant) {
+        self.coordination_table
+            .retain(|_round, entry| now.duration_since(entry.created_at) < COORDINATION_ENTRY_TTL);
+    }
 
     // Get bootstrap statistics (legacy removed)
 
@@ -3925,8 +3944,12 @@ impl BootstrapCoordinator {
     // Check if a session should advance its state (legacy removed)
     // Advance session state based on event (legacy removed)
 
-    #[allow(dead_code)]
-    fn cleanup_completed_sessions(&mut self, _now: Instant) {}
+    /// Remove coordination entries that have already completed (response
+    /// path reached). Called opportunistically so the table stays compact.
+    fn cleanup_completed_sessions(&mut self, _now: Instant) {
+        self.coordination_table
+            .retain(|_round, entry| !entry.completed);
+    }
 
     // Legacy retry mechanism removed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,8 +203,8 @@ pub mod tracing;
 /// Best-effort UPnP IGD port mapping for NAT traversal assistance.
 ///
 /// This module is feature-gated behind `upnp` (enabled by default). When
-/// disabled, [`UpnpMappingService`] is still present but is a no-op stub
-/// that always reports [`UpnpState::Unavailable`].
+/// disabled, [`upnp::UpnpMappingService`] is still present but is a no-op stub
+/// that always reports [`upnp::UpnpState::Unavailable`].
 pub mod upnp;
 
 // Public modules with new structure

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,6 +259,9 @@ pub mod metrics;
 /// TURN-style relay protocol for NAT traversal fallback
 pub mod relay;
 
+/// Node-wide hole-punch coordinator back-pressure (Tier 4 lite).
+pub mod relay_slot_table;
+
 /// MASQUE CONNECT-UDP Bind protocol for fully connectable P2P nodes
 pub mod masque;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,6 +168,9 @@ pub mod node_status;
 /// Unified events for P2P nodes
 pub mod node_event;
 
+/// Reachability scope and traversal metadata shared across APIs
+pub mod reachability;
+
 // Core implementation modules
 /// Configuration structures and validation
 pub mod config;
@@ -333,6 +336,7 @@ pub use nat_traversal_api::{
     BootstrapNode, CandidateAddress, NatTraversalConfig, NatTraversalEndpoint, NatTraversalError,
     NatTraversalEvent, NatTraversalStatistics,
 };
+pub use reachability::{ReachabilityScope, TraversalMethod};
 
 // ============================================================================
 // SIMPLE API EXPORTS - Zero Configuration P2P (RECOMMENDED)
@@ -348,7 +352,7 @@ pub use node_config::{NodeConfig, NodeConfigBuilder};
 pub use node_status::{NatType, NodeStatus};
 
 /// Unified events for P2P nodes
-pub use node_event::{DisconnectReason as NodeDisconnectReason, NodeEvent, TraversalMethod};
+pub use node_event::{DisconnectReason as NodeDisconnectReason, NodeEvent};
 
 // ============================================================================
 // P2P API EXPORTS (for advanced use)

--- a/src/link_transport.rs
+++ b/src/link_transport.rs
@@ -1030,7 +1030,7 @@ pub type BoxStream<'a, T> = Pin<Box<dyn futures_util::Stream<Item = T> + Send + 
 ///
 /// This trait abstracts a single QUIC connection, providing methods to
 /// open streams and send/receive datagrams. Connections are obtained via
-/// [`LinkTransport::dial`] or [`LinkTransport::accept`].
+/// [`LinkTransport::dial_addr`] or [`LinkTransport::accept`].
 ///
 /// # Stream Types
 ///

--- a/src/link_transport.rs
+++ b/src/link_transport.rs
@@ -624,6 +624,9 @@ pub struct Capabilities {
     /// Observed external addresses for this peer.
     pub observed_addrs: Vec<SocketAddr>,
 
+    /// Broadest direct reachability scope verified for this connected peer.
+    pub direct_reachability_scope: Option<crate::reachability::ReachabilityScope>,
+
     /// Protocols this peer advertises support for.
     pub protocols: Vec<ProtocolId>,
 
@@ -661,6 +664,7 @@ impl Default for Capabilities {
             supports_relay: false,
             supports_coordination: false,
             observed_addrs: Vec::new(),
+            direct_reachability_scope: None,
             protocols: Vec::new(),
             last_seen: SystemTime::UNIX_EPOCH,
             rtt_ms_p50: 0,

--- a/src/link_transport_impl.rs
+++ b/src/link_transport_impl.rs
@@ -489,7 +489,7 @@ impl P2pLinkTransport {
                         P2pEvent::PeerConnected {
                             addr,
                             public_key,
-                            side: _,
+                            side,
                             traversal_method,
                         } => {
                             // Extract SocketAddr (currently UDP-only)
@@ -498,7 +498,12 @@ impl P2pLinkTransport {
                                 SocketAddr::from(([0, 0, 0, 0], 0))
                             });
                             let mut caps = Capabilities::new_connected(socket_addr);
-                            if traversal_method.is_direct() {
+                            // Only promote relay/coordinator when we connected to
+                            // them directly (Client side), proving they accept
+                            // inbound connections. A peer that connected to us
+                            // (Server side) only proves they can make outbound
+                            // connections, not that they are reachable by others.
+                            if traversal_method.is_direct() && side.is_client() {
                                 caps.supports_relay = true;
                                 caps.supports_coordination = true;
                                 caps.direct_reachability_scope =

--- a/src/link_transport_impl.rs
+++ b/src/link_transport_impl.rs
@@ -490,13 +490,20 @@ impl P2pLinkTransport {
                             addr,
                             public_key,
                             side: _,
+                            traversal_method,
                         } => {
                             // Extract SocketAddr (currently UDP-only)
                             let socket_addr = addr.as_socket_addr().unwrap_or_else(|| {
                                 // Fallback for non-UDP transports - use unspecified address
                                 SocketAddr::from(([0, 0, 0, 0], 0))
                             });
-                            let caps = Capabilities::new_connected(socket_addr);
+                            let mut caps = Capabilities::new_connected(socket_addr);
+                            if traversal_method.is_direct() {
+                                caps.supports_relay = true;
+                                caps.supports_coordination = true;
+                                caps.direct_reachability_scope =
+                                    crate::reachability::socket_addr_scope(socket_addr);
+                            }
                             // Update capabilities cache keyed by address
                             if let Ok(mut state) = state.write() {
                                 state.capabilities.insert(socket_addr, caps.clone());
@@ -537,6 +544,9 @@ impl P2pLinkTransport {
                             if let Ok(mut state) = state.write() {
                                 if let Some(caps) = state.capabilities.get_mut(&socket_addr) {
                                     caps.is_connected = false;
+                                    caps.supports_relay = false;
+                                    caps.supports_coordination = false;
+                                    caps.direct_reachability_scope = None;
                                 }
                             }
                             Some(LinkEvent::PeerDisconnected {

--- a/src/masque/relay_server.rs
+++ b/src/masque/relay_server.rs
@@ -868,7 +868,7 @@ impl MasqueRelayServer {
     /// of unreliable QUIC datagrams. This avoids the MTU limitation that causes
     /// "datagram too large" errors for QUIC Initial packets (1200+ bytes).
     ///
-    /// Protocol: each forwarded packet is framed as [4-byte BE length][payload].
+    /// Protocol: each forwarded packet is framed as \[4-byte BE length\]\[payload\].
     pub async fn run_stream_forwarding_loop(
         self: &Arc<Self>,
         session_id: u64,

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -492,44 +492,51 @@ pub struct NatTraversalConfig {
     #[serde(default)]
     pub allow_loopback: bool,
 
-    /// Maximum number of concurrent hole-punch relay slots this node will
-    /// service as a coordinator.
+    /// Cap on simultaneous in-flight hole-punch coordinator sessions
+    /// **across the entire node** (Tier 4 lite back-pressure).
     ///
-    /// When the active relay count reaches this cap, incoming `PUNCH_ME_NOW`
-    /// frames that would otherwise be relayed are *silently refused*: the
-    /// coordinator drops the relay without notifying the initiator. The
-    /// initiator's per-attempt timeout (Tier 2 rotation) drives it to
-    /// advance to the next preferred coordinator in its list.
+    /// When the shared `RelaySlotTable` is full, additional `PUNCH_ME_NOW`
+    /// relay frames are *silently refused*: the coordinator drops them
+    /// without notifying the initiator, and the initiator's per-attempt
+    /// timeout (Tier 2 rotation) advances to the next preferred
+    /// coordinator in its list.
+    ///
+    /// A "session" is one `(initiator_addr, target_peer_id)` pair. The
+    /// same pair re-sending across rounds re-arms one slot rather than
+    /// allocating new ones. Slots are released either by the explicit
+    /// connection-close path (when the initiator's connection drops, the
+    /// `BootstrapCoordinator::Drop` releases every slot it owned) or by
+    /// the [`Self::coordinator_relay_slot_idle_timeout`] safety net for
+    /// peers that vanish without an orderly close.
     ///
     /// Defaults to [`NatTraversalConfig::DEFAULT_COORDINATOR_MAX_ACTIVE_RELAYS`]
-    /// (32). Picked as roughly 32% of saorsa-core's 100-connection cap so
-    /// the coordinator still has headroom for its own peer traffic, while
-    /// being low enough that a cold-start storm is shed and pushed onto
-    /// alternates.
-    ///
-    /// Each "active relay" represents one in-flight initiator→target
-    /// coordination, indexed by `(initiator_peer_id, target_peer_id)`. The
-    /// counter is decremented when the relay completes or after
-    /// [`Self::coordinator_relay_slot_timeout`] elapses (whichever first).
+    /// (32). Sized to keep a coordinator's worst-case in-flight
+    /// coordination work bounded under a cold-start storm of peers all
+    /// converging on the same bootstrap, while still leaving headroom
+    /// for steady-state per-peer traffic.
     #[serde(default = "default_coordinator_max_active_relays")]
     pub coordinator_max_active_relays: usize,
 
-    /// Maximum lifetime of a coordinator relay slot before it is reclaimed
-    /// by the inline garbage-collection sweep.
+    /// Idle-release timeout for an in-flight coordinator relay session.
     ///
-    /// A successful hole-punch typically completes in 1-3 seconds; this
-    /// timeout exists purely as a safety net so that a relay slot cannot
-    /// leak forever if a peer crashes mid-coordination, a NAT rebind
-    /// silently drops the session, or a follow-up signal is lost. Without
-    /// it the active-relay counter would drift upward over time and the
-    /// coordinator would eventually refuse legitimate traffic.
+    /// A slot lasts from the first `PUNCH_ME_NOW` arrival until either
+    /// (a) the connection that owns it closes — in which case
+    /// `BootstrapCoordinator::Drop` releases all of that connection's
+    /// slots immediately, or (b) no new round arrives for the same
+    /// `(initiator_addr, target_peer_id)` pair within this idle window —
+    /// the *safety net* for peers that crash, get NAT-rebound, or stop
+    /// rotating without an orderly close. The coordinator cannot
+    /// directly observe whether the punch ultimately succeeded (the
+    /// punch traffic flows initiator↔target, bypassing the coordinator),
+    /// so the idle timeout is the only signal available for "vanished"
+    /// sessions.
     ///
-    /// Defaults to [`NatTraversalConfig::DEFAULT_COORDINATOR_RELAY_SLOT_TIMEOUT`]
+    /// Defaults to [`NatTraversalConfig::DEFAULT_COORDINATOR_RELAY_SLOT_IDLE_TIMEOUT`]
     /// (5 seconds): comfortably above the worst-case successful punch
-    /// latency on high-RTT links, but short enough to keep ghost slots
-    /// from impacting steady-state burst capacity.
-    #[serde(default = "default_coordinator_relay_slot_timeout")]
-    pub coordinator_relay_slot_timeout: Duration,
+    /// latency on high-RTT links, short enough to keep capacity from
+    /// being held by ghost sessions.
+    #[serde(default = "default_coordinator_relay_slot_idle_timeout")]
+    pub coordinator_relay_slot_idle_timeout: Duration,
 
     /// Best-effort UPnP IGD port mapping configuration.
     ///
@@ -552,18 +559,19 @@ fn default_coordinator_max_active_relays() -> usize {
     NatTraversalConfig::DEFAULT_COORDINATOR_MAX_ACTIVE_RELAYS
 }
 
-fn default_coordinator_relay_slot_timeout() -> Duration {
-    NatTraversalConfig::DEFAULT_COORDINATOR_RELAY_SLOT_TIMEOUT
+fn default_coordinator_relay_slot_idle_timeout() -> Duration {
+    NatTraversalConfig::DEFAULT_COORDINATOR_RELAY_SLOT_IDLE_TIMEOUT
 }
 
 impl NatTraversalConfig {
-    /// Default cap on simultaneous coordinator relay slots.
+    /// Default cap on simultaneous coordinator relay sessions.
     /// See [`Self::coordinator_max_active_relays`] for rationale.
     pub const DEFAULT_COORDINATOR_MAX_ACTIVE_RELAYS: usize = 32;
 
-    /// Default reclamation timeout for stale coordinator relay slots.
-    /// See [`Self::coordinator_relay_slot_timeout`] for rationale.
-    pub const DEFAULT_COORDINATOR_RELAY_SLOT_TIMEOUT: Duration = Duration::from_secs(5);
+    /// Default idle-release timeout for in-flight coordinator relay
+    /// sessions. See [`Self::coordinator_relay_slot_idle_timeout`] for
+    /// rationale.
+    pub const DEFAULT_COORDINATOR_RELAY_SLOT_IDLE_TIMEOUT: Duration = Duration::from_secs(5);
 }
 
 /// Convert `max_message_size` to a QUIC `VarInt` for stream/send window configuration.
@@ -1146,7 +1154,7 @@ impl Default for NatTraversalConfig {
             max_message_size: crate::unified_config::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
             allow_loopback: false,
             coordinator_max_active_relays: Self::DEFAULT_COORDINATOR_MAX_ACTIVE_RELAYS,
-            coordinator_relay_slot_timeout: Self::DEFAULT_COORDINATOR_RELAY_SLOT_TIMEOUT,
+            coordinator_relay_slot_idle_timeout: Self::DEFAULT_COORDINATOR_RELAY_SLOT_IDLE_TIMEOUT,
             upnp: crate::upnp::UpnpConfig::default(),
         }
     }
@@ -1201,14 +1209,14 @@ impl ConfigValidator for NatTraversalConfig {
         validate_range(
             self.coordinator_max_active_relays,
             1,
-            256,
+            1024,
             "coordinator_max_active_relays",
         )?;
         validate_duration(
-            self.coordinator_relay_slot_timeout,
+            self.coordinator_relay_slot_idle_timeout,
             Duration::from_millis(100),
             Duration::from_secs(60),
-            "coordinator_relay_slot_timeout",
+            "coordinator_relay_slot_idle_timeout",
         )?;
 
         Ok(())
@@ -2623,6 +2631,18 @@ impl NatTraversalEndpoint {
     > {
         use std::sync::Arc;
 
+        // Tier 4 (lite) coordinator back-pressure: every connection
+        // spawned by this endpoint shares ONE node-wide
+        // `RelaySlotTable`. Both the server-side `TransportConfig` and
+        // the client-side `TransportConfig` get a clone of the same
+        // `Arc`, so a relay arriving on a server-accepted connection
+        // and a relay arriving on a client-initiated connection both
+        // count against the same cap.
+        let relay_slot_table = Arc::new(crate::relay_slot_table::RelaySlotTable::new(
+            config.coordinator_max_active_relays,
+            config.coordinator_relay_slot_idle_timeout,
+        ));
+
         // v0.13.0+: All nodes are symmetric P2P nodes - always create server config
         let server_config = {
             info!("Creating server config using Raw Public Keys (RFC 7250) for symmetric P2P node");
@@ -2686,8 +2706,7 @@ impl NatTraversalEndpoint {
             };
             transport_config.nat_traversal_config(Some(nat_config));
             transport_config.allow_loopback(config.allow_loopback);
-            transport_config.coordinator_max_active_relays(config.coordinator_max_active_relays);
-            transport_config.coordinator_relay_slot_timeout(config.coordinator_relay_slot_timeout);
+            transport_config.relay_slot_table(Some(Arc::clone(&relay_slot_table)));
 
             server_config.transport_config(Arc::new(transport_config));
 
@@ -2759,8 +2778,7 @@ impl NatTraversalEndpoint {
             };
             transport_config.nat_traversal_config(Some(nat_config));
             transport_config.allow_loopback(config.allow_loopback);
-            transport_config.coordinator_max_active_relays(config.coordinator_max_active_relays);
-            transport_config.coordinator_relay_slot_timeout(config.coordinator_relay_slot_timeout);
+            transport_config.relay_slot_table(Some(Arc::clone(&relay_slot_table)));
 
             client_config.transport_config(Arc::new(transport_config));
 

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -479,7 +479,7 @@ pub struct NatTraversalConfig {
     /// Internally tunes the QUIC per-stream receive window so that a single
     /// message of this size can be transmitted without flow-control rejection.
     ///
-    /// Default: [`P2pConfig::DEFAULT_MAX_MESSAGE_SIZE`] (1 MiB).
+    /// Default: [`crate::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE`] (1 MiB).
     #[serde(default = "default_max_message_size")]
     pub max_message_size: usize,
 

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -492,6 +492,45 @@ pub struct NatTraversalConfig {
     #[serde(default)]
     pub allow_loopback: bool,
 
+    /// Maximum number of concurrent hole-punch relay slots this node will
+    /// service as a coordinator.
+    ///
+    /// When the active relay count reaches this cap, incoming `PUNCH_ME_NOW`
+    /// frames that would otherwise be relayed are *silently refused*: the
+    /// coordinator drops the relay without notifying the initiator. The
+    /// initiator's per-attempt timeout (Tier 2 rotation) drives it to
+    /// advance to the next preferred coordinator in its list.
+    ///
+    /// Defaults to [`NatTraversalConfig::DEFAULT_COORDINATOR_MAX_ACTIVE_RELAYS`]
+    /// (32). Picked as roughly 32% of saorsa-core's 100-connection cap so
+    /// the coordinator still has headroom for its own peer traffic, while
+    /// being low enough that a cold-start storm is shed and pushed onto
+    /// alternates.
+    ///
+    /// Each "active relay" represents one in-flight initiator→target
+    /// coordination, indexed by `(initiator_peer_id, target_peer_id)`. The
+    /// counter is decremented when the relay completes or after
+    /// [`Self::coordinator_relay_slot_timeout`] elapses (whichever first).
+    #[serde(default = "default_coordinator_max_active_relays")]
+    pub coordinator_max_active_relays: usize,
+
+    /// Maximum lifetime of a coordinator relay slot before it is reclaimed
+    /// by the inline garbage-collection sweep.
+    ///
+    /// A successful hole-punch typically completes in 1-3 seconds; this
+    /// timeout exists purely as a safety net so that a relay slot cannot
+    /// leak forever if a peer crashes mid-coordination, a NAT rebind
+    /// silently drops the session, or a follow-up signal is lost. Without
+    /// it the active-relay counter would drift upward over time and the
+    /// coordinator would eventually refuse legitimate traffic.
+    ///
+    /// Defaults to [`NatTraversalConfig::DEFAULT_COORDINATOR_RELAY_SLOT_TIMEOUT`]
+    /// (5 seconds): comfortably above the worst-case successful punch
+    /// latency on high-RTT links, but short enough to keep ghost slots
+    /// from impacting steady-state burst capacity.
+    #[serde(default = "default_coordinator_relay_slot_timeout")]
+    pub coordinator_relay_slot_timeout: Duration,
+
     /// Best-effort UPnP IGD port mapping configuration.
     ///
     /// When enabled, the endpoint asks the local Internet Gateway Device
@@ -507,6 +546,24 @@ pub struct NatTraversalConfig {
 
 fn default_max_message_size() -> usize {
     crate::unified_config::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE
+}
+
+fn default_coordinator_max_active_relays() -> usize {
+    NatTraversalConfig::DEFAULT_COORDINATOR_MAX_ACTIVE_RELAYS
+}
+
+fn default_coordinator_relay_slot_timeout() -> Duration {
+    NatTraversalConfig::DEFAULT_COORDINATOR_RELAY_SLOT_TIMEOUT
+}
+
+impl NatTraversalConfig {
+    /// Default cap on simultaneous coordinator relay slots.
+    /// See [`Self::coordinator_max_active_relays`] for rationale.
+    pub const DEFAULT_COORDINATOR_MAX_ACTIVE_RELAYS: usize = 32;
+
+    /// Default reclamation timeout for stale coordinator relay slots.
+    /// See [`Self::coordinator_relay_slot_timeout`] for rationale.
+    pub const DEFAULT_COORDINATOR_RELAY_SLOT_TIMEOUT: Duration = Duration::from_secs(5);
 }
 
 /// Convert `max_message_size` to a QUIC `VarInt` for stream/send window configuration.
@@ -1088,6 +1145,8 @@ impl Default for NatTraversalConfig {
             transport_registry: None, // Use direct UDP binding by default
             max_message_size: crate::unified_config::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
             allow_loopback: false,
+            coordinator_max_active_relays: Self::DEFAULT_COORDINATOR_MAX_ACTIVE_RELAYS,
+            coordinator_relay_slot_timeout: Self::DEFAULT_COORDINATOR_RELAY_SLOT_TIMEOUT,
             upnp: crate::upnp::UpnpConfig::default(),
         }
     }
@@ -1137,6 +1196,20 @@ impl ConfigValidator for NatTraversalConfig {
                 "max_concurrent_attempts cannot exceed max_candidates".to_string(),
             ));
         }
+
+        // Validate coordinator back-pressure limits (Tier 4 lite).
+        validate_range(
+            self.coordinator_max_active_relays,
+            1,
+            256,
+            "coordinator_max_active_relays",
+        )?;
+        validate_duration(
+            self.coordinator_relay_slot_timeout,
+            Duration::from_millis(100),
+            Duration::from_secs(60),
+            "coordinator_relay_slot_timeout",
+        )?;
 
         Ok(())
     }
@@ -2613,6 +2686,8 @@ impl NatTraversalEndpoint {
             };
             transport_config.nat_traversal_config(Some(nat_config));
             transport_config.allow_loopback(config.allow_loopback);
+            transport_config.coordinator_max_active_relays(config.coordinator_max_active_relays);
+            transport_config.coordinator_relay_slot_timeout(config.coordinator_relay_slot_timeout);
 
             server_config.transport_config(Arc::new(transport_config));
 
@@ -2684,6 +2759,8 @@ impl NatTraversalEndpoint {
             };
             transport_config.nat_traversal_config(Some(nat_config));
             transport_config.allow_loopback(config.allow_loopback);
+            transport_config.coordinator_max_active_relays(config.coordinator_max_active_relays);
+            transport_config.coordinator_relay_slot_timeout(config.coordinator_relay_slot_timeout);
 
             client_config.transport_config(Arc::new(transport_config));
 

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -5421,7 +5421,12 @@ impl NatTraversalEndpoint {
                     );
 
                     let mut connection = None;
-                    let mut bootstrap = relay_candidates[0]; // default, overwritten on success
+                    let Some(&first_candidate) = relay_candidates.first() else {
+                        warn!("No relay candidates available for symmetric NAT setup");
+                        relay_setup_attempted.store(false, std::sync::atomic::Ordering::Relaxed);
+                        return;
+                    };
+                    let mut bootstrap = first_candidate; // default, overwritten on success
 
                     for candidate in &relay_candidates {
                         match connections.get(candidate) {
@@ -6208,13 +6213,12 @@ impl NatTraversalEndpoint {
             }
 
             // For testing: if we're in punching phase and have candidates, simulate success with the first one
-            if session.phase == TraversalPhase::Punching && !session.candidates.is_empty() {
-                let candidate_addr = session.candidates[0].address;
-                info!(
-                    "Simulating successful punch for testing: {} at {}",
-                    addr, candidate_addr
-                );
-                return Some(candidate_addr);
+            if session.phase == TraversalPhase::Punching {
+                if let Some(first_candidate) = session.candidates.first() {
+                    let candidate_addr = first_candidate.address;
+                    info!("Simulating successful punch for testing: {addr} at {candidate_addr}",);
+                    return Some(candidate_addr);
+                }
             }
 
             // No validated candidates, return first candidate as fallback

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -15,6 +15,7 @@
 use std::{fmt, net::SocketAddr, sync::Arc, time::Duration};
 
 use crate::constrained::{ConstrainedEngine, EngineConfig, EngineEvent};
+use crate::reachability::TraversalMethod;
 use crate::transport::TransportRegistry;
 
 use crate::SHUTDOWN_DRAIN_TIMEOUT;
@@ -1042,6 +1043,8 @@ pub enum NatTraversalEvent {
         remote_address: SocketAddr,
         /// Who initiated the connection (Client = we connected, Server = they connected)
         side: Side,
+        /// Whether the connection was direct, hole-punched, or relayed.
+        traversal_method: TraversalMethod,
         /// ML-DSA-65 public key extracted from the TLS identity, if available
         public_key: Option<Vec<u8>>,
     },
@@ -2976,6 +2979,7 @@ impl NatTraversalEndpoint {
                                         event_tx.send(NatTraversalEvent::ConnectionEstablished {
                                             remote_address,
                                             side: Side::Server,
+                                            traversal_method: TraversalMethod::Direct,
                                             public_key,
                                         });
                                     incoming_notify.notify_one();
@@ -3346,6 +3350,7 @@ impl NatTraversalEndpoint {
             let _ = event_tx.send(NatTraversalEvent::ConnectionEstablished {
                 remote_address: remote_addr,
                 side: Side::Client,
+                traversal_method: TraversalMethod::Direct,
                 public_key,
             });
             self.incoming_notify.notify_one();
@@ -3961,11 +3966,13 @@ impl NatTraversalEndpoint {
     /// * `addr` - The remote address of the connection
     /// * `connection` - The established QUIC connection
     /// * `side` - Who initiated the connection (Client = we connected, Server = they connected)
+    /// * `traversal_method` - Whether the path is direct, hole-punched, or relayed
     pub fn spawn_connection_handler(
         &self,
         addr: SocketAddr,
         connection: InnerConnection,
         side: Side,
+        traversal_method: TraversalMethod,
     ) -> Result<(), NatTraversalError> {
         let event_tx = self.event_tx.as_ref().cloned().ok_or_else(|| {
             NatTraversalError::ConfigError("NAT traversal event channel not configured".to_string())
@@ -3982,6 +3989,7 @@ impl NatTraversalEndpoint {
             let _ = event_tx.send(NatTraversalEvent::ConnectionEstablished {
                 remote_address,
                 side,
+                traversal_method,
                 public_key,
             });
             self.incoming_notify.notify_one();
@@ -4917,6 +4925,7 @@ impl NatTraversalEndpoint {
                                         event_tx.send(NatTraversalEvent::ConnectionEstablished {
                                             remote_address: remote,
                                             side: Side::Client,
+                                            traversal_method: TraversalMethod::HolePunch,
                                             public_key,
                                         });
                                     incoming_notify.notify_one();
@@ -6631,6 +6640,7 @@ impl NatTraversalEndpoint {
             callback(NatTraversalEvent::ConnectionEstablished {
                 remote_address: candidate_address,
                 side: Side::Client,
+                traversal_method: TraversalMethod::HolePunch,
                 public_key,
             });
         }
@@ -6717,26 +6727,6 @@ impl NatTraversalEndpoint {
         } else {
             Err(NatTraversalError::PeerNotConnected)
         }
-    }
-
-    /// Get NAT traversal statistics
-    #[allow(clippy::panic)]
-    pub fn get_nat_stats(
-        &self,
-    ) -> Result<NatTraversalStatistics, Box<dyn std::error::Error + Send + Sync>> {
-        // Return default statistics for now
-        // In a real implementation, this would collect actual stats from the endpoint
-        Ok(NatTraversalStatistics {
-            active_sessions: self.active_sessions.len(),
-            // parking_lot::RwLock doesn't poison - always succeeds
-            total_bootstrap_nodes: self.bootstrap_nodes.read().len(),
-            successful_coordinations: 7,
-            average_coordination_time: self.timeout_config.nat_traversal.retry_interval,
-            total_attempts: 10,
-            successful_connections: 7,
-            direct_connections: 5,
-            relayed_connections: 2,
-        })
     }
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -56,6 +56,7 @@ use crate::node_config::NodeConfig;
 use crate::node_event::NodeEvent;
 use crate::node_status::{NatType, NodeStatus};
 use crate::p2p_endpoint::{EndpointError, P2pEndpoint, P2pEvent, PeerConnection};
+use crate::reachability::{DIRECT_REACHABILITY_TTL, socket_addr_scope};
 use crate::unified_config::P2pConfig;
 use crate::unified_config::load_or_generate_endpoint_keypair;
 
@@ -328,10 +329,12 @@ impl Node {
                 addr,
                 public_key,
                 side: _,
+                traversal_method,
             } => Some(NodeEvent::PeerConnected {
                 addr,
                 public_key,
-                direct: true, // P2pEvent doesn't distinguish, assume direct
+                method: traversal_method,
+                direct: traversal_method.is_direct(),
             }),
             P2pEvent::PeerDisconnected { addr, reason } => Some(NodeEvent::PeerDisconnected {
                 addr: addr.to_synthetic_socket_addr(),
@@ -502,22 +505,15 @@ impl Node {
     /// ```
     pub async fn status(&self) -> NodeStatus {
         let stats = self.inner.stats().await;
-        let nat_stats = self.inner.nat_stats().ok();
         let connected_peers = self.inner.connected_peers().await;
 
-        // Determine NAT type from stats
-        let nat_type = self.detect_nat_type(&stats, nat_stats.as_ref());
+        // Determine NAT type from observed connection outcomes only.
+        let nat_type = self.detect_nat_type(&stats);
 
-        // Check if we have public IP
+        // Address knowledge and reachability are separate concepts.
+        // A global address is not proof of direct reachability.
         let local_addr = self.local_addr();
         let external_addr = self.external_addr();
-        let has_public_ip = match (local_addr, external_addr) {
-            (Some(local), Some(external)) => {
-                // Public if external matches local (ignoring port differences)
-                local.ip() == external.ip()
-            }
-            _ => false,
-        };
 
         // Collect external addresses
         let mut external_addrs = Vec::new();
@@ -532,34 +528,48 @@ impl Node {
             0.0
         };
 
-        // Determine if we can help with traversal
-        let can_receive_direct =
-            has_public_ip || nat_type == NatType::FullCone || nat_type == NatType::None;
+        let has_global_address = external_addrs
+            .iter()
+            .copied()
+            .chain(local_addr)
+            .any(|addr| {
+                socket_addr_scope(addr)
+                    .is_some_and(|scope| scope == crate::ReachabilityScope::Global)
+            });
 
-        // Check relay status from NAT stats
-        // Currently, relay status is indicated by having relayed_connections > 0
-        // and active sessions that may be acting as relays
-        let (is_relaying, relay_sessions, relay_bytes_forwarded) = if let Some(ref nat) = nat_stats
-        {
-            // If we have any active sessions and are accepting connections,
-            // we're potentially relaying
-            let relaying = nat.relayed_connections > 0 && can_receive_direct;
+        // A node is directly reachable only after fresh, peer-verified direct
+        // inbound evidence. Scope is freshness-aware too, so an old global
+        // observation cannot keep inflating current reachability.
+        let fresh_scope = [
             (
-                relaying,
-                if relaying { nat.active_sessions } else { 0 },
-                0u64, // Not tracked yet - future enhancement
-            )
-        } else {
-            (false, 0, 0)
-        };
+                crate::ReachabilityScope::Global,
+                stats.last_direct_global_at,
+            ),
+            (
+                crate::ReachabilityScope::LocalNetwork,
+                stats.last_direct_local_at,
+            ),
+            (
+                crate::ReachabilityScope::Loopback,
+                stats.last_direct_loopback_at,
+            ),
+        ]
+        .into_iter()
+        .find_map(|(scope, seen)| {
+            seen.filter(|instant| instant.elapsed() <= DIRECT_REACHABILITY_TTL)
+                .map(|_| scope)
+        });
+        let can_receive_direct =
+            stats.active_direct_incoming_connections > 0 || fresh_scope.is_some();
+        let direct_reachability_scope = fresh_scope;
 
-        // Check coordination status
-        // Any node with active sessions is acting as a coordinator
-        let (is_coordinating, coordination_sessions) = if let Some(ref nat) = nat_stats {
-            (nat.active_sessions > 0, nat.active_sessions)
-        } else {
-            (false, 0)
-        };
+        // Relay/coordinator activity must be backed by real runtime metrics.
+        // The NAT stats path is still placeholder-ish, so stay conservative here.
+        let is_relaying = false;
+        let relay_sessions = 0;
+        let relay_bytes_forwarded = 0u64;
+        let is_coordinating = false;
+        let coordination_sessions = 0;
 
         // Calculate average RTT from connected peers
         let mut total_rtt = Duration::ZERO;
@@ -589,7 +599,8 @@ impl Node {
             external_addrs,
             nat_type,
             can_receive_direct,
-            has_public_ip,
+            direct_reachability_scope,
+            has_global_address,
             connected_peers: connected_peers.len(),
             active_connections: stats.active_connections,
             pending_connections: 0, // Not tracked yet
@@ -655,51 +666,21 @@ impl Node {
     // === Private Helpers ===
 
     /// Detect NAT type from statistics
-    fn detect_nat_type(
-        &self,
-        stats: &crate::p2p_endpoint::EndpointStats,
-        nat_stats: Option<&crate::nat_traversal_api::NatTraversalStatistics>,
-    ) -> NatType {
-        // If we have lots of direct connections and no relayed, likely no/easy NAT
+    fn detect_nat_type(&self, stats: &crate::p2p_endpoint::EndpointStats) -> NatType {
+        // This remains a soft debug hint only. Do not treat it as direct
+        // reachability evidence.
         if stats.direct_connections > 0 && stats.relayed_connections == 0 {
-            if let Some(nat) = nat_stats {
-                // Calculate direct connection rate
-                let total = nat.direct_connections + nat.relayed_connections;
-                if total > 0 {
-                    let direct_rate = nat.direct_connections as f64 / total as f64;
-                    if direct_rate > 0.9 {
-                        return NatType::FullCone;
-                    }
-                }
-            }
-            return NatType::FullCone; // Assume easy NAT if all direct
+            return NatType::FullCone;
         }
 
-        // If we have mixed connections, harder NAT
         if stats.direct_connections > 0 && stats.relayed_connections > 0 {
-            if let Some(nat) = nat_stats {
-                // Calculate success rate from total attempts vs successful connections
-                let success_rate = if nat.total_attempts > 0 {
-                    nat.successful_connections as f64 / nat.total_attempts as f64
-                } else {
-                    0.0
-                };
-
-                if success_rate > 0.7 {
-                    return NatType::PortRestricted;
-                } else if success_rate > 0.3 {
-                    return NatType::AddressRestricted;
-                }
-            }
             return NatType::PortRestricted;
         }
 
-        // If mostly relayed, likely symmetric NAT
         if stats.relayed_connections > stats.direct_connections {
             return NatType::Symmetric;
         }
 
-        // Not enough data yet
         NatType::Unknown
     }
 }

--- a/src/node_event.rs
+++ b/src/node_event.rs
@@ -37,6 +37,7 @@
 use std::net::SocketAddr;
 
 use crate::node_status::NatType;
+pub use crate::reachability::TraversalMethod;
 use crate::transport::TransportAddr;
 
 /// Reason for peer disconnection
@@ -85,7 +86,9 @@ pub enum NodeEvent {
         addr: TransportAddr,
         /// The peer's public key bytes (ML-DSA-65 SPKI), if available from TLS handshake
         public_key: Option<Vec<u8>>,
-        /// Whether this is a direct connection (vs relayed)
+        /// How the connection was established.
+        method: TraversalMethod,
+        /// Whether this is a direct connection (vs relayed or assisted)
         direct: bool,
     },
 
@@ -186,30 +189,6 @@ pub enum NodeEvent {
     },
 }
 
-/// Method used for NAT traversal
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum TraversalMethod {
-    /// Direct connection (no NAT or easy NAT)
-    Direct,
-    /// Hole punching succeeded
-    HolePunch,
-    /// Connection via relay
-    Relay,
-    /// Port prediction for symmetric NAT
-    PortPrediction,
-}
-
-impl std::fmt::Display for TraversalMethod {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Direct => write!(f, "direct"),
-            Self::HolePunch => write!(f, "hole punch"),
-            Self::Relay => write!(f, "relay"),
-            Self::PortPrediction => write!(f, "port prediction"),
-        }
-    }
-}
-
 impl NodeEvent {
     /// Check if this is a connection event
     pub fn is_connection_event(&self) -> bool {
@@ -305,6 +284,7 @@ mod tests {
         let event = NodeEvent::PeerConnected {
             addr: TransportAddr::Udp(test_addr()),
             public_key: None,
+            method: TraversalMethod::Direct,
             direct: true,
         };
 
@@ -417,6 +397,7 @@ mod tests {
         let event = NodeEvent::PeerConnected {
             addr: TransportAddr::Udp(test_addr()),
             public_key: None,
+            method: TraversalMethod::Direct,
             direct: true,
         };
 

--- a/src/node_status.rs
+++ b/src/node_status.rs
@@ -28,15 +28,18 @@
 use std::net::SocketAddr;
 use std::time::Duration;
 
+pub use crate::reachability::ReachabilityScope;
+
 /// Detected NAT type for the node
 ///
 /// NAT type affects connectivity - some types are easier to traverse than others.
 /// The node automatically detects its NAT type and adjusts traversal strategies.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum NatType {
-    /// No NAT detected - direct public connectivity
+    /// No NAT detected.
     ///
-    /// The node has a public IP address and can accept connections directly.
+    /// This indicates the observed path did not require NAT traversal. It does
+    /// not, by itself, prove current direct reachability to other peers.
     None,
 
     /// Full cone NAT - easiest to traverse
@@ -73,7 +76,7 @@ pub enum NatType {
 impl std::fmt::Display for NatType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::None => write!(f, "None (Public IP)"),
+            Self::None => write!(f, "None (No NAT detected)"),
             Self::FullCone => write!(f, "Full Cone"),
             Self::AddressRestricted => write!(f, "Address Restricted"),
             Self::PortRestricted => write!(f, "Port Restricted"),
@@ -91,7 +94,7 @@ impl std::fmt::Display for NatType {
 /// # Status Categories
 ///
 /// - **Identity**: peer_id, local_addr, external_addrs
-/// - **NAT Status**: nat_type, can_receive_direct, has_public_ip
+/// - **NAT Status**: nat_type, can_receive_direct, direct_reachability_scope, has_global_address
 /// - **Connections**: connected_peers, active_connections, pending_connections
 /// - **NAT Traversal**: direct_connections, relayed_connections, hole_punch_success_rate
 /// - **Relay**: is_relaying, relay_sessions, relay_bytes_forwarded
@@ -118,13 +121,17 @@ pub struct NodeStatus {
 
     /// Whether this node can receive direct connections
     ///
-    /// `true` if the node has a public IP or is behind a traversable NAT.
+    /// `true` only after this node has peer-verified evidence that another
+    /// node reached it directly without coordinator or relay assistance.
     pub can_receive_direct: bool,
 
-    /// Whether this node has a public IP
+    /// Broadest scope in which direct inbound reachability has been verified.
+    pub direct_reachability_scope: Option<ReachabilityScope>,
+
+    /// Whether this node has a globally routable address candidate.
     ///
-    /// `true` if local_addr matches an external_addr (no NAT).
-    pub has_public_ip: bool,
+    /// This is an address property, not proof of reachability.
+    pub has_global_address: bool,
 
     // --- Connections ---
     /// Number of connected peers
@@ -151,8 +158,8 @@ pub struct NodeStatus {
     // --- Relay Status (NEW - key visibility) ---
     /// Whether this node is currently acting as a relay for others
     ///
-    /// `true` if this node has public connectivity and is forwarding
-    /// traffic for peers behind restrictive NATs.
+    /// `true` if this node has fresh peer-verified direct reachability and is
+    /// forwarding traffic for peers behind restrictive NATs.
     pub is_relaying: bool,
 
     /// Number of active relay sessions
@@ -165,7 +172,8 @@ pub struct NodeStatus {
     /// Whether this node is coordinating NAT traversal
     ///
     /// `true` if this node is helping peers coordinate hole punching.
-    /// All nodes with public connectivity act as coordinators.
+    /// Fresh peer-verified direct reachability is the signal other peers should
+    /// use when deciding whether this node is a viable coordinator.
     pub is_coordinating: bool,
 
     /// Number of active coordination sessions
@@ -189,7 +197,8 @@ impl Default for NodeStatus {
             external_addrs: Vec::new(),
             nat_type: NatType::Unknown,
             can_receive_direct: false,
-            has_public_ip: false,
+            direct_reachability_scope: None,
+            has_global_address: false,
             connected_peers: 0,
             active_connections: 0,
             pending_connections: 0,
@@ -215,10 +224,10 @@ impl NodeStatus {
 
     /// Check if node can help with NAT traversal
     ///
-    /// Returns true if the node has public connectivity and can
+    /// Returns true if the node has peer-verified direct reachability and can
     /// act as coordinator/relay for other peers.
     pub fn can_help_traversal(&self) -> bool {
-        self.has_public_ip || self.can_receive_direct
+        self.can_receive_direct
     }
 
     /// Get the total number of connections (direct + relayed)
@@ -245,7 +254,7 @@ mod tests {
 
     #[test]
     fn test_nat_type_display() {
-        assert_eq!(format!("{}", NatType::None), "None (Public IP)");
+        assert_eq!(format!("{}", NatType::None), "None (No NAT detected)");
         assert_eq!(format!("{}", NatType::FullCone), "Full Cone");
         assert_eq!(
             format!("{}", NatType::AddressRestricted),
@@ -266,7 +275,8 @@ mod tests {
         let status = NodeStatus::default();
         assert_eq!(status.nat_type, NatType::Unknown);
         assert!(!status.can_receive_direct);
-        assert!(!status.has_public_ip);
+        assert_eq!(status.direct_reachability_scope, None);
+        assert!(!status.has_global_address);
         assert_eq!(status.connected_peers, 0);
         assert!(!status.is_relaying);
         assert!(!status.is_coordinating);
@@ -286,12 +296,27 @@ mod tests {
         let mut status = NodeStatus::default();
         assert!(!status.can_help_traversal());
 
-        status.has_public_ip = true;
-        assert!(status.can_help_traversal());
+        status.has_global_address = true;
+        assert!(
+            !status.can_help_traversal(),
+            "Global address alone must not imply direct reachability"
+        );
 
-        status.has_public_ip = false;
         status.can_receive_direct = true;
+        status.direct_reachability_scope = Some(ReachabilityScope::Global);
         assert!(status.can_help_traversal());
+    }
+
+    #[test]
+    fn test_direct_reachability_scope_tracks_observer_scope() {
+        let mut status = NodeStatus::default();
+        status.can_receive_direct = true;
+        status.direct_reachability_scope = Some(ReachabilityScope::LocalNetwork);
+
+        assert_eq!(
+            status.direct_reachability_scope,
+            Some(ReachabilityScope::LocalNetwork)
+        );
     }
 
     #[test]

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -1257,6 +1257,23 @@ impl P2pEndpoint {
     /// hole-punch timeout to give it time to complete the punch.
     ///
     /// Empty `coordinators` removes any preferred coordinators for `target`.
+    ///
+    /// ## Interaction with `StrategyConfig::max_holepunch_rounds`
+    ///
+    /// Each rotation step in the connect loop calls
+    /// `ConnectionStrategy::increment_round`, so the strategy's per-round
+    /// counter and the rotation index advance together. With the default
+    /// `max_holepunch_rounds = 2`, supplying `K ≥ 2` preferred coordinators
+    /// gives each coordinator (including the final one) exactly one
+    /// attempt — the rotation fully replaces the legacy retry loop and the
+    /// worst-case dial time is `(K-1) * 1.5s + 8s`.
+    ///
+    /// If a caller has explicitly raised `max_holepunch_rounds` (e.g.
+    /// `with_max_holepunch_rounds(5)`) **and** also supplies a preferred
+    /// list, the *final* coordinator inherits the leftover round budget
+    /// — it will be retried `max_rounds - K + 1` times at the full
+    /// hole-punch timeout. This is usually fine but worth knowing if you
+    /// were expecting the rotation to be the only retry mechanism.
     pub async fn set_hole_punch_preferred_coordinators(
         &self,
         target: SocketAddr,
@@ -1381,11 +1398,13 @@ impl P2pEndpoint {
         // Drop any pre-existing copies of the preferred entries from the
         // tail so we don't end up with duplicates after the front-insert.
         coordinator_candidates.retain(|a| !preferred.contains(a));
-        // Insert in reverse so `preferred[0]` ends up at index 0,
-        // `preferred[1]` at index 1, etc.
-        for preferred_addr in preferred.iter().rev() {
-            coordinator_candidates.insert(0, *preferred_addr);
-        }
+        // Build the merged list in one allocation rather than calling
+        // `Vec::insert(0, ..)` in a loop (which shifts the entire tail
+        // on every iteration — O(N·M) instead of O(N+M)).
+        let mut merged = Vec::with_capacity(preferred.len() + coordinator_candidates.len());
+        merged.extend_from_slice(preferred);
+        merged.append(coordinator_candidates);
+        *coordinator_candidates = merged;
     }
 
     /// Inner implementation of connect_with_fallback (separated for dedup wrapper).
@@ -1702,6 +1721,25 @@ impl P2pEndpoint {
                     } else {
                         strategy.holepunch_timeout()
                     };
+
+                    // Invariant: while rotating, the strategy's current
+                    // coordinator must equal `coordinator_candidates[idx]`.
+                    // This is maintained by `set_coordinator()` on every
+                    // rotation step; the assert catches any future
+                    // regression where a caller sets the strategy's
+                    // coordinator out of band without updating the
+                    // candidate list.
+                    debug_assert!(
+                        !is_rotating
+                            || coordinator_candidates
+                                .get(current_preferred_coordinator_idx)
+                                .copied()
+                                == Some(coordinator),
+                        "rotation index out of sync with strategy coordinator: idx={}, coord={}, candidates={:?}",
+                        current_preferred_coordinator_idx,
+                        coordinator,
+                        coordinator_candidates,
+                    );
 
                     info!(
                         "Trying hole-punch to {} via {} (round {}, attempt timeout {:?}, rotating={})",

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -92,17 +92,22 @@ const STALE_REAPER_INTERVAL: Duration = Duration::from_secs(10);
 const POST_HOLEPUNCH_DIRECT_RETRY_TIMEOUT: Duration = Duration::from_secs(1);
 
 /// Per-attempt hole-punch timeout used when rotating through a list of
-/// preferred coordinators. Kept short so a busy or unreachable coordinator
-/// is abandoned quickly and the next one in the list is tried; the *last*
-/// coordinator in the rotation falls back to the strategy's full
+/// preferred coordinators. Kept reasonably short so a busy or unreachable
+/// coordinator is abandoned and the next one in the list is tried; the
+/// *last* coordinator in the rotation falls back to the strategy's full
 /// hole-punch timeout to give it time to actually complete the punch.
 ///
-/// Tuned for the Tier 2 + Tier 4 (lite) coordinator-rotation flow: 1.5s
-/// is comfortably above one round-trip on most internet links but well
-/// below the strategy default (~8s), so the worst-case wait for K
-/// preferred coordinators is roughly `(K-1) * 1.5s + 8s` instead of
-/// `K * 8s`.
-const PER_COORDINATOR_QUICK_HOLEPUNCH_TIMEOUT: Duration = Duration::from_millis(1500);
+/// **Sized to outlast one full PUNCH_ME_NOW round trip on cross-region
+/// links.** With 1.5s, rotation routinely fired while the previous
+/// round's relayed return connection was still in flight, producing
+/// multiple parallel hole-punch attempts and the "duplicate connection"
+/// dedup storm under symmetric NAT. 4s gives a comfortably high margin
+/// over the worst-case relay→target→back round trip on cross-region
+/// links and dramatically reduces the racing-attempt window. Worst-case
+/// wait for K preferred coordinators is now roughly
+/// `(K-1) * 4s + holepunch_timeout` instead of `K * holepunch_timeout`,
+/// which is still well below `K * 8s`.
+const PER_COORDINATOR_QUICK_HOLEPUNCH_TIMEOUT: Duration = Duration::from_secs(4);
 
 use crate::SHUTDOWN_DRAIN_TIMEOUT;
 
@@ -1814,20 +1819,26 @@ impl P2pEndpoint {
                     let attempt_result =
                         timeout(attempt_timeout, self.try_hole_punch(target, coordinator)).await;
 
-                    // Common post-attempt step: try a quick direct connect.
-                    // The NAT binding may have been created by the target's
-                    // outgoing packets even though our try_hole_punch didn't
-                    // detect the connection.
-                    let post_direct = async {
-                        if let Ok(Ok(peer_conn)) =
-                            timeout(POST_HOLEPUNCH_DIRECT_RETRY_TIMEOUT, self.connect(target)).await
-                        {
-                            info!("✓ Post-hole-punch direct connect succeeded to {}", target);
-                            Some(peer_conn)
-                        } else {
-                            None
-                        }
-                    };
+                    // Per-rotation `post_direct` probe REMOVED.
+                    //
+                    // Previously this loop fired a `self.connect(target)`
+                    // probe after every failed hole-punch round to opportunistically
+                    // catch a NAT binding the target's reply might have created.
+                    // That probe issued a parallel A→B QUIC dial which raced
+                    // the relayed B→A return from the same round. Under
+                    // symmetric NAT each round's return arrived on a fresh
+                    // source port, so the `connected_peers` SocketAddr-keyed
+                    // dedup did not collapse them and several connections
+                    // accumulated for the same logical peer. Each ended up
+                    // closed as `b"duplicate"` once the first was promoted —
+                    // and any of those closes that happened to be the one
+                    // saorsa-core's lifecycle monitor was tracking killed the
+                    // identity exchange.
+                    //
+                    // Direct probing now happens **once** at the end of the
+                    // rotation chain (see the post-loop attempt below), which
+                    // preserves the NAT-binding optimisation without producing
+                    // a per-round race.
 
                     match attempt_result {
                         Ok(Ok(conn)) => {
@@ -1835,12 +1846,6 @@ impl P2pEndpoint {
                             return Ok((conn, ConnectionMethod::HolePunched { coordinator }));
                         }
                         Ok(Err(e)) => {
-                            if let Some(peer_conn) = post_direct.await {
-                                return Ok((
-                                    peer_conn,
-                                    ConnectionMethod::HolePunched { coordinator },
-                                ));
-                            }
                             strategy.record_holepunch_error(round, e.to_string());
                             // Bounds-safe rotation: bail out of rotation and
                             // fall back to relay if for any reason the index
@@ -1872,18 +1877,26 @@ impl P2pEndpoint {
                                     round
                                 );
                                 strategy.increment_round();
+                            } else if let Some(peer_conn) =
+                                self.try_post_rotation_direct(target).await
+                            {
+                                // Final post-rotation probe: maybe the
+                                // accumulated NAT bindings from the rotation
+                                // chain finally let a direct dial through.
+                                info!(
+                                    "✓ Post-rotation direct connect succeeded to {} after rotation chain",
+                                    target
+                                );
+                                return Ok((
+                                    peer_conn,
+                                    ConnectionMethod::HolePunched { coordinator },
+                                ));
                             } else {
                                 debug!("Hole-punch failed after {} rounds", round);
                                 strategy.transition_to_relay(e.to_string());
                             }
                         }
                         Err(_) => {
-                            if let Some(peer_conn) = post_direct.await {
-                                return Ok((
-                                    peer_conn,
-                                    ConnectionMethod::HolePunched { coordinator },
-                                ));
-                            }
                             strategy.record_holepunch_error(round, "Timeout".to_string());
                             let next_coord = if is_rotating && !is_final_rotation_attempt {
                                 coordinator_candidates
@@ -1910,6 +1923,17 @@ impl P2pEndpoint {
                                     round
                                 );
                                 strategy.increment_round();
+                            } else if let Some(peer_conn) =
+                                self.try_post_rotation_direct(target).await
+                            {
+                                info!(
+                                    "✓ Post-rotation direct connect succeeded to {} after timeout rotation chain",
+                                    target
+                                );
+                                return Ok((
+                                    peer_conn,
+                                    ConnectionMethod::HolePunched { coordinator },
+                                ));
                             } else {
                                 debug!("Hole-punch timed out after {} rounds", round);
                                 strategy.transition_to_relay("Timeout");
@@ -2070,6 +2094,41 @@ impl P2pEndpoint {
     }
 
     /// Internal helper for hole-punch attempt
+    /// Single direct-dial attempt at the end of a coordinator rotation.
+    ///
+    /// Replaces the per-round `post_direct` probe that used to fire after
+    /// every failed hole-punch attempt. The per-round probe was the source
+    /// of the "duplicate connection" close storm: each round opened a
+    /// parallel A→B QUIC dial alongside the relayed B→A return, and under
+    /// symmetric NAT each return arrived on a fresh source port that
+    /// SocketAddr-keyed dedup did not collapse.
+    ///
+    /// Calling this exactly once after the rotation chain has been
+    /// exhausted preserves the original optimisation — the cumulative NAT
+    /// bindings created by the rotation may finally let a direct dial
+    /// through — without producing a per-round race. Returns `Some` only
+    /// if the dial completes within
+    /// [`POST_HOLEPUNCH_DIRECT_RETRY_TIMEOUT`].
+    async fn try_post_rotation_direct(&self, target: SocketAddr) -> Option<PeerConnection> {
+        match timeout(POST_HOLEPUNCH_DIRECT_RETRY_TIMEOUT, self.connect(target)).await {
+            Ok(Ok(peer_conn)) => Some(peer_conn),
+            Ok(Err(e)) => {
+                debug!(
+                    "try_post_rotation_direct: connect to {} failed: {}",
+                    target, e
+                );
+                None
+            }
+            Err(_) => {
+                debug!(
+                    "try_post_rotation_direct: connect to {} timed out after {:?}",
+                    target, POST_HOLEPUNCH_DIRECT_RETRY_TIMEOUT
+                );
+                None
+            }
+        }
+    }
+
     async fn try_hole_punch(
         &self,
         target: SocketAddr,
@@ -2342,6 +2401,34 @@ impl P2pEndpoint {
         peers.values().any(|p| p.remote_addr == transport_addr)
     }
 
+    /// Find an existing live connection from the same TLS public key.
+    ///
+    /// Used to dedup symmetric-NAT rebinds at accept time. When a peer's
+    /// rotation chain produces several return connections on different
+    /// source ports, the SocketAddr-keyed `connected_peers` map cannot
+    /// collapse them; this helper closes the gap by scanning for any
+    /// existing entry whose `public_key` matches and whose underlying
+    /// QUIC connection is still alive.
+    ///
+    /// Returns the [`SocketAddr`] of the surviving connection on a hit,
+    /// `None` otherwise. O(N) over connected peers; acceptable since
+    /// accept rate is bounded by the network and the typical N is in
+    /// the hundreds.
+    async fn find_live_connection_by_public_key(&self, public_key: &[u8]) -> Option<SocketAddr> {
+        let peers = self.connected_peers.read().await;
+        for (addr, peer_conn) in peers.iter() {
+            if peer_conn
+                .public_key
+                .as_deref()
+                .is_some_and(|existing| existing == public_key)
+                && self.inner.is_connected(addr)
+            {
+                return Some(*addr);
+            }
+        }
+        None
+    }
+
     /// Accept incoming connections
     ///
     /// Returns `None` if the endpoint is shutting down or the accept fails.
@@ -2361,6 +2448,32 @@ impl P2pEndpoint {
             Ok((remote_addr, connection)) => {
                 // Extract public key from TLS handshake
                 let remote_public_key = extract_public_key_bytes_from_connection(&connection);
+
+                // Peer-identity dedup: under symmetric NAT a single
+                // logical peer can produce several QUIC connections in
+                // close succession (one per coordinator round in the
+                // dialer's rotation chain), each arriving on a fresh
+                // source port. The SocketAddr-keyed dedup in
+                // `spawn_accept_loop` and `attempt_hole_punch` cannot
+                // collapse them because their keys differ. Without this
+                // peer-id check those duplicates accumulate in
+                // `connected_peers`, race for the same logical channel
+                // up at saorsa-core, and produce the "duplicate
+                // connection" close storm that previously broke identity
+                // exchange. Catching duplicates by TLS public key
+                // *before* registering them keeps the first surviving
+                // connection authoritative and silently drops the rest.
+                if let Some(ref new_key) = remote_public_key
+                    && let Some(existing_addr) =
+                        self.find_live_connection_by_public_key(new_key).await
+                {
+                    info!(
+                        "accept: duplicate connection from already-connected peer (existing addr {}, new addr {}) — closing new",
+                        existing_addr, remote_addr
+                    );
+                    connection.close(0u32.into(), b"duplicate-peer-id");
+                    return None;
+                }
 
                 // They initiated the connection to us = Server side
                 if let Err(e) = self.inner.spawn_connection_handler(

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -1895,8 +1895,9 @@ impl P2pEndpoint {
                 }
 
                 ConnectionStage::Connected { via } => {
-                    // This shouldn't happen in the loop, but handle it
-                    unreachable!("Connected stage reached in loop: {:?}", via);
+                    return Err(EndpointError::Connection(format!(
+                        "unexpected Connected stage reached in loop: {via:?}"
+                    )));
                 }
             }
         }

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -1875,12 +1875,12 @@ impl P2pEndpoint {
                             return Ok((conn, ConnectionMethod::Relayed { relay: relay_addr }));
                         }
                         Ok(Err(e)) => {
-                            debug!("Relay connection failed: {}", e);
-                            strategy.transition_to_failed(e.to_string());
+                            debug!("Relay connection failed: {e}");
+                            strategy.transition_to_next_relay(e.to_string());
                         }
                         Err(_) => {
                             debug!("Relay connection timed out");
-                            strategy.transition_to_failed("Timeout");
+                            strategy.transition_to_next_relay("Timeout");
                         }
                     }
                 }

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -2329,28 +2329,11 @@ impl P2pEndpoint {
         Ok(peer_conn)
     }
 
-    /// Check if we're connected to a specific address
-    async fn record_direct_incoming_stats(&self, remote_addr: SocketAddr) {
-        let mut stats = self.stats.write().await;
-        stats.active_connections += 1;
-        stats.successful_connections += 1;
-        stats.direct_connections += 1;
-        stats.active_direct_incoming_connections += 1;
-        let now = Instant::now();
-
-        match socket_addr_scope(remote_addr) {
-            Some(ReachabilityScope::Loopback) => {
-                stats.last_direct_loopback_at = Some(now);
-            }
-            Some(ReachabilityScope::LocalNetwork) => {
-                stats.last_direct_local_at = Some(now);
-            }
-            Some(ReachabilityScope::Global) => {
-                stats.last_direct_global_at = Some(now);
-            }
-            None => {}
-        }
-    }
+    // NOTE: direct incoming stats (active_direct_incoming_connections and
+    // scope timestamps) are recorded exclusively in the event_callback
+    // closure when NatTraversalEvent::ConnectionEstablished is emitted by
+    // spawn_connection_handler. No separate increment here to avoid
+    // double-counting.
 
     async fn is_connected_to_addr(&self, addr: SocketAddr) -> bool {
         let transport_addr = TransportAddr::Quic(addr);
@@ -2426,7 +2409,8 @@ impl P2pEndpoint {
                     .await
                     .insert(remote_addr, peer_conn.clone());
 
-                self.record_direct_incoming_stats(remote_addr).await;
+                // Stats are recorded by the event_callback when
+                // spawn_connection_handler emits ConnectionEstablished.
 
                 // They initiated the connection to us = Server side
                 let _ = self.event_tx.send(P2pEvent::PeerConnected {

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -71,9 +71,8 @@ use crate::constrained::EngineEvent;
 use crate::crypto::raw_public_keys::key_utils::generate_ml_dsa_keypair;
 use crate::happy_eyeballs::{self, HappyEyeballsConfig};
 pub use crate::nat_traversal_api::TraversalPhase;
-use crate::nat_traversal_api::{
-    NatTraversalEndpoint, NatTraversalError, NatTraversalEvent, NatTraversalStatistics,
-};
+use crate::nat_traversal_api::{NatTraversalEndpoint, NatTraversalError, NatTraversalEvent};
+use crate::reachability::{ReachabilityScope, TraversalMethod, socket_addr_scope};
 use crate::transport::{ProtocolEngine, TransportAddr, TransportRegistry};
 use crate::unified_config::P2pConfig;
 use rustls;
@@ -251,6 +250,12 @@ pub struct PeerConnection {
     /// Remote address (supports all transport types)
     pub remote_addr: TransportAddr,
 
+    /// How this connection was established.
+    pub traversal_method: TraversalMethod,
+
+    /// Who initiated the connection.
+    pub side: Side,
+
     /// Whether peer is authenticated
     pub authenticated: bool,
 
@@ -298,8 +303,20 @@ pub struct EndpointStats {
     /// Successful NAT traversals
     pub nat_traversal_successes: u64,
 
-    /// Direct connections (no NAT traversal needed)
+    /// Direct connections (no coordinator or relay needed)
     pub direct_connections: u64,
+
+    /// Currently active direct inbound connections from peers.
+    pub active_direct_incoming_connections: u64,
+
+    /// Most recent loopback-scoped direct inbound observation.
+    pub last_direct_loopback_at: Option<Instant>,
+
+    /// Most recent LAN-scoped direct inbound observation.
+    pub last_direct_local_at: Option<Instant>,
+
+    /// Most recent globally scoped direct inbound observation.
+    pub last_direct_global_at: Option<Instant>,
 
     /// Relayed connections
     pub relayed_connections: u64,
@@ -326,6 +343,10 @@ impl Default for EndpointStats {
             nat_traversal_attempts: 0,
             nat_traversal_successes: 0,
             direct_connections: 0,
+            active_direct_incoming_connections: 0,
+            last_direct_loopback_at: None,
+            last_direct_local_at: None,
+            last_direct_global_at: None,
             relayed_connections: 0,
             total_bootstrap_nodes: 0,
             connected_bootstrap_nodes: 0,
@@ -349,7 +370,7 @@ impl Default for EndpointStats {
 ///
 /// while let Ok(event) = events.recv().await {
 ///     match event {
-///         P2pEvent::PeerConnected { peer_id, addr, side } => {
+///         P2pEvent::PeerConnected { addr, public_key, side, traversal_method } => {
 ///             // Handle different transport types
 ///             match addr {
 ///                 TransportAddr::Quic(socket_addr) => {
@@ -403,6 +424,8 @@ pub enum P2pEvent {
         public_key: Option<Vec<u8>>,
         /// Who initiated the connection (Client = we connected, Server = they connected)
         side: Side,
+        /// Whether the connection was direct, hole-punched, or relayed.
+        traversal_method: TraversalMethod,
     },
 
     /// A peer has disconnected.
@@ -586,6 +609,10 @@ async fn do_cleanup_connection(
         {
             let mut s = stats.write().await;
             s.active_connections = s.active_connections.saturating_sub(1);
+            if peer_conn.traversal_method.is_direct() && peer_conn.side.is_server() {
+                s.active_direct_incoming_connections =
+                    s.active_direct_incoming_connections.saturating_sub(1);
+            }
         }
 
         let _ = event_tx.send(P2pEvent::PeerDisconnected {
@@ -650,17 +677,45 @@ impl P2pEndpoint {
                     NatTraversalEvent::ConnectionEstablished {
                         remote_address,
                         side,
+                        traversal_method,
                         public_key,
                     } => {
                         stats_guard.nat_traversal_successes += 1;
                         stats_guard.active_connections += 1;
                         stats_guard.successful_connections += 1;
 
+                        match traversal_method {
+                            TraversalMethod::Direct => {
+                                stats_guard.direct_connections += 1;
+                                if side.is_server() {
+                                    stats_guard.active_direct_incoming_connections += 1;
+                                    let now = Instant::now();
+                                    match socket_addr_scope(*remote_address) {
+                                        Some(ReachabilityScope::Loopback) => {
+                                            stats_guard.last_direct_loopback_at = Some(now);
+                                        }
+                                        Some(ReachabilityScope::LocalNetwork) => {
+                                            stats_guard.last_direct_local_at = Some(now);
+                                        }
+                                        Some(ReachabilityScope::Global) => {
+                                            stats_guard.last_direct_global_at = Some(now);
+                                        }
+                                        None => {}
+                                    }
+                                }
+                            }
+                            TraversalMethod::Relay => {
+                                stats_guard.relayed_connections += 1;
+                            }
+                            TraversalMethod::HolePunch | TraversalMethod::PortPrediction => {}
+                        }
+
                         // Broadcast event with connection direction
                         let _ = event_tx.send(P2pEvent::PeerConnected {
                             addr: TransportAddr::Quic(*remote_address),
                             public_key: public_key.clone(),
                             side: *side,
+                            traversal_method: *traversal_method,
                         });
                     }
                     NatTraversalEvent::TraversalFailed { remote_address, .. } => {
@@ -960,7 +1015,7 @@ impl P2pEndpoint {
 
         // Spawn handler (we initiated the connection = Client side)
         self.inner
-            .spawn_connection_handler(addr, connection, Side::Client)
+            .spawn_connection_handler(addr, connection, Side::Client, TraversalMethod::Direct)
             .map_err(EndpointError::NatTraversal)?;
 
         // Create peer connection record
@@ -968,6 +1023,8 @@ impl P2pEndpoint {
         let peer_conn = PeerConnection {
             public_key: remote_public_key.clone(),
             remote_addr: TransportAddr::Quic(addr),
+            traversal_method: TraversalMethod::Direct,
+            side: Side::Client,
             authenticated: true, // TLS handles authentication
             connected_at: Instant::now(),
             last_activity: Instant::now(),
@@ -999,6 +1056,7 @@ impl P2pEndpoint {
             addr: TransportAddr::Quic(addr),
             public_key: remote_public_key,
             side: Side::Client,
+            traversal_method: TraversalMethod::Direct,
         });
 
         Ok(peer_conn)
@@ -1074,6 +1132,8 @@ impl P2pEndpoint {
                 let peer_conn = PeerConnection {
                     public_key: None, // Constrained connections don't have TLS auth yet
                     remote_addr: addr.clone(),
+                    traversal_method: TraversalMethod::Direct,
+                    side: Side::Client,
                     authenticated: false,
                     connected_at: Instant::now(),
                     last_activity: Instant::now(),
@@ -1096,6 +1156,7 @@ impl P2pEndpoint {
                     addr: addr.clone(),
                     public_key: None,
                     side: Side::Client,
+                    traversal_method: TraversalMethod::Direct,
                 });
 
                 Ok(peer_conn)
@@ -1570,6 +1631,8 @@ impl P2pEndpoint {
                     let peer_conn = PeerConnection {
                         public_key: None,
                         remote_addr: TransportAddr::Quic(target_addr),
+                        traversal_method: TraversalMethod::HolePunch,
+                        side: Side::Client,
                         authenticated: true,
                         connected_at: Instant::now(),
                         last_activity: Instant::now(),
@@ -1589,6 +1652,7 @@ impl P2pEndpoint {
                         addr: TransportAddr::Quic(target_addr),
                         public_key: peer_conn.public_key.clone(),
                         side: Side::Client,
+                        traversal_method: TraversalMethod::HolePunch,
                     });
 
                     return Ok((
@@ -1964,12 +2028,14 @@ impl P2pEndpoint {
 
         // Spawn connection handler (Client side - we initiated)
         self.inner
-            .spawn_connection_handler(addr, connection, Side::Client)
+            .spawn_connection_handler(addr, connection, Side::Client, TraversalMethod::Direct)
             .map_err(EndpointError::NatTraversal)?;
 
         let peer_conn = PeerConnection {
             public_key: remote_public_key.clone(),
             remote_addr: TransportAddr::Quic(addr),
+            traversal_method: TraversalMethod::Direct,
+            side: Side::Client,
             authenticated: true,
             connected_at: Instant::now(),
             last_activity: Instant::now(),
@@ -1996,6 +2062,7 @@ impl P2pEndpoint {
             addr: TransportAddr::Quic(addr),
             public_key: remote_public_key,
             side: Side::Client,
+            traversal_method: TraversalMethod::Direct,
         });
 
         Ok(peer_conn)
@@ -2104,6 +2171,8 @@ impl P2pEndpoint {
                 let peer_conn = PeerConnection {
                     public_key: None,
                     remote_addr: TransportAddr::Quic(actual_addr),
+                    traversal_method: TraversalMethod::HolePunch,
+                    side: Side::Client,
                     authenticated: true,
                     connected_at: Instant::now(),
                     last_activity: Instant::now(),
@@ -2228,12 +2297,14 @@ impl P2pEndpoint {
             .map_err(EndpointError::NatTraversal)?;
 
         self.inner
-            .spawn_connection_handler(target, connection, Side::Client)
+            .spawn_connection_handler(target, connection, Side::Client, TraversalMethod::Relay)
             .map_err(EndpointError::NatTraversal)?;
 
         let peer_conn = PeerConnection {
             public_key: remote_public_key,
             remote_addr: TransportAddr::Quic(target),
+            traversal_method: TraversalMethod::Relay,
+            side: Side::Client,
             authenticated: true,
             connected_at: Instant::now(),
             last_activity: Instant::now(),
@@ -2259,6 +2330,28 @@ impl P2pEndpoint {
     }
 
     /// Check if we're connected to a specific address
+    async fn record_direct_incoming_stats(&self, remote_addr: SocketAddr) {
+        let mut stats = self.stats.write().await;
+        stats.active_connections += 1;
+        stats.successful_connections += 1;
+        stats.direct_connections += 1;
+        stats.active_direct_incoming_connections += 1;
+        let now = Instant::now();
+
+        match socket_addr_scope(remote_addr) {
+            Some(ReachabilityScope::Loopback) => {
+                stats.last_direct_loopback_at = Some(now);
+            }
+            Some(ReachabilityScope::LocalNetwork) => {
+                stats.last_direct_local_at = Some(now);
+            }
+            Some(ReachabilityScope::Global) => {
+                stats.last_direct_global_at = Some(now);
+            }
+            None => {}
+        }
+    }
+
     async fn is_connected_to_addr(&self, addr: SocketAddr) -> bool {
         let transport_addr = TransportAddr::Quic(addr);
         let peers = self.connected_peers.read().await;
@@ -2286,10 +2379,12 @@ impl P2pEndpoint {
                 let remote_public_key = extract_public_key_bytes_from_connection(&connection);
 
                 // They initiated the connection to us = Server side
-                if let Err(e) =
-                    self.inner
-                        .spawn_connection_handler(remote_addr, connection, Side::Server)
-                {
+                if let Err(e) = self.inner.spawn_connection_handler(
+                    remote_addr,
+                    connection,
+                    Side::Server,
+                    TraversalMethod::Direct,
+                ) {
                     error!("Failed to spawn connection handler: {}", e);
                     return None;
                 }
@@ -2298,6 +2393,8 @@ impl P2pEndpoint {
                 let peer_conn = PeerConnection {
                     public_key: remote_public_key.clone(),
                     remote_addr: TransportAddr::Quic(remote_addr),
+                    traversal_method: TraversalMethod::Direct,
+                    side: Side::Server,
                     authenticated: true, // TLS handles authentication
                     connected_at: Instant::now(),
                     last_activity: Instant::now(),
@@ -2329,17 +2426,14 @@ impl P2pEndpoint {
                     .await
                     .insert(remote_addr, peer_conn.clone());
 
-                {
-                    let mut stats = self.stats.write().await;
-                    stats.active_connections += 1;
-                    stats.successful_connections += 1;
-                }
+                self.record_direct_incoming_stats(remote_addr).await;
 
                 // They initiated the connection to us = Server side
                 let _ = self.event_tx.send(P2pEvent::PeerConnected {
                     addr: TransportAddr::Quic(remote_addr),
                     public_key: remote_public_key,
                     side: Side::Server,
+                    traversal_method: TraversalMethod::Direct,
                 });
 
                 Some(peer_conn)
@@ -2459,6 +2553,8 @@ impl P2pEndpoint {
                     let peer_conn = PeerConnection {
                         public_key: None,
                         remote_addr: TransportAddr::Quic(*addr),
+                        traversal_method: TraversalMethod::HolePunch,
+                        side: Side::Server,
                         authenticated: true,
                         connected_at: Instant::now(),
                         last_activity: Instant::now(),
@@ -2468,6 +2564,7 @@ impl P2pEndpoint {
                         addr: TransportAddr::Quic(*addr),
                         public_key: None,
                         side: Side::Server,
+                        traversal_method: TraversalMethod::HolePunch,
                     });
                     (TransportAddr::Quic(*addr), Some(conn))
                 } else {
@@ -2678,13 +2775,6 @@ impl P2pEndpoint {
                 / (stats.path.sent_packets + stats.path.lost_packets).max(1) as f64,
             last_activity,
         })
-    }
-
-    /// Get NAT traversal statistics
-    pub fn nat_stats(&self) -> Result<NatTraversalStatistics, EndpointError> {
-        self.inner
-            .get_nat_stats()
-            .map_err(|e| EndpointError::Connection(e.to_string()))
     }
 
     // === Known Peers ===
@@ -3012,6 +3102,8 @@ impl P2pEndpoint {
                 PeerConnection {
                     public_key: None,
                     remote_addr: addr.clone(),
+                    traversal_method: TraversalMethod::Direct,
+                    side,
                     authenticated: false,
                     connected_at: Instant::now(),
                     last_activity: Instant::now(),
@@ -3021,6 +3113,7 @@ impl P2pEndpoint {
                 addr: addr.clone(),
                 public_key: None,
                 side,
+                traversal_method: TraversalMethod::Direct,
             });
         }
 
@@ -3387,6 +3480,8 @@ impl P2pEndpoint {
                 let peer_conn = PeerConnection {
                     public_key: None,
                     remote_addr: TransportAddr::Quic(addr),
+                    traversal_method: TraversalMethod::HolePunch,
+                    side: Side::Server,
                     authenticated: true,
                     connected_at: Instant::now(),
                     last_activity: Instant::now(),
@@ -3457,6 +3552,7 @@ impl P2pEndpoint {
                     addr: TransportAddr::Quic(addr),
                     public_key: None,
                     side: Side::Server,
+                    traversal_method: TraversalMethod::HolePunch,
                 });
 
                 // Spawn a reader task for the connection so incoming streams
@@ -3585,6 +3681,8 @@ mod tests {
         let conn = PeerConnection {
             public_key: None,
             remote_addr: TransportAddr::Quic(socket_addr),
+            traversal_method: TraversalMethod::Direct,
+            side: Side::Client,
             authenticated: false,
             connected_at: Instant::now(),
             last_activity: Instant::now(),
@@ -3696,6 +3794,7 @@ mod tests {
             addr: TransportAddr::Quic(socket_addr),
             public_key: None,
             side: Side::Client,
+            traversal_method: TraversalMethod::Direct,
         };
 
         // Verify event fields
@@ -3703,11 +3802,13 @@ mod tests {
             addr,
             public_key,
             side,
+            traversal_method,
         } = event
         {
             assert!(public_key.is_none());
             assert_eq!(addr, TransportAddr::Quic(socket_addr));
             assert!(side.is_client());
+            assert_eq!(traversal_method, TraversalMethod::Direct);
 
             // Verify as_socket_addr() works
             let extracted = addr.as_socket_addr();
@@ -3728,6 +3829,7 @@ mod tests {
             },
             public_key: None,
             side: Side::Server,
+            traversal_method: TraversalMethod::Direct,
         };
 
         // Verify event fields
@@ -3735,10 +3837,12 @@ mod tests {
             addr,
             public_key,
             side,
+            traversal_method,
         } = event
         {
             assert!(public_key.is_none());
             assert!(side.is_server());
+            assert_eq!(traversal_method, TraversalMethod::Direct);
 
             // Verify as_socket_addr() returns None for BLE
             assert!(addr.as_socket_addr().is_none());
@@ -3775,6 +3879,7 @@ mod tests {
             addr: TransportAddr::Quic(socket_addr),
             public_key: Some(vec![0x11; 32]),
             side: Side::Client,
+            traversal_method: TraversalMethod::Direct,
         };
 
         // Verify events are Clone
@@ -3804,6 +3909,8 @@ mod tests {
         let udp_conn = PeerConnection {
             public_key: None,
             remote_addr: TransportAddr::Quic(udp_addr),
+            traversal_method: TraversalMethod::Direct,
+            side: Side::Client,
             authenticated: true,
             connected_at: Instant::now(),
             last_activity: Instant::now(),
@@ -3822,6 +3929,8 @@ mod tests {
                 mac: mac_addr,
                 psm: 128,
             },
+            traversal_method: TraversalMethod::Direct,
+            side: Side::Client,
             authenticated: true,
             connected_at: Instant::now(),
             last_activity: Instant::now(),
@@ -3839,6 +3948,7 @@ mod tests {
             addr: TransportAddr::Quic(socket_addr),
             public_key: None,
             side: Side::Client,
+            traversal_method: TraversalMethod::Direct,
         };
 
         // Verify display formatting works for logging
@@ -3868,6 +3978,8 @@ mod tests {
         let conn = PeerConnection {
             public_key: None,
             remote_addr: TransportAddr::Quic(socket_addr),
+            traversal_method: TraversalMethod::Direct,
+            side: Side::Client,
             authenticated: true,
             connected_at: Instant::now(),
             last_activity: Instant::now(),
@@ -3898,6 +4010,8 @@ mod tests {
             PeerConnection {
                 public_key: None,
                 remote_addr: TransportAddr::Quic(udp_addr),
+                traversal_method: TraversalMethod::Direct,
+                side: Side::Client,
                 authenticated: true,
                 connected_at: Instant::now(),
                 last_activity: Instant::now(),
@@ -3916,6 +4030,8 @@ mod tests {
             PeerConnection {
                 public_key: None,
                 remote_addr: ble_addr,
+                traversal_method: TraversalMethod::Direct,
+                side: Side::Client,
                 authenticated: true,
                 connected_at: Instant::now(),
                 last_activity: Instant::now(),
@@ -3958,6 +4074,8 @@ mod tests {
                 PeerConnection {
                     public_key: None,
                     remote_addr: TransportAddr::Quic(socket_addr),
+                    traversal_method: TraversalMethod::Direct,
+                    side: Side::Client,
                     authenticated: true,
                     connected_at: Instant::now(),
                     last_activity: Instant::now(),
@@ -4007,6 +4125,8 @@ mod tests {
         let mut conn = PeerConnection {
             public_key: None,
             remote_addr: TransportAddr::Quic(socket_addr),
+            traversal_method: TraversalMethod::Direct,
+            side: Side::Client,
             authenticated: false,
             connected_at: Instant::now(),
             last_activity: Instant::now(),

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -92,6 +92,19 @@ const STALE_REAPER_INTERVAL: Duration = Duration::from_secs(10);
 /// through the pinhole needs only 1-2 RTTs (~600ms at 300ms worst-case RTT).
 const POST_HOLEPUNCH_DIRECT_RETRY_TIMEOUT: Duration = Duration::from_secs(1);
 
+/// Per-attempt hole-punch timeout used when rotating through a list of
+/// preferred coordinators. Kept short so a busy or unreachable coordinator
+/// is abandoned quickly and the next one in the list is tried; the *last*
+/// coordinator in the rotation falls back to the strategy's full
+/// hole-punch timeout to give it time to actually complete the punch.
+///
+/// Tuned for the Tier 2 + Tier 4 (lite) coordinator-rotation flow: 1.5s
+/// is comfortably above one round-trip on most internet links but well
+/// below the strategy default (~8s), so the worst-case wait for K
+/// preferred coordinators is roughly `(K-1) * 1.5s + 8s` instead of
+/// `K * 8s`.
+const PER_COORDINATOR_QUICK_HOLEPUNCH_TIMEOUT: Duration = Duration::from_millis(1500);
+
 use crate::SHUTDOWN_DRAIN_TIMEOUT;
 
 /// Extract the raw SPKI (SubjectPublicKeyInfo) bytes from a QUIC connection's
@@ -176,12 +189,17 @@ pub struct P2pEndpoint {
     /// address so concurrent dials don't race on shared state.
     hole_punch_target_peer_ids: Arc<dashmap::DashMap<SocketAddr, [u8; 32]>>,
 
-    /// Per-target preferred coordinator for hole-punch relay. When the DHT
-    /// lookup discovers a peer via a FindNode response from another node, that
-    /// responding node (the "referrer") has a connection to the discovered peer
-    /// and is an ideal coordinator for PUNCH_ME_NOW relay. Keyed by target
-    /// address, value is the referrer's socket address.
-    hole_punch_preferred_coordinators: Arc<dashmap::DashMap<SocketAddr, SocketAddr>>,
+    /// Per-target preferred coordinators for hole-punch relay. When the DHT
+    /// lookup discovers a peer via FindNode responses from one or more peers,
+    /// those responding nodes (the "referrers") all have a connection to the
+    /// discovered peer and are good coordinator candidates. Keyed by target
+    /// address, value is an ordered list of referrer socket addresses ranked
+    /// best-first by the caller (e.g. by DHT lookup round, trust score).
+    /// During hole-punching the list is iterated front to back: the first
+    /// candidates get a short per-attempt timeout so we rotate quickly past
+    /// busy or unreachable coordinators; the last candidate gets the full
+    /// hole-punch timeout to give it time to actually complete the punch.
+    hole_punch_preferred_coordinators: Arc<dashmap::DashMap<SocketAddr, Vec<SocketAddr>>>,
 
     /// Channel sender for data received from QUIC reader tasks and constrained poller
     data_tx: mpsc::Sender<(SocketAddr, Vec<u8>)>,
@@ -1227,16 +1245,44 @@ impl P2pEndpoint {
         self.hole_punch_target_peer_ids.insert(target, peer_id);
     }
 
-    /// Set a preferred coordinator for hole-punching to a specific target.
-    /// The preferred coordinator is a peer that referred us to the target
-    /// during a DHT lookup, so it has a connection to the target.
+    /// Set an ordered list of preferred coordinators for hole-punching to a
+    /// specific target.
+    ///
+    /// The caller (typically saorsa-core's DHT layer) is expected to rank
+    /// the list best-first using its own quality signals — e.g. DHT lookup
+    /// round, trust score, observed latency. During hole-punching the list
+    /// is iterated front to back: the first `coordinators.len() - 1` get a
+    /// short per-attempt timeout so a busy or unreachable coordinator is
+    /// abandoned quickly; the last coordinator gets the full strategy
+    /// hole-punch timeout to give it time to complete the punch.
+    ///
+    /// Empty `coordinators` removes any preferred coordinators for `target`.
+    pub async fn set_hole_punch_preferred_coordinators(
+        &self,
+        target: SocketAddr,
+        coordinators: Vec<SocketAddr>,
+    ) {
+        if coordinators.is_empty() {
+            self.hole_punch_preferred_coordinators.remove(&target);
+        } else {
+            self.hole_punch_preferred_coordinators
+                .insert(target, coordinators);
+        }
+    }
+
+    /// Set a single preferred coordinator for hole-punching to a specific
+    /// target.
+    ///
+    /// Thin wrapper around [`Self::set_hole_punch_preferred_coordinators`]
+    /// retained for callers that have only one coordinator candidate. New
+    /// callers should prefer the list form.
     pub async fn set_hole_punch_preferred_coordinator(
         &self,
         target: SocketAddr,
         coordinator: SocketAddr,
     ) {
-        self.hole_punch_preferred_coordinators
-            .insert(target, coordinator);
+        self.set_hole_punch_preferred_coordinators(target, vec![coordinator])
+            .await;
     }
 
     /// Connect with automatic fallback: Direct → HolePunch → Relay.
@@ -1312,6 +1358,36 @@ impl P2pEndpoint {
         result
     }
 
+    /// Merge a ranked list of preferred hole-punch coordinators into the
+    /// front of `coordinator_candidates`, preserving the relative order of
+    /// `preferred` and removing any pre-existing duplicates from the
+    /// candidate list.
+    ///
+    /// After this call returns, `coordinator_candidates[0..preferred.len()]`
+    /// equals `preferred` (in order). The hole-punch loop uses
+    /// `preferred.len()` directly to decide which attempts get the short
+    /// rotation timeout vs. the strategy's full hole-punch timeout.
+    ///
+    /// Pure function (no `&self`, no I/O) — extracted from
+    /// `connect_with_fallback_inner` so the front-insertion behaviour can
+    /// be unit-tested without spinning up a full endpoint.
+    fn merge_preferred_coordinators(
+        coordinator_candidates: &mut Vec<SocketAddr>,
+        preferred: &[SocketAddr],
+    ) {
+        if preferred.is_empty() {
+            return;
+        }
+        // Drop any pre-existing copies of the preferred entries from the
+        // tail so we don't end up with duplicates after the front-insert.
+        coordinator_candidates.retain(|a| !preferred.contains(a));
+        // Insert in reverse so `preferred[0]` ends up at index 0,
+        // `preferred[1]` at index 1, etc.
+        for preferred_addr in preferred.iter().rev() {
+            coordinator_candidates.insert(0, *preferred_addr);
+        }
+    }
+
     /// Inner implementation of connect_with_fallback (separated for dedup wrapper).
     async fn connect_with_fallback_inner(
         &self,
@@ -1343,17 +1419,32 @@ impl P2pEndpoint {
             }
         }
 
-        // If the DHT referrer set a preferred coordinator for this target,
-        // move it to the front of the candidate list so round 1 uses it.
+        // If the DHT layer set preferred coordinators for this target, move
+        // them to the front of the candidate list in order so the hole-punch
+        // loop tries them first. Each preferred coordinator is removed from
+        // its existing position (if any) before being inserted at the front
+        // so the relative ordering of the preferred list is preserved.
+        //
+        // `preferred_coordinator_count` is captured for the hole-punch loop:
+        // when > 0 the loop rotates through `coordinator_candidates[0..count]`
+        // with `PER_COORDINATOR_QUICK_HOLEPUNCH_TIMEOUT` per non-final attempt,
+        // and the strategy's full timeout for the last attempt. When 0 the
+        // loop falls back to the existing single-coordinator retry behaviour.
+        let mut preferred_coordinator_count: usize = 0;
         if let Some(target_addr) = target {
             if let Some(preferred) = self.hole_punch_preferred_coordinators.get(&target_addr) {
-                let preferred_addr = *preferred;
-                coordinator_candidates.retain(|a| *a != preferred_addr);
-                coordinator_candidates.insert(0, preferred_addr);
-                info!(
-                    "Using preferred coordinator {} for target {} (DHT referrer)",
-                    preferred_addr, target_addr
-                );
+                let preferred_list: Vec<SocketAddr> = preferred.clone();
+                drop(preferred); // Release the DashMap entry guard before mutating coordinator_candidates.
+                Self::merge_preferred_coordinators(&mut coordinator_candidates, &preferred_list);
+                preferred_coordinator_count = preferred_list.len();
+                if preferred_coordinator_count > 0 {
+                    info!(
+                        "Using {} preferred coordinator(s) for target {} (DHT referrers): {:?}",
+                        preferred_list.len(),
+                        target_addr,
+                        preferred_list
+                    );
+                }
             } else {
                 info!(
                     "No preferred coordinator for target {} (not discovered via DHT referral)",
@@ -1437,6 +1528,14 @@ impl P2pEndpoint {
         if let Some(v4) = target_ipv4 {
             direct_addresses.push(v4);
         }
+
+        // Index of the preferred coordinator currently being attempted (when
+        // `preferred_coordinator_count > 0`). The hole-punch loop advances
+        // this on each failed round and uses it together with
+        // `preferred_coordinator_count` to decide whether the *next* attempt
+        // is the final one (full strategy timeout) or an interim rotation
+        // attempt (`PER_COORDINATOR_QUICK_HOLEPUNCH_TIMEOUT`).
+        let mut current_preferred_coordinator_idx: usize = 0;
 
         loop {
             // Check if a previous hole-punch attempt established the connection
@@ -1578,44 +1677,94 @@ impl P2pEndpoint {
                         .or(target_ipv6)
                         .ok_or(EndpointError::NoAddress)?;
 
+                    // Coordinator-rotation policy (Tier 2):
+                    //
+                    // When `preferred_coordinator_count > 0` we have a ranked
+                    // list of DHT-supplied coordinators at
+                    // `coordinator_candidates[0..preferred_coordinator_count]`
+                    // and we rotate through them on each failed round. The
+                    // first `count - 1` attempts use a short timeout
+                    // (`PER_COORDINATOR_QUICK_HOLEPUNCH_TIMEOUT`) so a busy or
+                    // unreachable coordinator is abandoned quickly; the final
+                    // attempt uses the strategy's full hole-punch timeout to
+                    // give it time to actually complete.
+                    //
+                    // When `preferred_coordinator_count == 0` (no DHT
+                    // referrers — first contact, or non-DHT dial) we fall
+                    // back to the legacy single-coordinator behaviour:
+                    // strategy timeout per round, retry the same coordinator
+                    // until `should_retry_holepunch` is exhausted.
+                    let is_rotating = preferred_coordinator_count > 0;
+                    let is_final_rotation_attempt = is_rotating
+                        && current_preferred_coordinator_idx + 1 >= preferred_coordinator_count;
+                    let attempt_timeout = if is_rotating && !is_final_rotation_attempt {
+                        PER_COORDINATOR_QUICK_HOLEPUNCH_TIMEOUT
+                    } else {
+                        strategy.holepunch_timeout()
+                    };
+
                     info!(
-                        "Trying hole-punch to {} via {} (round {})",
-                        target, coordinator, round
+                        "Trying hole-punch to {} via {} (round {}, attempt timeout {:?}, rotating={})",
+                        target, coordinator, round, attempt_timeout, is_rotating
                     );
 
                     // Use our existing NAT traversal infrastructure
-                    match timeout(
-                        strategy.holepunch_timeout(),
-                        self.try_hole_punch(target, coordinator),
-                    )
-                    .await
-                    {
+                    let attempt_result =
+                        timeout(attempt_timeout, self.try_hole_punch(target, coordinator)).await;
+
+                    // Common post-attempt step: try a quick direct connect.
+                    // The NAT binding may have been created by the target's
+                    // outgoing packets even though our try_hole_punch didn't
+                    // detect the connection.
+                    let post_direct = async {
+                        if let Ok(Ok(peer_conn)) =
+                            timeout(POST_HOLEPUNCH_DIRECT_RETRY_TIMEOUT, self.connect(target)).await
+                        {
+                            info!("✓ Post-hole-punch direct connect succeeded to {}", target);
+                            Some(peer_conn)
+                        } else {
+                            None
+                        }
+                    };
+
+                    match attempt_result {
                         Ok(Ok(conn)) => {
                             info!("✓ Hole-punch succeeded to {} via {}", target, coordinator);
                             return Ok((conn, ConnectionMethod::HolePunched { coordinator }));
                         }
                         Ok(Err(e)) => {
-                            // After a failed hole-punch round, try a quick direct
-                            // connect — the NAT binding may have been created by
-                            // the target's outgoing packets even though our
-                            // try_hole_punch didn't detect the connection.
-                            if let Ok(Ok(peer_conn)) =
-                                timeout(POST_HOLEPUNCH_DIRECT_RETRY_TIMEOUT, self.connect(target))
-                                    .await
-                            {
-                                info!("✓ Post-hole-punch direct connect succeeded to {}", target);
+                            if let Some(peer_conn) = post_direct.await {
                                 return Ok((
                                     peer_conn,
                                     ConnectionMethod::HolePunched { coordinator },
                                 ));
                             }
                             strategy.record_holepunch_error(round, e.to_string());
-                            if strategy.should_retry_holepunch() {
-                                // Keep the same coordinator for retries. The preferred
-                                // coordinator (index 0) was chosen because it has a
-                                // known connection to the target. Switching to a random
-                                // fallback wastes another round on a coordinator that
-                                // likely can't relay to the target.
+                            // Bounds-safe rotation: bail out of rotation and
+                            // fall back to relay if for any reason the index
+                            // would go out of bounds (defensive — by
+                            // construction the bound holds while
+                            // `current_preferred_coordinator_idx + 1 < preferred_coordinator_count`).
+                            let next_coord = if is_rotating && !is_final_rotation_attempt {
+                                coordinator_candidates
+                                    .get(current_preferred_coordinator_idx + 1)
+                                    .copied()
+                            } else {
+                                None
+                            };
+                            if let Some(next_coord) = next_coord {
+                                current_preferred_coordinator_idx += 1;
+                                info!(
+                                    "Hole-punch via {} failed ({}), rotating to preferred coordinator {}/{}: {}",
+                                    coordinator,
+                                    e,
+                                    current_preferred_coordinator_idx + 1,
+                                    preferred_coordinator_count,
+                                    next_coord
+                                );
+                                strategy.set_coordinator(next_coord);
+                                strategy.increment_round();
+                            } else if strategy.should_retry_holepunch() {
                                 info!(
                                     "Hole-punch round {} failed, retrying with same coordinator",
                                     round
@@ -1627,19 +1776,33 @@ impl P2pEndpoint {
                             }
                         }
                         Err(_) => {
-                            // Same: try a quick direct connect after timeout
-                            if let Ok(Ok(peer_conn)) =
-                                timeout(POST_HOLEPUNCH_DIRECT_RETRY_TIMEOUT, self.connect(target))
-                                    .await
-                            {
-                                info!("✓ Post-hole-punch direct connect succeeded to {}", target);
+                            if let Some(peer_conn) = post_direct.await {
                                 return Ok((
                                     peer_conn,
                                     ConnectionMethod::HolePunched { coordinator },
                                 ));
                             }
                             strategy.record_holepunch_error(round, "Timeout".to_string());
-                            if strategy.should_retry_holepunch() {
+                            let next_coord = if is_rotating && !is_final_rotation_attempt {
+                                coordinator_candidates
+                                    .get(current_preferred_coordinator_idx + 1)
+                                    .copied()
+                            } else {
+                                None
+                            };
+                            if let Some(next_coord) = next_coord {
+                                current_preferred_coordinator_idx += 1;
+                                info!(
+                                    "Hole-punch via {} timed out after {:?}, rotating to preferred coordinator {}/{}: {}",
+                                    coordinator,
+                                    attempt_timeout,
+                                    current_preferred_coordinator_idx + 1,
+                                    preferred_coordinator_count,
+                                    next_coord
+                                );
+                                strategy.set_coordinator(next_coord);
+                                strategy.increment_round();
+                            } else if strategy.should_retry_holepunch() {
                                 info!(
                                     "Hole-punch round {} timed out, retrying with same coordinator",
                                     round
@@ -3818,5 +3981,87 @@ mod tests {
         // Verify transport address is preserved
         assert_eq!(conn.remote_addr, TransportAddr::Quic(socket_addr));
         assert!(conn.authenticated);
+    }
+
+    // ---- Tier 2: preferred-coordinator front-merge ----
+
+    fn make_addr(octet: u8) -> SocketAddr {
+        SocketAddr::from(([10, 0, 0, octet], 9000))
+    }
+
+    #[test]
+    fn merge_preferred_coordinators_empty_preferred_is_no_op() {
+        let mut candidates = vec![make_addr(1), make_addr(2)];
+        let original = candidates.clone();
+        P2pEndpoint::merge_preferred_coordinators(&mut candidates, &[]);
+        assert_eq!(
+            candidates, original,
+            "empty preferred must not mutate the candidate list"
+        );
+    }
+
+    #[test]
+    fn merge_preferred_coordinators_inserts_at_front_in_order() {
+        let mut candidates = vec![make_addr(10), make_addr(11)];
+        let preferred = vec![make_addr(1), make_addr(2), make_addr(3)];
+        P2pEndpoint::merge_preferred_coordinators(&mut candidates, &preferred);
+
+        assert_eq!(
+            candidates,
+            vec![
+                make_addr(1),
+                make_addr(2),
+                make_addr(3),
+                make_addr(10),
+                make_addr(11),
+            ],
+            "preferred entries must occupy [0..preferred.len()] in order"
+        );
+    }
+
+    #[test]
+    fn merge_preferred_coordinators_dedupes_existing_entries() {
+        // make_addr(2) is BOTH a pre-existing candidate AND in the preferred
+        // list. After the merge it should appear exactly once, at its
+        // preferred-list position (index 1), not at its original tail spot.
+        let mut candidates = vec![make_addr(2), make_addr(10), make_addr(11)];
+        let preferred = vec![make_addr(1), make_addr(2)];
+        P2pEndpoint::merge_preferred_coordinators(&mut candidates, &preferred);
+
+        assert_eq!(
+            candidates,
+            vec![make_addr(1), make_addr(2), make_addr(10), make_addr(11),],
+            "duplicate preferred entries must end up in the preferred slot, not the tail"
+        );
+        // No accidental duplication.
+        assert_eq!(
+            candidates.iter().filter(|a| **a == make_addr(2)).count(),
+            1,
+            "make_addr(2) must appear exactly once after dedup"
+        );
+    }
+
+    #[test]
+    fn merge_preferred_coordinators_only_dedupes_preferred_entries() {
+        // Pre-existing candidates that are NOT in the preferred list must
+        // remain in their original tail order.
+        let mut candidates = vec![make_addr(10), make_addr(11), make_addr(12)];
+        let preferred = vec![make_addr(1)];
+        P2pEndpoint::merge_preferred_coordinators(&mut candidates, &preferred);
+
+        assert_eq!(
+            candidates,
+            vec![make_addr(1), make_addr(10), make_addr(11), make_addr(12),],
+            "non-preferred candidates must keep their original relative order"
+        );
+    }
+
+    #[test]
+    fn merge_preferred_coordinators_works_on_empty_candidate_list() {
+        let mut candidates: Vec<SocketAddr> = Vec::new();
+        let preferred = vec![make_addr(1), make_addr(2)];
+        P2pEndpoint::merge_preferred_coordinators(&mut candidates, &preferred);
+
+        assert_eq!(candidates, vec![make_addr(1), make_addr(2)]);
     }
 }

--- a/src/reachability.rs
+++ b/src/reachability.rs
@@ -172,5 +172,6 @@ mod tests {
         assert!(TraversalMethod::Direct.is_direct());
         assert!(!TraversalMethod::HolePunch.is_direct());
         assert!(!TraversalMethod::Relay.is_direct());
+        assert!(!TraversalMethod::PortPrediction.is_direct());
     }
 }

--- a/src/reachability.rs
+++ b/src/reachability.rs
@@ -1,0 +1,176 @@
+// Copyright 2024 Saorsa Labs Ltd.
+//
+// This Saorsa Network Software is licensed under the General Public License (GPL), version 3.
+// Please see the file LICENSE-GPL, or visit <http://www.gnu.org/licenses/> for the full text.
+//
+// Full details available at https://saorsalabs.com/licenses
+
+//! Reachability and connection path helpers.
+//!
+//! This module separates address classification from actual reachability.
+//! A node may know that an address is globally routable without knowing whether
+//! other peers can reach it directly. Direct reachability is only learned from
+//! successful peer-observed direct connections.
+
+use std::net::{IpAddr, SocketAddr};
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+/// Default freshness window for peer-verified direct reachability.
+///
+/// Direct reachability is inherently time-sensitive, especially for NAT-backed
+/// addresses whose mappings may expire. Evidence older than this should no
+/// longer be treated as current relay/coordinator capability.
+pub const DIRECT_REACHABILITY_TTL: Duration = Duration::from_secs(15 * 60);
+
+/// Scope in which a socket address is directly reachable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum ReachabilityScope {
+    /// Reachable only from the same host.
+    Loopback,
+    /// Reachable on the local network, including RFC1918/ULA/link-local space.
+    LocalNetwork,
+    /// Reachable using a globally routable address.
+    Global,
+}
+
+impl std::fmt::Display for ReachabilityScope {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Loopback => write!(f, "loopback"),
+            Self::LocalNetwork => write!(f, "local-network"),
+            Self::Global => write!(f, "global"),
+        }
+    }
+}
+
+impl ReachabilityScope {
+    /// Returns the broader of two scopes.
+    pub fn broaden(self, other: Self) -> Self {
+        self.max(other)
+    }
+}
+
+/// Method used to establish a connection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TraversalMethod {
+    /// Direct connection, no coordinator or relay involved.
+    Direct,
+    /// Coordinated hole punching.
+    HolePunch,
+    /// Connection established via relay.
+    Relay,
+    /// Port prediction for symmetric NATs.
+    PortPrediction,
+}
+
+impl TraversalMethod {
+    /// Whether this connection path is directly reachable without assistance.
+    pub const fn is_direct(self) -> bool {
+        matches!(self, Self::Direct)
+    }
+}
+
+impl std::fmt::Display for TraversalMethod {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Direct => write!(f, "direct"),
+            Self::HolePunch => write!(f, "hole punch"),
+            Self::Relay => write!(f, "relay"),
+            Self::PortPrediction => write!(f, "port prediction"),
+        }
+    }
+}
+
+/// Classify the reachability scope implied by an address.
+///
+/// Returns `None` for unspecified or multicast addresses, which are not useful
+/// as direct reachability evidence.
+pub fn socket_addr_scope(addr: SocketAddr) -> Option<ReachabilityScope> {
+    match addr.ip() {
+        IpAddr::V4(ipv4) => {
+            if ipv4.is_unspecified() || ipv4.is_multicast() {
+                None
+            } else if ipv4.is_loopback() {
+                Some(ReachabilityScope::Loopback)
+            } else if ipv4.is_private() || ipv4.is_link_local() {
+                Some(ReachabilityScope::LocalNetwork)
+            } else {
+                Some(ReachabilityScope::Global)
+            }
+        }
+        IpAddr::V6(ipv6) => {
+            if ipv6.is_unspecified() || ipv6.is_multicast() {
+                None
+            } else if ipv6.is_loopback() {
+                Some(ReachabilityScope::Loopback)
+            } else if ipv6.is_unique_local() || ipv6.is_unicast_link_local() {
+                Some(ReachabilityScope::LocalNetwork)
+            } else {
+                Some(ReachabilityScope::Global)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    #[test]
+    fn test_socket_addr_scope_ipv4() {
+        assert_eq!(
+            socket_addr_scope(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 9000)),
+            Some(ReachabilityScope::Loopback)
+        );
+        assert_eq!(
+            socket_addr_scope(SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::new(192, 168, 1, 10)),
+                9000
+            )),
+            Some(ReachabilityScope::LocalNetwork)
+        );
+        assert_eq!(
+            socket_addr_scope(SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::new(203, 0, 113, 10)),
+                9000
+            )),
+            Some(ReachabilityScope::Global)
+        );
+        assert_eq!(
+            socket_addr_scope(SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 9000)),
+            None
+        );
+    }
+
+    #[test]
+    fn test_socket_addr_scope_ipv6() {
+        assert_eq!(
+            socket_addr_scope(SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 9000)),
+            Some(ReachabilityScope::Loopback)
+        );
+        assert_eq!(
+            socket_addr_scope(SocketAddr::new(
+                IpAddr::V6("fd00::1".parse::<Ipv6Addr>().expect("valid ULA")),
+                9000,
+            )),
+            Some(ReachabilityScope::LocalNetwork)
+        );
+        assert_eq!(
+            socket_addr_scope(SocketAddr::new(
+                IpAddr::V6("2001:db8::1".parse::<Ipv6Addr>().expect("valid global v6")),
+                9000,
+            )),
+            Some(ReachabilityScope::Global)
+        );
+    }
+
+    #[test]
+    fn test_traversal_method_direct_flag() {
+        assert!(TraversalMethod::Direct.is_direct());
+        assert!(!TraversalMethod::HolePunch.is_direct());
+        assert!(!TraversalMethod::Relay.is_direct());
+    }
+}

--- a/src/relay_slot_table.rs
+++ b/src/relay_slot_table.rs
@@ -1,0 +1,325 @@
+// Copyright 2024 Saorsa Labs Ltd.
+//
+// This Saorsa Network Software is licensed under the General Public License (GPL), version 3.
+// Please see the file LICENSE-GPL, or visit <http://www.gnu.org/licenses/> for the full text.
+//
+// Full details available at https://saorsalabs.com/licenses
+
+//! Node-wide hole-punch coordinator back-pressure (Tier 4 lite).
+//!
+//! Every connection that lands at a node and acts as a hole-punch coordinator
+//! shares one [`RelaySlotTable`]. The table caps the number of in-flight
+//! `(initiator, target)` relay sessions across the entire node, so a storm
+//! of cold-starting peers cannot pile up unbounded coordination work on a
+//! single bootstrap. When the cap is reached, additional `PUNCH_ME_NOW`
+//! relay frames are silently refused — the initiator's per-attempt timeout
+//! drives it to its next preferred coordinator (Tier 2 rotation).
+//!
+//! ## Lifetime model
+//!
+//! A "slot" represents an active coordination *session*: the same
+//! `(initiator_addr, target_peer_id)` pair sending one or more
+//! `PUNCH_ME_NOW` frames over the lifetime of a hole-punch attempt. The
+//! coordinator cannot directly observe whether a punch ultimately succeeded
+//! (the punch traffic flows initiator↔target, bypassing the coordinator),
+//! so slot release happens via three mechanisms:
+//!
+//! 1. **Inactivity timeout** ([`RelaySlotTable::idle_timeout`]). If no new
+//!    rounds for the same key arrive within this window the session is
+//!    considered done — either the punch succeeded (no more rounds needed)
+//!    or it definitively failed (the initiator rotated away). Default 5s.
+//!
+//! 2. **Connection close** via [`RelaySlotTable::release_for_initiator`].
+//!    When the initiator's connection drops, every slot it owned is
+//!    reclaimed immediately rather than waiting for the inactivity timeout.
+//!    Called from `BootstrapCoordinator::Drop`.
+//!
+//! 3. **Explicit re-arm refresh**. A re-sent frame for the same key
+//!    refreshes the timestamp without consuming additional capacity.
+//!
+//! ## Key choice
+//!
+//! Slots are keyed by `(initiator_addr, target_peer_id)` rather than
+//! `(initiator_peer_id, target_peer_id)` because the cryptographic PeerId
+//! is not available inside the QUIC connection state machine where the
+//! `PUNCH_ME_NOW` frame is processed (PQC auth state lives one layer up
+//! in `P2pEndpoint`). The remote socket address is constant across rounds
+//! within a session and unique enough across distinct initiators to give
+//! correct dedup behaviour for the back-pressure cap.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use tracing::{debug, warn};
+
+/// Cryptographic peer identifier — BLAKE3 hash of an ML-DSA-65 public key.
+/// Local alias to keep the table independent of the connection layer.
+pub(crate) type RelayTargetId = [u8; 32];
+
+/// Minimum interval between consecutive amortized sweeps. Sweeping less
+/// often than this on a hot path keeps the per-frame overhead bounded
+/// without letting expired entries pile up.
+const SWEEP_AMORTIZATION_INTERVAL: Duration = Duration::from_millis(100);
+
+/// One refusal warning every this many refusals, so an operator gets a
+/// log line at the start of a storm and periodically thereafter without
+/// flooding logs at line-rate.
+const REFUSAL_WARN_INTERVAL: u64 = 16;
+
+/// Node-wide table of in-flight hole-punch coordinator relay slots.
+///
+/// Cheap to clone via `Arc`. Internal state is guarded by a single
+/// `Mutex`; contention is bounded because each acquire/release holds the
+/// lock for a short critical section (a HashMap lookup plus optional
+/// amortized retain).
+pub struct RelaySlotTable {
+    inner: Mutex<RelaySlotTableInner>,
+    capacity: usize,
+    idle_timeout: Duration,
+    backpressure_refusals: AtomicU64,
+}
+
+struct RelaySlotTableInner {
+    slots: HashMap<(SocketAddr, RelayTargetId), Instant>,
+    last_swept: Instant,
+}
+
+impl RelaySlotTable {
+    /// Create a new shared table with the given capacity and idle timeout.
+    ///
+    /// `capacity` caps the number of distinct simultaneous in-flight
+    /// `(initiator_addr, target_peer_id)` sessions across the node.
+    /// `idle_timeout` is how long a slot lingers after its last refresh
+    /// before being reclaimed by the inline sweep — picks up the slack
+    /// when an initiator stops sending without explicitly releasing
+    /// (e.g. NAT rebind or process crash).
+    pub fn new(capacity: usize, idle_timeout: Duration) -> Self {
+        Self {
+            inner: Mutex::new(RelaySlotTableInner {
+                slots: HashMap::new(),
+                last_swept: Instant::now(),
+            }),
+            capacity,
+            idle_timeout,
+            backpressure_refusals: AtomicU64::new(0),
+        }
+    }
+
+    /// Try to acquire a slot for `(initiator_addr, target_peer_id)`.
+    ///
+    /// Returns `true` if the relay should proceed, `false` if the table
+    /// is at capacity. A re-acquisition for an already-held key always
+    /// succeeds and refreshes the timestamp without consuming additional
+    /// capacity — exactly what multi-round coordination needs.
+    pub(crate) fn try_acquire(
+        &self,
+        initiator_addr: SocketAddr,
+        target_peer_id: RelayTargetId,
+        now: Instant,
+    ) -> bool {
+        let mut inner = match self.inner.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        Self::sweep_if_due(&mut inner, self.idle_timeout, now);
+
+        let key = (initiator_addr, target_peer_id);
+        let already_active = inner.slots.contains_key(&key);
+        if !already_active && inner.slots.len() >= self.capacity {
+            // Drop the lock before logging so the warn! call cannot
+            // back-pressure the lock holder under contention.
+            let active = inner.slots.len();
+            drop(inner);
+            let prior = self.backpressure_refusals.fetch_add(1, Ordering::Relaxed);
+            // Log once at first refusal, then periodically.
+            if prior == 0 || (prior + 1).is_multiple_of(REFUSAL_WARN_INTERVAL) {
+                warn!(
+                    "hole-punch coordinator at capacity: refused relay #{} ({}/{} slots in use, initiator={})",
+                    prior + 1,
+                    active,
+                    self.capacity,
+                    initiator_addr,
+                );
+            } else {
+                debug!(
+                    "hole-punch relay refused (back-pressure): initiator={} target={}",
+                    initiator_addr,
+                    hex::encode(&target_peer_id[..8])
+                );
+            }
+            return false;
+        }
+        inner.slots.insert(key, now);
+        true
+    }
+
+    /// Explicitly release every slot owned by `initiator_addr`. Called
+    /// from `BootstrapCoordinator::Drop` when the initiator's connection
+    /// closes, so the table doesn't have to wait out the idle timeout to
+    /// reclaim capacity for a known-dead session.
+    pub(crate) fn release_for_initiator(&self, initiator_addr: SocketAddr) {
+        let mut inner = match self.inner.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        inner.slots.retain(|(addr, _), _| *addr != initiator_addr);
+    }
+
+    /// Total number of relay frames refused since the table was created.
+    pub fn backpressure_refusals(&self) -> u64 {
+        self.backpressure_refusals.load(Ordering::Relaxed)
+    }
+
+    /// Configured capacity (maximum simultaneous active slots).
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Configured idle-release timeout for inactive slots.
+    pub fn idle_timeout(&self) -> Duration {
+        self.idle_timeout
+    }
+
+    /// Snapshot of the current active slot count. Test/diagnostic only;
+    /// callers must treat the value as advisory because the table may
+    /// change between calls.
+    pub fn active_count(&self) -> usize {
+        match self.inner.lock() {
+            Ok(g) => g.slots.len(),
+            Err(poisoned) => poisoned.into_inner().slots.len(),
+        }
+    }
+
+    /// Amortized sweep: prune slots whose last refresh is older than the
+    /// idle timeout, but only if the previous sweep was at least
+    /// [`SWEEP_AMORTIZATION_INTERVAL`] ago. This bounds the per-frame
+    /// retain cost on hot paths while still draining stale entries
+    /// promptly enough to free capacity ahead of the next storm.
+    fn sweep_if_due(inner: &mut RelaySlotTableInner, idle_timeout: Duration, now: Instant) {
+        if now.duration_since(inner.last_swept) < SWEEP_AMORTIZATION_INTERVAL {
+            return;
+        }
+        inner
+            .slots
+            .retain(|_, arrived_at| now.duration_since(*arrived_at) < idle_timeout);
+        inner.last_swept = now;
+    }
+}
+
+impl std::fmt::Debug for RelaySlotTable {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt.debug_struct("RelaySlotTable")
+            .field("capacity", &self.capacity)
+            .field("idle_timeout", &self.idle_timeout)
+            .field(
+                "backpressure_refusals",
+                &self.backpressure_refusals.load(Ordering::Relaxed),
+            )
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn target(byte: u8) -> RelayTargetId {
+        let mut id = [0u8; 32];
+        id[0] = byte;
+        id
+    }
+
+    fn addr(port: u16) -> SocketAddr {
+        SocketAddr::from(([127, 0, 0, 1], port))
+    }
+
+    #[test]
+    fn under_capacity_acquires() {
+        let table = RelaySlotTable::new(4, Duration::from_secs(5));
+        let now = Instant::now();
+        assert!(table.try_acquire(addr(5000), target(0x01), now));
+        assert_eq!(table.active_count(), 1);
+        assert_eq!(table.backpressure_refusals(), 0);
+    }
+
+    #[test]
+    fn at_capacity_refuses_silently() {
+        let table = RelaySlotTable::new(2, Duration::from_secs(5));
+        let now = Instant::now();
+        assert!(table.try_acquire(addr(5000), target(0x01), now));
+        assert!(table.try_acquire(addr(5001), target(0x02), now));
+        assert!(!table.try_acquire(addr(5002), target(0x03), now));
+        assert_eq!(table.active_count(), 2);
+        assert_eq!(table.backpressure_refusals(), 1);
+    }
+
+    #[test]
+    fn re_arm_refreshes_without_consuming_capacity() {
+        let table = RelaySlotTable::new(2, Duration::from_secs(5));
+        let now = Instant::now();
+        assert!(table.try_acquire(addr(5000), target(0x01), now));
+        let later = now + Duration::from_millis(500);
+        assert!(table.try_acquire(addr(5000), target(0x01), later));
+        assert_eq!(
+            table.active_count(),
+            1,
+            "re-arm must not allocate a second slot"
+        );
+    }
+
+    #[test]
+    fn idle_sweep_reclaims_stale_slots() {
+        let timeout = Duration::from_secs(5);
+        let table = RelaySlotTable::new(2, timeout);
+        let now = Instant::now();
+        assert!(table.try_acquire(addr(5000), target(0x01), now));
+        assert!(table.try_acquire(addr(5001), target(0x02), now));
+        // Past idle timeout AND past sweep amortization interval.
+        let much_later = now + timeout + Duration::from_secs(1);
+        assert!(table.try_acquire(addr(5002), target(0x03), much_later));
+        assert_eq!(
+            table.active_count(),
+            1,
+            "stale slots reclaimed by inline sweep before the cap check"
+        );
+        assert_eq!(table.backpressure_refusals(), 0);
+    }
+
+    #[test]
+    fn release_for_initiator_drops_owned_slots_only() {
+        let table = RelaySlotTable::new(8, Duration::from_secs(5));
+        let now = Instant::now();
+        // Two distinct sessions for initiator A.
+        assert!(table.try_acquire(addr(5000), target(0x01), now));
+        assert!(table.try_acquire(addr(5000), target(0x02), now));
+        // One session for a different initiator B.
+        assert!(table.try_acquire(addr(5999), target(0x03), now));
+        assert_eq!(table.active_count(), 3);
+
+        table.release_for_initiator(addr(5000));
+        assert_eq!(
+            table.active_count(),
+            1,
+            "release must drop slots for the named initiator only"
+        );
+        // The B slot is still there.
+        let later = now + Duration::from_millis(50);
+        assert!(table.try_acquire(addr(5999), target(0x03), later));
+        assert_eq!(table.active_count(), 1);
+    }
+
+    #[test]
+    fn refusal_count_accumulates_across_distinct_targets() {
+        let table = RelaySlotTable::new(1, Duration::from_secs(5));
+        let now = Instant::now();
+        assert!(table.try_acquire(addr(5000), target(0x01), now));
+        // Three distinct refusals at the same instant — sweep won't fire.
+        assert!(!table.try_acquire(addr(5001), target(0x02), now));
+        assert!(!table.try_acquire(addr(5002), target(0x03), now));
+        assert!(!table.try_acquire(addr(5003), target(0x04), now));
+        assert_eq!(table.backpressure_refusals(), 3);
+    }
+}

--- a/src/relay_slot_table.rs
+++ b/src/relay_slot_table.rs
@@ -8,7 +8,7 @@
 //! Node-wide hole-punch coordinator back-pressure (Tier 4 lite).
 //!
 //! Every connection that lands at a node and acts as a hole-punch coordinator
-//! shares one [`RelaySlotTable`]. The table caps the number of in-flight
+//! shares one [`RelaySlotTable`](crate::relay_slot_table::RelaySlotTable). The table caps the number of in-flight
 //! `(initiator, target)` relay sessions across the entire node, so a storm
 //! of cold-starting peers cannot pile up unbounded coordination work on a
 //! single bootstrap. When the cap is reached, additional `PUNCH_ME_NOW`
@@ -24,12 +24,12 @@
 //! (the punch traffic flows initiator↔target, bypassing the coordinator),
 //! so slot release happens via three mechanisms:
 //!
-//! 1. **Inactivity timeout** ([`RelaySlotTable::idle_timeout`]). If no new
+//! 1. **Inactivity timeout** ([`RelaySlotTable::idle_timeout`](crate::relay_slot_table::RelaySlotTable::idle_timeout)). If no new
 //!    rounds for the same key arrive within this window the session is
 //!    considered done — either the punch succeeded (no more rounds needed)
 //!    or it definitively failed (the initiator rotated away). Default 5s.
 //!
-//! 2. **Connection close** via [`RelaySlotTable::release_for_initiator`].
+//! 2. **Connection close** via `RelaySlotTable::release_for_initiator`.
 //!    When the initiator's connection drops, every slot it owned is
 //!    reclaimed immediately rather than waiting for the inactivity timeout.
 //!    Called from `BootstrapCoordinator::Drop`.

--- a/src/unified_config.rs
+++ b/src/unified_config.rs
@@ -145,6 +145,29 @@ pub struct NatConfig {
     /// Default: `false`
     pub allow_loopback: bool,
 
+    /// Cap on simultaneous in-flight hole-punch coordinator sessions
+    /// **across the entire node** (Tier 4 lite back-pressure). When the
+    /// shared `RelaySlotTable` is at capacity, additional `PUNCH_ME_NOW`
+    /// relay frames are silently refused so the initiator's per-attempt
+    /// timeout (Tier 2 rotation) can advance to its next preferred
+    /// coordinator. See
+    /// [`crate::nat_traversal_api::NatTraversalConfig::coordinator_max_active_relays`]
+    /// for the full rationale.
+    ///
+    /// Default: 32.
+    pub coordinator_max_active_relays: usize,
+
+    /// Idle-release timeout for an in-flight coordinator relay session.
+    /// A slot lasts from the first `PUNCH_ME_NOW` until either the
+    /// owning connection closes (immediate release) or this many
+    /// seconds with no further rounds for the same
+    /// `(initiator_addr, target_peer_id)` pair. See
+    /// [`crate::nat_traversal_api::NatTraversalConfig::coordinator_relay_slot_idle_timeout`]
+    /// for the full rationale.
+    ///
+    /// Default: 5 seconds.
+    pub coordinator_relay_slot_idle_timeout: Duration,
+
     /// Best-effort UPnP IGD port mapping configuration. When enabled
     /// (default), the endpoint asks the local router to forward its UDP
     /// port and surfaces the resulting public address as a high-priority
@@ -163,6 +186,10 @@ impl Default for NatConfig {
             max_concurrent_attempts: 3,
             prefer_rfc_nat_traversal: true,
             allow_loopback: false,
+            coordinator_max_active_relays:
+                crate::nat_traversal_api::NatTraversalConfig::DEFAULT_COORDINATOR_MAX_ACTIVE_RELAYS,
+            coordinator_relay_slot_idle_timeout:
+                crate::nat_traversal_api::NatTraversalConfig::DEFAULT_COORDINATOR_RELAY_SLOT_IDLE_TIMEOUT,
             upnp: crate::upnp::UpnpConfig::default(),
         }
     }
@@ -317,10 +344,8 @@ impl P2pConfig {
             transport_registry: Some(Arc::new(self.transport_registry.clone())),
             max_message_size: self.max_message_size,
             allow_loopback: self.nat.allow_loopback,
-            coordinator_max_active_relays:
-                crate::nat_traversal_api::NatTraversalConfig::DEFAULT_COORDINATOR_MAX_ACTIVE_RELAYS,
-            coordinator_relay_slot_timeout:
-                crate::nat_traversal_api::NatTraversalConfig::DEFAULT_COORDINATOR_RELAY_SLOT_TIMEOUT,
+            coordinator_max_active_relays: self.nat.coordinator_max_active_relays,
+            coordinator_relay_slot_idle_timeout: self.nat.coordinator_relay_slot_idle_timeout,
             upnp: self.nat.upnp.clone(),
         }
     }

--- a/src/unified_config.rs
+++ b/src/unified_config.rs
@@ -317,6 +317,10 @@ impl P2pConfig {
             transport_registry: Some(Arc::new(self.transport_registry.clone())),
             max_message_size: self.max_message_size,
             allow_loopback: self.nat.allow_loopback,
+            coordinator_max_active_relays:
+                crate::nat_traversal_api::NatTraversalConfig::DEFAULT_COORDINATOR_MAX_ACTIVE_RELAYS,
+            coordinator_relay_slot_timeout:
+                crate::nat_traversal_api::NatTraversalConfig::DEFAULT_COORDINATOR_RELAY_SLOT_TIMEOUT,
             upnp: self.nat.upnp.clone(),
         }
     }

--- a/src/upnp.rs
+++ b/src/upnp.rs
@@ -24,7 +24,7 @@
 //!
 //! Concretely this means:
 //!
-//! 1. [`UpnpMappingService::start`] never returns an error and never blocks
+//! 1. [`UpnpMappingService::start`](crate::upnp::UpnpMappingService::start) never returns an error and never blocks
 //!    on network I/O — it spawns a background task and returns immediately.
 //! 2. All failures are swallowed and logged at `debug` level. The only
 //!    `info` log line is the success path.
@@ -34,7 +34,7 @@
 //! 4. The lease is finite (one hour by default), so a crashed process
 //!    cannot leak a permanent mapping on the gateway.
 //!
-//! Callers consume the service by polling [`UpnpMappingService::current`]
+//! Callers consume the service by polling [`UpnpMappingService::current`](crate::upnp::UpnpMappingService::current)
 //! when they want the most recent state. The poll is a lock-free atomic
 //! load on the underlying `tokio::sync::watch` channel, so it is cheap to
 //! call from the candidate discovery hot path.

--- a/tests/connection_lifecycle_tests.rs
+++ b/tests/connection_lifecycle_tests.rs
@@ -283,15 +283,16 @@ mod connection_lifecycle {
 
     /// Test NAT statistics
     #[tokio::test]
-    async fn test_nat_statistics() {
+    async fn test_endpoint_stats() {
         let config = test_node_config(vec![]);
         let node = P2pEndpoint::new(config)
             .await
             .expect("Failed to create node");
 
-        // Get NAT stats - synchronous call
-        let _nat_stats = node.nat_stats();
-        println!("NAT stats received");
+        // Get endpoint stats
+        let stats = node.stats().await;
+        assert_eq!(stats.active_connections, 0);
+        println!("Endpoint stats received");
 
         shutdown_with_timeout(node).await;
     }

--- a/tests/constrained_integration.rs
+++ b/tests/constrained_integration.rs
@@ -753,6 +753,8 @@ fn test_peer_connection_transport_addr() {
     let peer_conn_udp = PeerConnection {
         public_key: Some(vec![0x11; 32]),
         remote_addr: udp_addr.clone(),
+        traversal_method: saorsa_transport::TraversalMethod::Direct,
+        side: saorsa_transport::Side::Client,
         authenticated: true,
         connected_at: Instant::now(),
         last_activity: Instant::now(),
@@ -771,6 +773,8 @@ fn test_peer_connection_transport_addr() {
     let peer_conn_ble = PeerConnection {
         public_key: None,
         remote_addr: ble_addr.clone(),
+        traversal_method: saorsa_transport::TraversalMethod::Direct,
+        side: saorsa_transport::Side::Client,
         authenticated: false,
         connected_at: Instant::now(),
         last_activity: Instant::now(),

--- a/tests/event_migration.rs
+++ b/tests/event_migration.rs
@@ -76,6 +76,7 @@ fn test_peer_connected_event_construction_udp() {
         addr: TransportAddr::Udp(socket_addr),
         public_key: Some(test_public_key.clone()),
         side: saorsa_transport::Side::Client,
+        traversal_method: saorsa_transport::TraversalMethod::Direct,
     };
 
     // Verify we can destructure it correctly
@@ -83,6 +84,7 @@ fn test_peer_connected_event_construction_udp() {
         addr,
         public_key,
         side,
+        ..
     } = event
     {
         assert_eq!(public_key.unwrap(), test_public_key);
@@ -128,6 +130,7 @@ fn test_event_clone_for_broadcast() {
         addr: TransportAddr::Udp(socket_addr),
         public_key: Some(vec![0xaa; 32]),
         side: saorsa_transport::Side::Server,
+        traversal_method: saorsa_transport::TraversalMethod::Direct,
     };
 
     // Clone is required for broadcast channel
@@ -140,11 +143,13 @@ fn test_event_clone_for_broadcast() {
                 addr: a1,
                 public_key: pk1,
                 side: s1,
+                ..
             },
             P2pEvent::PeerConnected {
                 addr: a2,
                 public_key: pk2,
                 side: s2,
+                ..
             },
         ) => {
             assert_eq!(pk1, pk2);
@@ -166,6 +171,7 @@ fn test_multi_transport_events() {
         addr: TransportAddr::Udp(udp_addr),
         public_key: Some(vec![0x01; 32]),
         side: saorsa_transport::Side::Client,
+        traversal_method: saorsa_transport::TraversalMethod::Direct,
     };
 
     // BLE event
@@ -176,6 +182,7 @@ fn test_multi_transport_events() {
         },
         public_key: Some(vec![0x02; 32]),
         side: saorsa_transport::Side::Server,
+        traversal_method: saorsa_transport::TraversalMethod::Direct,
     };
 
     // Verify we can distinguish between them
@@ -202,6 +209,7 @@ fn test_transport_aware_event_handling() {
             addr: TransportAddr::Udp("10.0.0.1:8080".parse().expect("valid")),
             public_key: Some(vec![0x01; 32]),
             side: saorsa_transport::Side::Client,
+            traversal_method: saorsa_transport::TraversalMethod::Direct,
         },
         P2pEvent::PeerConnected {
             addr: TransportAddr::Ble {
@@ -210,6 +218,7 @@ fn test_transport_aware_event_handling() {
             },
             public_key: Some(vec![0x02; 32]),
             side: saorsa_transport::Side::Server,
+            traversal_method: saorsa_transport::TraversalMethod::Direct,
         },
         P2pEvent::ExternalAddressDiscovered {
             addr: TransportAddr::Udp("203.0.113.1:9000".parse().expect("valid")),
@@ -248,6 +257,7 @@ fn test_backward_compatibility_with_as_socket_addr() {
         addr: TransportAddr::Udp(socket_addr),
         public_key: Some(vec![0xff; 32]),
         side: saorsa_transport::Side::Client,
+        traversal_method: saorsa_transport::TraversalMethod::Direct,
     };
 
     // Simulate legacy code that expects SocketAddr
@@ -291,6 +301,7 @@ fn test_event_debug_formatting() {
         addr: TransportAddr::Udp("192.168.0.100:9001".parse().expect("valid")),
         public_key: Some(vec![0x55; 32]),
         side: saorsa_transport::Side::Client,
+        traversal_method: saorsa_transport::TraversalMethod::Direct,
     };
 
     let debug = format!("{:?}", event);

--- a/tests/relay_queue_tests.rs
+++ b/tests/relay_queue_tests.rs
@@ -56,7 +56,7 @@ mod nat_traversal_api_tests {
             max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
             allow_loopback: false,
             coordinator_max_active_relays: 32,
-            coordinator_relay_slot_timeout: Duration::from_secs(5),
+            coordinator_relay_slot_idle_timeout: Duration::from_secs(5),
             upnp: Default::default(),
         };
 
@@ -195,7 +195,7 @@ mod functional_tests {
             max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
             allow_loopback: false,
             coordinator_max_active_relays: 32,
-            coordinator_relay_slot_timeout: Duration::from_secs(5),
+            coordinator_relay_slot_idle_timeout: Duration::from_secs(5),
             upnp: Default::default(),
         };
 
@@ -224,7 +224,7 @@ mod functional_tests {
             max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
             allow_loopback: false,
             coordinator_max_active_relays: 32,
-            coordinator_relay_slot_timeout: Duration::from_secs(5),
+            coordinator_relay_slot_idle_timeout: Duration::from_secs(5),
             upnp: Default::default(),
         };
 
@@ -419,7 +419,7 @@ mod performance_tests {
                 max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
                 allow_loopback: false,
                 coordinator_max_active_relays: 32,
-                coordinator_relay_slot_timeout: Duration::from_secs(5),
+                coordinator_relay_slot_idle_timeout: Duration::from_secs(5),
                 upnp: Default::default(),
             };
 
@@ -492,7 +492,7 @@ mod relay_functionality_tests {
             max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
             allow_loopback: false,
             coordinator_max_active_relays: 32,
-            coordinator_relay_slot_timeout: Duration::from_secs(5),
+            coordinator_relay_slot_idle_timeout: Duration::from_secs(5),
             upnp: Default::default(),
         };
 

--- a/tests/relay_queue_tests.rs
+++ b/tests/relay_queue_tests.rs
@@ -55,6 +55,8 @@ mod nat_traversal_api_tests {
             transport_registry: None,
             max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
             allow_loopback: false,
+            coordinator_max_active_relays: 32,
+            coordinator_relay_slot_timeout: Duration::from_secs(5),
             upnp: Default::default(),
         };
 
@@ -192,6 +194,8 @@ mod functional_tests {
             transport_registry: None,
             max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
             allow_loopback: false,
+            coordinator_max_active_relays: 32,
+            coordinator_relay_slot_timeout: Duration::from_secs(5),
             upnp: Default::default(),
         };
 
@@ -219,6 +223,8 @@ mod functional_tests {
             transport_registry: None,
             max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
             allow_loopback: false,
+            coordinator_max_active_relays: 32,
+            coordinator_relay_slot_timeout: Duration::from_secs(5),
             upnp: Default::default(),
         };
 
@@ -412,6 +418,8 @@ mod performance_tests {
                 transport_registry: None,
                 max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
                 allow_loopback: false,
+                coordinator_max_active_relays: 32,
+                coordinator_relay_slot_timeout: Duration::from_secs(5),
                 upnp: Default::default(),
             };
 
@@ -483,6 +491,8 @@ mod relay_functionality_tests {
             transport_registry: None,
             max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
             allow_loopback: false,
+            coordinator_max_active_relays: 32,
+            coordinator_relay_slot_timeout: Duration::from_secs(5),
             upnp: Default::default(),
         };
 

--- a/tests/security_regression_tests.rs
+++ b/tests/security_regression_tests.rs
@@ -38,7 +38,7 @@ fn test_peer_config() -> NatTraversalConfig {
         max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
         allow_loopback: true,
         coordinator_max_active_relays: 32,
-        coordinator_relay_slot_timeout: Duration::from_secs(5),
+        coordinator_relay_slot_idle_timeout: Duration::from_secs(5),
         upnp: Default::default(),
     }
 }
@@ -65,7 +65,7 @@ fn test_server_config() -> NatTraversalConfig {
         max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
         allow_loopback: true,
         coordinator_max_active_relays: 32,
-        coordinator_relay_slot_timeout: Duration::from_secs(5),
+        coordinator_relay_slot_idle_timeout: Duration::from_secs(5),
         upnp: Default::default(),
     }
 }
@@ -115,7 +115,7 @@ async fn test_error_handling_no_panic() {
         max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
         allow_loopback: true,
         coordinator_max_active_relays: 32,
-        coordinator_relay_slot_timeout: Duration::from_secs(5),
+        coordinator_relay_slot_idle_timeout: Duration::from_secs(5),
         upnp: Default::default(),
     };
 
@@ -146,7 +146,7 @@ async fn test_error_handling_no_panic() {
         max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
         allow_loopback: true,
         coordinator_max_active_relays: 32,
-        coordinator_relay_slot_timeout: Duration::from_secs(5),
+        coordinator_relay_slot_idle_timeout: Duration::from_secs(5),
         upnp: Default::default(),
     };
 
@@ -240,7 +240,7 @@ async fn test_malformed_config_handling() {
         max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
         allow_loopback: true,
         coordinator_max_active_relays: 32,
-        coordinator_relay_slot_timeout: Duration::from_secs(5),
+        coordinator_relay_slot_idle_timeout: Duration::from_secs(5),
         upnp: Default::default(),
     };
 
@@ -272,7 +272,7 @@ async fn test_malformed_config_handling() {
         max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
         allow_loopback: true,
         coordinator_max_active_relays: 32,
-        coordinator_relay_slot_timeout: Duration::from_secs(5),
+        coordinator_relay_slot_idle_timeout: Duration::from_secs(5),
         upnp: Default::default(),
     };
 
@@ -311,7 +311,7 @@ async fn test_input_sanitization() {
         max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
         allow_loopback: true,
         coordinator_max_active_relays: 32,
-        coordinator_relay_slot_timeout: Duration::from_secs(5),
+        coordinator_relay_slot_idle_timeout: Duration::from_secs(5),
         upnp: Default::default(),
     };
 
@@ -385,7 +385,7 @@ mod specific_regression_tests {
             max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
             allow_loopback: true,
             coordinator_max_active_relays: 32,
-            coordinator_relay_slot_timeout: Duration::from_secs(5),
+            coordinator_relay_slot_idle_timeout: Duration::from_secs(5),
             upnp: Default::default(),
         };
 
@@ -439,7 +439,7 @@ mod specific_regression_tests {
             max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
             allow_loopback: true,
             coordinator_max_active_relays: 32,
-            coordinator_relay_slot_timeout: Duration::from_secs(5),
+            coordinator_relay_slot_idle_timeout: Duration::from_secs(5),
             upnp: Default::default(),
         };
 

--- a/tests/security_regression_tests.rs
+++ b/tests/security_regression_tests.rs
@@ -37,6 +37,8 @@ fn test_peer_config() -> NatTraversalConfig {
         transport_registry: None,
         max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
         allow_loopback: true,
+        coordinator_max_active_relays: 32,
+        coordinator_relay_slot_timeout: Duration::from_secs(5),
         upnp: Default::default(),
     }
 }
@@ -62,6 +64,8 @@ fn test_server_config() -> NatTraversalConfig {
         transport_registry: None,
         max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
         allow_loopback: true,
+        coordinator_max_active_relays: 32,
+        coordinator_relay_slot_timeout: Duration::from_secs(5),
         upnp: Default::default(),
     }
 }
@@ -110,6 +114,8 @@ async fn test_error_handling_no_panic() {
         transport_registry: None,
         max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
         allow_loopback: true,
+        coordinator_max_active_relays: 32,
+        coordinator_relay_slot_timeout: Duration::from_secs(5),
         upnp: Default::default(),
     };
 
@@ -139,6 +145,8 @@ async fn test_error_handling_no_panic() {
         transport_registry: None,
         max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
         allow_loopback: true,
+        coordinator_max_active_relays: 32,
+        coordinator_relay_slot_timeout: Duration::from_secs(5),
         upnp: Default::default(),
     };
 
@@ -231,6 +239,8 @@ async fn test_malformed_config_handling() {
         transport_registry: None,
         max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
         allow_loopback: true,
+        coordinator_max_active_relays: 32,
+        coordinator_relay_slot_timeout: Duration::from_secs(5),
         upnp: Default::default(),
     };
 
@@ -261,6 +271,8 @@ async fn test_malformed_config_handling() {
         transport_registry: None,
         max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
         allow_loopback: true,
+        coordinator_max_active_relays: 32,
+        coordinator_relay_slot_timeout: Duration::from_secs(5),
         upnp: Default::default(),
     };
 
@@ -298,6 +310,8 @@ async fn test_input_sanitization() {
         transport_registry: None,
         max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
         allow_loopback: true,
+        coordinator_max_active_relays: 32,
+        coordinator_relay_slot_timeout: Duration::from_secs(5),
         upnp: Default::default(),
     };
 
@@ -370,6 +384,8 @@ mod specific_regression_tests {
             transport_registry: None,
             max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
             allow_loopback: true,
+            coordinator_max_active_relays: 32,
+            coordinator_relay_slot_timeout: Duration::from_secs(5),
             upnp: Default::default(),
         };
 
@@ -422,6 +438,8 @@ mod specific_regression_tests {
             transport_registry: None,
             max_message_size: saorsa_transport::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE,
             allow_loopback: true,
+            coordinator_max_active_relays: 32,
+            coordinator_relay_slot_timeout: Duration::from_secs(5),
             upnp: Default::default(),
         };
 


### PR DESCRIPTION
## Summary

- **Bumps `PER_COORDINATOR_QUICK_HOLEPUNCH_TIMEOUT` from 1.5 s → 4 s** so coordinator rotation no longer fires while the previous round's relayed PUNCH_ME_NOW return is still in flight on cross-region links.
- **Removes the per-rotation `post_direct` probe** that was opening a parallel A→B QUIC dial every round, racing the relayed B→A return and producing the "duplicate connection" close storm under symmetric NAT. Replaces it with a single `try_post_rotation_direct` attempt at the end of the rotation chain.
- **Adds peer-identity dedup at `P2pEndpoint::accept`** via a new `find_live_connection_by_public_key` helper. When a new connection's TLS public key matches an existing live entry, the new one is closed silently with `b"duplicate-peer-id"` and never registered. Symmetric-NAT rebinds (where each return arrives on a fresh source port) now collapse to one authoritative connection regardless of the `SocketAddr`.

## Why

Testnet logs from the symmetric-NAT validation showed identity exchange consistently timing out at exactly 15 s. Tracing it back, the failure mode was:

1. saorsa-core's DHT layer fired multiple parallel `dial_addresses` calls per peer (lookup batches, bootstrap, self-lookup all overlapping).
2. Each call entered this rotation loop and issued a `PUNCH_ME_NOW` via the next coordinator.
3. The 1.5 s per-rotation timeout was below one full PUNCH_ME_NOW round trip on cross-region links, so rotation routinely fired while the previous round's relayed return was still in flight.
4. The per-round `post_direct` probe opened a separate A→B dial alongside the still-in-flight B→A return.
5. Under symmetric NAT each return arrived on a different source port, so the existing `SocketAddr`-keyed dedup in `spawn_accept_loop` could not collapse them. Several connections accumulated for the same logical peer.
6. The first to be promoted "won"; the losers were closed as `b"duplicate"`. Whichever close happened to be the one saorsa-core's lifecycle monitor was tracking killed the identity exchange — and the next 15 s timeout was the wait for an announce that would never arrive.

The companion saorsa-core change (PR-pending) eliminates the announce protocol entirely by deriving peer identity from the TLS handshake. This PR is the saorsa-transport half: stop producing the duplicate connections in the first place.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --lib` — all 1489 unit tests pass
- [x] `cargo test --tests` — all targeted integration tests pass; the 2 pre-existing `nat_traversal_race_condition_tests` failures (`test_full_roundtrip_connection_check`, `test_concurrent_initiate_nat_traversal_same_peer`) reproduce on `rc-2026.4.1` and are unrelated to this PR.
- [ ] Symmetric/open NAT testnet rerun: confirm the per-15-second identity-exchange-failure log line is gone.
- [ ] Confirm that the `accept: duplicate connection from already-connected peer` log line appears at most once per logical peer pair under sustained dial pressure (proves the new dedup is collapsing rebinds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses a testnet-observed failure where identity exchanges timed out at 15s under symmetric NAT. The fix has three coordinated parts: (1) bumping `PER_COORDINATOR_QUICK_HOLEPUNCH_TIMEOUT` from 1.5 s → 4 s so coordinator rotation no longer fires while the previous round's relayed return is still in-flight; (2) removing the per-rotation `post_direct` probe that was racing the B→A return and producing a duplicate-connection storm; and (3) adding TLS-public-key–based dedup at `P2pEndpoint::accept` so symmetric-NAT rebinds that still produce multiple connections are silently collapsed. A new `RelaySlotTable` module adds node-wide back-pressure (Tier 4 lite) for coordinator relay sessions.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all remaining findings are P2 (documentation inconsistency and defensive comments); no runtime correctness issues introduced.

The three-part fix (timeout bump, per-rotation probe removal, TLS-key dedup) directly and correctly addresses the root cause traced in the PR description. The new RelaySlotTable is well-tested in isolation and correctly integrated. The only open items are a stale "1.5s" figure in one doc comment and two places that would benefit from clarifying comments about single-task accept and NAT-rebind slot accounting — none of these affect runtime behaviour.

src/p2p_endpoint.rs — doc comment inconsistency (1.5s vs 4s) and the TOCTOU note; both are P2 only.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/p2p_endpoint.rs | Core of the PR: removes per-rotation post_direct probe, adds coordinator-rotation with per-attempt timeouts, introduces find_live_connection_by_public_key dedup at accept. Doc comment in set_hole_punch_preferred_coordinators cites "1.5s" which now contradicts the 4s constant. |
| src/relay_slot_table.rs | New module implementing node-wide back-pressure for coordinator relay sessions. Amortized sweep, re-arm refresh, and release-for-initiator are all correct; comprehensive unit tests cover the key invariants. |
| src/connection/nat_traversal.rs | Integrates RelaySlotTable into BootstrapCoordinator; adds TTL and completed-entry cleanup; max_coordination_per_window raised from 50→300 to match new back-pressure design. relay_initiator_addr tracks first relay source addr for Drop-based cleanup. |
| src/reachability.rs | New module extracting TraversalMethod (moved from node_event.rs) and ReachabilityScope with socket_addr_scope classifier. Clean, well-tested. |
| src/connection/mod.rs | Passes relay_slot_table through to NatTraversalState; replaces unsafe unwrap on nat_traversal with if-let early return. Safe and straightforward. |
| src/nat_traversal_api.rs | Adds traversal_method to ConnectionEstablished event, propagates relay_slot_table to both server/client TransportConfig, fixes bounds-unsafe relay_candidates[0] access. |
| src/node.rs | Replaces inaccurate has_public_ip heuristic with peer-verified reachability model using EndpointStats timestamps and active_direct_incoming_connections. Cleaner and more correct. |
| src/node_status.rs | Replaces has_public_ip (address-only) with has_global_address + direct_reachability_scope (reachability-evidence). doc and test updates align. can_help_traversal now only returns true on verified reachability. |
| src/link_transport_impl.rs | Promotes relay/coordinator capability only on verified direct outbound connections; resets those caps on disconnect. |
| src/config/transport.rs | Adds optional relay_slot_table field to TransportConfig and corresponding setter. Defaults to None so low-level fixtures are unaffected. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant A as Node A (dialer)
    participant C as Coordinator
    participant B as Node B (target)
    participant Accept as A.accept()

    Note over A,B: Before this PR — per-rotation post_direct race
    A->>C: PUNCH_ME_NOW (round 1, port X)
    C->>B: relay frame
    A->>B: post_direct dial (parallel, races B→A return)
    B-->>A: return on port Y (new src port under sym NAT)
    A-->>A: both land in connected_peers → duplicate storm

    Note over A,B: After this PR — single post-rotation probe + TLS dedup
    A->>C: PUNCH_ME_NOW (round 1, via coord 1, timeout=4s)
    C->>B: relay
    B-->>Accept: return on port Y₁
    Accept->>Accept: find_live_connection_by_public_key → miss (first connection)
    Accept-->>A: registered ✓

    A->>C: PUNCH_ME_NOW (round 2, via coord 2, timeout=4s)
    C->>B: relay
    B-->>Accept: return on port Y₂ (sym NAT rebind)
    Accept->>Accept: find_live_connection_by_public_key → HIT (same TLS key)
    Accept-->>Accept: close(b"duplicate-peer-id") — not registered

    Note over A: rotation exhausted
    A->>B: try_post_rotation_direct (once, 1s timeout)
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/p2p_endpoint.rs`, line 1729-1732 ([link](https://github.com/saorsa-labs/saorsa-transport/blob/b36957c830d617c8ce9851235e2cc0c2fc9c6f76/src/p2p_endpoint.rs#L1729-L1732)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Stale "1.5s" figure in doc comment**

   The formula `(K-1) * 1.5s + 8s` was written before this PR bumped `PER_COORDINATOR_QUICK_HOLEPUNCH_TIMEOUT` to 4 s. The constant's own block correctly states the new value; the doc here should match.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/p2p_endpoint.rs
   Line: 1729-1732

   Comment:
   **Stale "1.5s" figure in doc comment**

   The formula `(K-1) * 1.5s + 8s` was written before this PR bumped `PER_COORDINATOR_QUICK_HOLEPUNCH_TIMEOUT` to 4 s. The constant's own block correctly states the new value; the doc here should match.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/p2p_endpoint.rs
Line: 1729-1732

Comment:
**Stale "1.5s" figure in doc comment**

The formula `(K-1) * 1.5s + 8s` was written before this PR bumped `PER_COORDINATOR_QUICK_HOLEPUNCH_TIMEOUT` to 4 s. The constant's own block correctly states the new value; the doc here should match.

```suggestion
    /// attempt — the rotation fully replaces the legacy retry loop and the
    /// worst-case dial time is `(K-1) * 4s + holepunch_timeout`.
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/p2p_endpoint.rs
Line: 2466-2476

Comment:
**TOCTOU window between dedup check and `connected_peers` insertion**

`find_live_connection_by_public_key` reads `connected_peers` under a shared lock, then releases it before `connected_peers.write().await.insert(...)` roughly 50 lines later. If `accept()` were ever driven from more than one task simultaneously (e.g. a future multi-accept refactor), two connections from the same peer arriving in the same window could both pass the check before either is registered — the exact duplicate scenario this PR is fixing.

In the current single-task accept-loop this window is harmless, but adding a comment near the insertion to document the single-consumer assumption would guard against an accidental future regression:

```suggestion
                // NOTE: This check-then-insert is safe only while accept() is
                // driven from a single task. A multi-task accept() loop would
                // reintroduce the TOCTOU window and require a write-lock that
                // spans both the dedup check and the insert.
                self.connected_peers
                    .write()
                    .await
                    .insert(remote_addr, peer_conn.clone());
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/connection/nat_traversal.rs
Line: 3566-3592

Comment:
**`relay_initiator_addr` only tracks the first relay frame's source address**

Under symmetric NAT a peer may rebind between rounds, causing later `PUNCH_ME_NOW` frames to arrive from a different source port. Because `relay_initiator_addr` is set once and never updated, those slots (acquired with the new `source_addr`) won't be released by `Drop::drop` — only the original port's slots are released eagerly. The 5 s idle timeout is the only reclaim path for the rebind-port slots.

This is a minor capacity-accounting gap rather than a functional bug (the table stays bounded), but it means a connection that rebinds several times during a long rotation chain will hold slightly more slots until idle expiry than the Drop doc implies. A comment on the field noting this limitation would prevent future confusion.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(nat): drop per-rotation direct probe..."](https://github.com/saorsa-labs/saorsa-transport/commit/b36957c830d617c8ce9851235e2cc0c2fc9c6f76) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27640840)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->