### PR TITLE
feat: increase ACK timeout size budget from 1ms/KB to 4ms/KB

### DIFF
--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -2701,12 +2701,11 @@ impl P2pEndpoint {
                 //
                 // The base timeout handles small messages and dead-connection
                 // detection. For large payloads we add time proportional to
-                // size: QUIC slow-start over a high-RTT path needs multiple
-                // round trips to ramp the congestion window, so a 4 MB chunk
-                // over a 250 ms RTT link can take 2-3 s just to transmit.
+                // size at ~4 ms/KB (~250 KB/s floor): a 4 MB chunk gets ~16 s
+                // of budget on top of the base timeout.
                 let base_timeout = self.config.timeouts.send_ack_timeout;
                 let size_budget =
-                    std::time::Duration::from_millis((data.len() as u64).saturating_div(1024));
+                    std::time::Duration::from_millis((data.len() as u64).saturating_div(256));
                 let ack_timeout = base_timeout + size_budget;
                 match timeout(ack_timeout, send_stream.stopped()).await {
                     Ok(Ok(None)) => {}


### PR DESCRIPTION
## Summary

- Increase the per-stream ACK timeout size budget from 1 ms/KB to 4 ms/KB (~250 KB/s floor)
- A 2.8 MB chunk now gets ~11s of budget on top of the 5s base timeout (total ~16s), instead of ~2.8s (total ~7.8s)
- Eliminates chunk PUT timeouts on residential connections with limited upload bandwidth
- No effect on fast connections where the ACK arrives well before the timeout

## Context

On bandwidth-constrained residential connections, chunk PUTs (each ~2.8 MB sent to multiple peers) were consistently timing out. The `send_ack_timeout` budget of 1 ms/KB gave only ~2.8s of size-proportional budget, totalling ~7.8s — insufficient when the QUIC congestion window is competing with concurrent streams.

Testing showed this change reduced per-peer PUT timeouts from 94 to 0 on a slow home connection, and had no measurable impact on cloud-to-cloud upload performance.

## Test plan

- [x] Upload 8 MB file from slow home connection with `--store-concurrency 1`: zero chunk PUT timeouts (was 94 before)
- [x] Upload 50 MB files from cloud VM (lon1): 3 runs all succeeded, times within baseline range

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR increases the per-stream ACK timeout size budget from 1 ms/KB (`saturating_div(1024)`) to 4 ms/KB (`saturating_div(256)`) in `p2p_endpoint.rs`, targeting residential connections where 2.8 MB chunk PUTs were timing out due to congestion-window competition across concurrent streams. The math is correct, the updated inline comment accurately reflects the new rate, and empirical results (0 vs. 94 timeouts on a slow home connection) support the change.

<h3>Confidence Score: 5/5</h3>

Safe to merge — minimal, focused change with correct math and empirical test evidence.

The only changed line is the divisor in a timeout formula (1024 to 256). The math and comment are consistent with the stated 4 ms/KB rate. No P0 or P1 findings; empirical results strongly support the change.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/p2p_endpoint.rs | Divisor changed from 1024 to 256 in ACK timeout size-budget formula, yielding 4 ms/KB; comment and math are consistent; no other logic changed. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: increase ACK timeout size budget f..."](https://github.com/saorsa-labs/saorsa-transport/commit/35a43c70b7b2e0a8848aa9e528506354790b3ccf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28204363)</sub>

<!-- /greptile_comment -->