### PR TITLE
fix: increase handshake channel capacity from 32 to 1024

### DIFF
--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -1474,8 +1474,12 @@ impl NatTraversalEndpoint {
         let (nack_tx, nack_rx) = mpsc::unbounded_channel();
         inner_endpoint.set_nack_tx(nack_tx);
 
-        // Channel for background handshake completion (persistent across accept calls)
-        let (hs_tx, hs_rx) = mpsc::channel(32);
+        // Channel for background handshake completion (persistent across accept calls).
+        // Capacity 1024: the consumer (accept_connection_direct → P2pEndpoint::accept)
+        // can stall briefly under write-lock contention in saorsa-core's accept loop.
+        // A small buffer (32) caused the pipeline to back up after 15+ hours in a
+        // 1000-node testnet, blocking all new connection handoffs.
+        let (hs_tx, hs_rx) = mpsc::channel(1024);
 
         // Compute local peer ID = BLAKE3(public_key_spki) for
         // deterministic simultaneous-connect tie-breaking.
@@ -1946,8 +1950,12 @@ impl NatTraversalEndpoint {
         let (nack_tx, nack_rx) = mpsc::unbounded_channel();
         inner_endpoint.set_nack_tx(nack_tx);
 
-        // Channel for background handshake completion (persistent across accept calls)
-        let (hs_tx, hs_rx) = mpsc::channel(32);
+        // Channel for background handshake completion (persistent across accept calls).
+        // Capacity 1024: the consumer (accept_connection_direct → P2pEndpoint::accept)
+        // can stall briefly under write-lock contention in saorsa-core's accept loop.
+        // A small buffer (32) caused the pipeline to back up after 15+ hours in a
+        // 1000-node testnet, blocking all new connection handoffs.
+        let (hs_tx, hs_rx) = mpsc::channel(1024);
 
         // Compute local peer ID = BLAKE3(public_key_spki) for
         // deterministic simultaneous-connect tie-breaking.


### PR DESCRIPTION
## Summary

- The bounded `mpsc::channel(32)` in `nat_traversal_api.rs` carries completed connections from the accept loop to the reader task spawn path. When the consumer stalls under write-lock contention, the channel fills and all subsequent connection handoffs block silently.
- Increase capacity from 32 to 1024 to provide sufficient buffer for transient stalls.

## Context

In the ant-rc-18 testnet (1000 nodes, 17+ hours), the channel filled and 1,079 connections were accepted at the QUIC level but never forwarded to spawn reader tasks. This stalled identity exchange and degraded upload times from ~175s to 358s+.

## Companion PR

saorsa-labs/saorsa-core#82 — the primary fix, which spawns the accept loop's registration work into a separate task so it never blocks on write locks. This channel capacity increase provides defense in depth.

## Test plan

- [x] `cargo check` passes


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Increases the bounded `mpsc` handshake channel capacity from 32 to 1024 in both `NatTraversalEndpoint` constructors to prevent the accept pipeline from stalling when the consumer (`accept_connection_direct`) is briefly blocked on write-lock contention in `saorsa-core`. The PR explicitly describes this as defense-in-depth alongside the primary fix in saorsa-core#82.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — one-line capacity change with clear rationale, no logic or security concerns.
- The diff is two identical single-line changes, each accompanied by thorough inline comments explaining the production evidence. The bounded channel is correct for the design (backpressure when the consumer is healthy), and 1024 provides ample headroom for the stalls addressed by the companion fix. The only finding is a P2 style suggestion to extract a named constant.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/nat_traversal_api.rs | Increases bounded mpsc handshake channel capacity from 32 to 1024 at two constructor sites (lines 1482 and 1958); change is minimal, well-commented, and directly addresses the observed testnet backlog. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant QL as Quinn Accept
    participant AL as spawn_accept_loop (tokio::spawn)
    participant HS as Handshake Task (tokio::spawn)
    participant CH as mpsc::channel(1024)
    participant ACD as accept_connection_direct

    QL->>AL: endpoint.accept() → Connecting
    AL->>HS: tokio::spawn handshake task
    HS->>HS: connecting.await (TLS/PQC handshake)
    HS->>CH: tx.send(Ok((addr, conn))).await
    Note over CH: buffered capacity: 1024\n(was 32 — filled under lock contention)
    ACD->>CH: rx.recv().await
    CH-->>ACD: Ok((addr, conn))
    ACD-->>ACD: return connection to caller
    Note over ACD: stalls under saorsa-core write-lock\n→ channel fills → new handoffs block
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/nat_traversal_api.rs
Line: 1482

Comment:
**Capacity duplicated in two constructors**

The value `1024` appears at both line 1482 and line 1958. A named constant would make future adjustments atomic and signal intent:

```rust
/// Buffer for completed handshakes. Sized above the peak backlog observed
/// in the ant-rc-18 testnet (1 079 connections) so transient consumer
/// stalls don't block the accept loop.
const HANDSHAKE_CHANNEL_CAPACITY: usize = 1024;
```

Then `mpsc::channel(HANDSHAKE_CHANNEL_CAPACITY)` at both sites.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: increase handshake channel capacity..."](https://github.com/saorsa-labs/saorsa-transport/commit/8f1dd140f6e4c05109525823b7ec02b6c37128d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28352294)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->
