### PR TITLE
revert: undo PR #59 handshake channel capacity increase

### DIFF
--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -1474,12 +1474,8 @@ impl NatTraversalEndpoint {
         let (nack_tx, nack_rx) = mpsc::unbounded_channel();
         inner_endpoint.set_nack_tx(nack_tx);
 
-        // Channel for background handshake completion (persistent across accept calls).
-        // Capacity 1024: the consumer (accept_connection_direct → P2pEndpoint::accept)
-        // can stall briefly under write-lock contention in saorsa-core's accept loop.
-        // A small buffer (32) caused the pipeline to back up after 15+ hours in a
-        // 1000-node testnet, blocking all new connection handoffs.
-        let (hs_tx, hs_rx) = mpsc::channel(1024);
+        // Channel for background handshake completion (persistent across accept calls)
+        let (hs_tx, hs_rx) = mpsc::channel(32);
 
         // Compute local peer ID = BLAKE3(public_key_spki) for
         // deterministic simultaneous-connect tie-breaking.
@@ -1950,12 +1946,8 @@ impl NatTraversalEndpoint {
         let (nack_tx, nack_rx) = mpsc::unbounded_channel();
         inner_endpoint.set_nack_tx(nack_tx);
 
-        // Channel for background handshake completion (persistent across accept calls).
-        // Capacity 1024: the consumer (accept_connection_direct → P2pEndpoint::accept)
-        // can stall briefly under write-lock contention in saorsa-core's accept loop.
-        // A small buffer (32) caused the pipeline to back up after 15+ hours in a
-        // 1000-node testnet, blocking all new connection handoffs.
-        let (hs_tx, hs_rx) = mpsc::channel(1024);
+        // Channel for background handshake completion (persistent across accept calls)
+        let (hs_tx, hs_rx) = mpsc::channel(32);
 
         // Compute local peer ID = BLAKE3(public_key_spki) for
         // deterministic simultaneous-connect tie-breaking.


### PR DESCRIPTION
## Summary

- Reverts PR #59 which increased the handshake channel capacity from 32 to 1024
- The change turned out to be problematic and needs to be backed out before the release

## Reverted Change

`mpsc::channel(1024)` → `mpsc::channel(32)` in `src/nat_traversal_api.rs` (two call sites)

## Test plan

- [ ] CI passes on the RC branch
- [ ] Merge to main and tag release after this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reverts PR #59, restoring the `handshake_tx`/`handshake_rx` channel capacity from 1024 back to 32 at both call sites in `src/nat_traversal_api.rs`. The revert commit is clean and mechanically correct — the two changed lines exactly undo the prior increase.

<h3>Confidence Score: 5/5</h3>

Safe to merge — clean two-line revert with no surrounding logic changes.

The PR is a minimal, mechanically correct revert. Both changed lines are confirmed to match the pre-PR #59 state (capacity 32). No other code paths are touched, and all remaining observations are P2 or lower.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/nat_traversal_api.rs | Two `mpsc::channel(1024)` calls reverted to `mpsc::channel(32)`; no other logic touched. Revert is mechanically correct. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant QL as Quinn Accept
    participant AL as spawn_accept_loop
    participant CH as handshake_tx (cap: 32)
    participant ACD as accept_connection_direct

    QL->>AL: new Connecting
    AL->>AL: tokio::spawn handshake
    AL->>CH: tx.send(Ok((addr, conn))).await
    Note over CH: blocks sender if 32 slots full
    ACD->>CH: rx.recv().await
    CH-->>ACD: (addr, InnerConnection)
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/nat_traversal_api.rs
Line: 1478

Comment:
**Back-pressure risk at capacity 32**

With a bounded channel of 32, the background handshake tasks (spawned in `spawn_accept_loop`) will block on `tx.send().await` as soon as 32 completions are queued ahead of an active `accept_connection_direct` consumer. Under a burst of simultaneous connections — the same scenario that originally motivated PR #59 — this can stall the accept loop and let Quinn's internal accept queue grow unbounded. It would be worth documenting why 1024 was "problematic" (e.g. memory pressure, masking a consumer-side bug) so the right fix can be tracked, since restoring 32 re-exposes the original condition.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Revert &quot;Merge pull request #59 from saor..."](https://github.com/saorsa-labs/saorsa-transport/commit/66a1c6f3e2f96b46e86dce5fadeeade6e2a2e7d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28413489)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->