### PR TITLE
chore(release): remove Docker image build/push from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 # Release - Build and publish releases
-# Builds multi-platform binaries, Docker images, and publishes to crates.io
+# Builds multi-platform binaries and publishes to crates.io
 
 name: Release
 
@@ -331,50 +331,6 @@ jobs:
             ${{ matrix.archive }}.sha256
           retention-days: 1
 
-  build-docker:
-    name: Build Docker Images
-    needs: [validate, test]
-    runs-on: ubuntu-latest
-    continue-on-error: true  # Don't block release on Docker build failures
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to Docker Hub
-        if: github.event.inputs.dry_run != 'true'
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Login to GitHub Container Registry
-        if: github.event.inputs.dry_run != 'true'
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push Docker images
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
-          push: ${{ github.event.inputs.dry_run != 'true' }}
-          tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/saorsa-transport:${{ needs.validate.outputs.version_number }}
-            ${{ secrets.DOCKERHUB_USERNAME }}/saorsa-transport:latest
-            ghcr.io/${{ github.repository }}:${{ needs.validate.outputs.version_number }}
-            ghcr.io/${{ github.repository }}:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
   publish-crate:
     name: Publish to crates.io
     needs: [validate, test, changelog]
@@ -464,11 +420,6 @@ jobs:
             ```powershell
             Expand-Archive saorsa-transport-*.zip
             .\saorsa-transport.exe --help
-            ```
-
-            #### Docker
-            ```bash
-            docker pull ghcr.io/${{ github.repository }}:${{ needs.validate.outputs.version_number }}
             ```
 
             ### What's Changed


### PR DESCRIPTION
## Summary
- Removes the `build-docker` job from `.github/workflows/release.yml`, which previously logged into Docker Hub + GHCR and pushed multi-arch (`linux/amd64,linux/arm64,linux/arm/v7`) images on every tag.
- Drops the `#### Docker` install snippet from the generated GitHub Release body, and updates the file header comment so it no longer claims the workflow builds Docker images.
- No other job depended on `build-docker` via `needs:`, so the rest of the release pipeline (`validate` → `test`/`changelog`/`build` → `publish-crate` + `release` → `notify`) is unchanged.

## Test plan
- [ ] `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/release.yml"))'` parses cleanly (confirmed locally).
- [ ] `grep -i docker .github/workflows/release.yml` returns no matches (confirmed locally).
- [ ] On the next tag push, confirm in the Actions UI that `build-docker` no longer appears and `release` still publishes binaries + the crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the `build-docker` job from the release workflow along with the associated Docker install snippet in the generated release body. The change is a clean removal — no other jobs had a `needs: build-docker` dependency, so the rest of the pipeline (`validate` → `test`/`changelog`/`build` → `publish-crate` + `release` → `notify`) is unaffected.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the removal is self-contained with no downstream job dependencies broken.

Single-file change that purely deletes a job with no dependents; header comment and release body are updated consistently. No logic or correctness issues identified.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Removed the `build-docker` job (Docker Hub + GHCR multi-arch image push) and the `#### Docker` release-body snippet; updated header comment to match. No remaining Docker references; remaining pipeline graph is intact. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[validate] --> B[test]
    A --> C[changelog]
    A --> D[build]
    B --> E[publish-crate]
    B --> F[release]
    C --> E
    C --> F
    D --> F
    E --> G[notify]
    F --> G

    style REMOVED fill:#f88,stroke:#c00
    REMOVED["build-docker ❌ REMOVED\n(was: needs validate + test)"]
```

<sub>Reviews (1): Last reviewed commit: ["chore(release): remove Docker image buil..."](https://github.com/saorsa-labs/saorsa-transport/commit/3f74832a5bc93141b7c4c2f83e1e82ff5cda5a36) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29643530)</sub>

<!-- /greptile_comment -->