### PR TITLE
perf(logging): demote per-connection 'Registered peer ID' log to debug

### DIFF
--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -244,11 +244,27 @@ impl Endpoint {
         self.pending_peer_address_updates.drain(..)
     }
 
-    /// Set the peer ID for an existing connection
-    pub fn set_connection_peer_id(&mut self, connection_handle: ConnectionHandle, peer_id: PeerId) {
+    /// Set the peer ID for an existing connection.
+    ///
+    /// Returns `true` when the peer ID was newly assigned (or changed) on the
+    /// connection, and `false` when the connection already had this peer ID
+    /// (or no such connection exists). This lets callers skip duplicate work
+    /// — notably duplicate log emissions when the dual-stack adapter
+    /// re-registers the same peer through both v4 and v6 socket forms.
+    pub fn set_connection_peer_id(
+        &mut self,
+        connection_handle: ConnectionHandle,
+        peer_id: PeerId,
+    ) -> bool {
         if let Some(connection) = self.connections.get_mut(connection_handle.0) {
+            if connection.peer_id == Some(peer_id) {
+                return false;
+            }
             connection.peer_id = Some(peer_id);
             self.register_peer(peer_id, connection_handle);
+            true
+        } else {
+            false
         }
     }
 

--- a/src/high_level/endpoint.rs
+++ b/src/high_level/endpoint.rs
@@ -321,12 +321,14 @@ impl Endpoint {
             // Find the connection handle for this address
             let handle = state.inner.connection_handle_for_addr(&addr);
             if let Some(ch) = handle {
-                state.inner.set_connection_peer_id(ch, peer_id);
-                tracing::info!(
-                    "Registered peer ID {} for connection {} at low-level endpoint",
-                    hex::encode(&peer_id.0[..8]),
-                    addr
-                );
+                let changed = state.inner.set_connection_peer_id(ch, peer_id);
+                if changed {
+                    tracing::debug!(
+                        "Registered peer ID {} for connection {} at low-level endpoint",
+                        hex::encode(&peer_id.0[..8]),
+                        addr
+                    );
+                }
             } else {
                 tracing::debug!(
                     "No connection handle found for {} — peer ID not registered",


### PR DESCRIPTION
## Summary

Two changes, narrowly scoped to one log site:

- `Endpoint::set_connection_peer_id` now returns `bool` indicating whether the peer
  ID assignment was new (or a no-op because the connection already had it).
- `register_connection_peer_id` only emits its log line on actual change, and the
  log itself drops `info!` → `debug!`.

## Why

The dual-stack adapter in `saorsa-core` calls `register_connection_peer_id` with
both the original socket addr and the IPv4-mapped/unmapped alt form, on each of the
v4 and v6 nodes. With both forms resolving to the same connection handle, the prior
implementation logged the same registration twice per peer per connection (e.g.
`[::ffff:217.154.252.27]:30187` and `217.154.252.27:30187` both appearing).

In production this was one of the top three contributors to log volume — ~275 M docs
in Elasticsearch on a single day, of which roughly half were duplicates of the same
event. The bool-return + skip-on-no-op fix eliminates the duplicate at the source;
the demotion to `debug!` keeps it out of default-INFO production logs entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)