### PR TITLE
feat(p2p): delivery-ack send path, relay client cap, send-path timing

### DIFF
--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -25,7 +25,7 @@ use crate::SHUTDOWN_DRAIN_TIMEOUT;
 /// infrastructure for the whole network. The cap bounds relay load while still
 /// giving private peers enough choice to find an accepting relayer within their
 /// XOR close-group walk.
-const MAX_RELAY_CLIENTS_PER_PUBLIC_PEER: usize = 4;
+const MAX_RELAY_CLIENTS_PER_PUBLIC_PEER: usize = 3;
 
 /// HTTP-like status code returned by a MASQUE relay when it refuses a new
 /// CONNECT-UDP Bind request because its relay client slots are full.

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -655,6 +655,13 @@ async fn write_stream_with_progress_timeout(
     data: &[u8],
 ) -> Result<usize, EndpointError> {
     let mut bytes_written = 0usize;
+    let write_started = Instant::now();
+
+    debug!(
+        "send({}): starting QUIC stream write ({} bytes)",
+        addr,
+        data.len()
+    );
 
     while bytes_written < data.len() {
         let end = bytes_written
@@ -706,6 +713,13 @@ async fn write_stream_with_progress_timeout(
             }
         }
     }
+
+    debug!(
+        "send({}): QUIC stream write completed ({} bytes in {:?})",
+        addr,
+        bytes_written,
+        write_started.elapsed()
+    );
 
     Ok(bytes_written)
 }
@@ -2710,6 +2724,8 @@ impl P2pEndpoint {
                     return Err(EndpointError::PeerNotFound(*addr));
                 }
 
+                let send_started = Instant::now();
+
                 let _large_send_permit = if data.len() >= LARGE_SEND_BACKPRESSURE_THRESHOLD {
                     let permit_key = match transport_addr {
                         TransportAddr::Quic(addr) => normalize_socket_addr(addr),
@@ -2720,21 +2736,31 @@ impl P2pEndpoint {
                         .entry(permit_key)
                         .or_insert_with(|| Arc::new(Semaphore::new(LARGE_SEND_PER_ADDR_PERMITS)))
                         .clone();
+                    let permit_wait_started = Instant::now();
                     debug!(
-                        "send({}): waiting for large-send permit ({} bytes)",
+                        "send({}): waiting for large-send permit ({} bytes, available_permits={}, max_per_addr={})",
                         permit_key,
+                        data.len(),
+                        semaphore.available_permits(),
+                        LARGE_SEND_PER_ADDR_PERMITS
+                    );
+                    let permit = semaphore
+                        .acquire_owned()
+                        .await
+                        .map_err(|_| EndpointError::ShuttingDown)?;
+                    debug!(
+                        "send({}): acquired large-send permit after {:?} ({} bytes)",
+                        permit_key,
+                        permit_wait_started.elapsed(),
                         data.len()
                     );
-                    Some(
-                        semaphore
-                            .acquire_owned()
-                            .await
-                            .map_err(|_| EndpointError::ShuttingDown)?,
-                    )
+                    Some(permit)
                 } else {
                     None
                 };
 
+                let open_uni_started = Instant::now();
+                debug!("send({}): opening QUIC uni stream", addr);
                 let mut send_stream =
                     match timeout(STREAM_WRITE_PROGRESS_TIMEOUT, connection.open_uni()).await {
                         Ok(Ok(stream)) => stream,
@@ -2761,6 +2787,11 @@ impl P2pEndpoint {
                             ));
                         }
                     };
+                debug!(
+                    "send({}): opened QUIC uni stream in {:?}",
+                    addr,
+                    open_uni_started.elapsed()
+                );
 
                 let bytes_written =
                     match write_stream_with_progress_timeout(&mut send_stream, *addr, data).await {
@@ -2772,12 +2803,27 @@ impl P2pEndpoint {
                         }
                     };
 
+                let finish_started = Instant::now();
+                debug!(
+                    "send({}): finishing QUIC uni stream after writing {} bytes",
+                    addr, bytes_written
+                );
                 send_stream.finish().map_err(|e| {
                     warn!("send({}): finish failed: {}", addr, e);
                     send_failed(SendFailureStage::Finish, bytes_written, e.to_string())
                 })?;
+                debug!(
+                    "send({}): finished QUIC uni stream in {:?}",
+                    addr,
+                    finish_started.elapsed()
+                );
 
-                debug!("Sent {} bytes to {} via QUIC", data.len(), addr);
+                debug!(
+                    "Sent {} bytes to {} via QUIC (send path took {:?})",
+                    data.len(),
+                    addr,
+                    send_started.elapsed()
+                );
             }
             crate::transport::ProtocolEngine::Constrained => {
                 // Check if we have an established constrained connection for this address

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -90,10 +90,11 @@ const EVENT_CHANNEL_CAPACITY: usize = 256;
 /// event-driven reader-exit detection.
 const STALE_REAPER_INTERVAL: Duration = Duration::from_secs(10);
 
-/// Payload size above which QUIC sends are serialized per remote address.
+/// Payload size above which QUIC sends are serialized per remote address and
+/// wait for the peer to acknowledge receipt after the stream is finished.
 const LARGE_SEND_BACKPRESSURE_THRESHOLD: usize = 1024 * 1024;
 
-/// Number of large sends allowed in flight per remote address.
+/// Number of delivery-ack sends allowed in flight per remote address.
 const LARGE_SEND_PER_ADDR_PERMITS: usize = 1;
 
 /// Per-write chunk size used for stream write progress accounting.
@@ -101,6 +102,10 @@ const STREAM_WRITE_CHUNK_SIZE: usize = 64 * 1024;
 
 /// Maximum time a QUIC stream write may make no forward progress.
 const STREAM_WRITE_PROGRESS_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Maximum time a delivery-ack QUIC send may wait for the peer to acknowledge
+/// receipt of all stream data after the local stream is finished.
+const STREAM_DELIVERY_ACK_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// Application error code used when aborting a stuck/failed send stream.
 /// `0` is the conventional "generic abort, no specific application error"
@@ -567,6 +572,10 @@ pub enum SendFailureStage {
     Write,
     /// The stream could not be finished after all bytes were queued.
     Finish,
+    /// The peer stopped the stream or the connection failed before delivery was acknowledged.
+    DeliveryAck,
+    /// The peer did not acknowledge delivery of the finished stream in time.
+    DeliveryAckTimeout,
 }
 
 impl std::fmt::Display for SendFailureStage {
@@ -577,6 +586,8 @@ impl std::fmt::Display for SendFailureStage {
             Self::WriteProgressTimeout => "write_progress_timeout",
             Self::Write => "write",
             Self::Finish => "finish",
+            Self::DeliveryAck => "delivery_ack",
+            Self::DeliveryAckTimeout => "delivery_ack_timeout",
         };
         f.write_str(label)
     }
@@ -722,6 +733,70 @@ async fn write_stream_with_progress_timeout(
     );
 
     Ok(bytes_written)
+}
+
+async fn wait_for_stream_delivery_ack(
+    send_stream: &crate::high_level::SendStream,
+    addr: SocketAddr,
+    bytes_written: usize,
+) -> Result<(), EndpointError> {
+    let ack_started = Instant::now();
+
+    debug!(
+        "send({}): waiting for peer to acknowledge QUIC stream delivery ({} bytes, timeout {:?})",
+        addr, bytes_written, STREAM_DELIVERY_ACK_TIMEOUT
+    );
+
+    match timeout(STREAM_DELIVERY_ACK_TIMEOUT, send_stream.stopped()).await {
+        Ok(Ok(None)) => {
+            debug!(
+                "send({}): peer acknowledged QUIC stream delivery in {:?}",
+                addr,
+                ack_started.elapsed()
+            );
+            Ok(())
+        }
+        Ok(Ok(Some(error_code))) => {
+            warn!(
+                "send({}): peer stopped QUIC stream before delivery was acknowledged after {:?} (error_code={:?})",
+                addr,
+                ack_started.elapsed(),
+                error_code
+            );
+            Err(send_failed(
+                SendFailureStage::DeliveryAck,
+                bytes_written,
+                format!("peer stopped QUIC stream with error code {error_code:?}"),
+            ))
+        }
+        Ok(Err(e)) => {
+            warn!(
+                "send({}): failed while waiting for QUIC stream delivery ack after {:?}: {}",
+                addr,
+                ack_started.elapsed(),
+                e
+            );
+            Err(send_failed(
+                SendFailureStage::DeliveryAck,
+                bytes_written,
+                e.to_string(),
+            ))
+        }
+        Err(_elapsed) => {
+            warn!(
+                "send({}): timed out after {:?} waiting for peer to acknowledge QUIC stream delivery ({} bytes)",
+                addr, STREAM_DELIVERY_ACK_TIMEOUT, bytes_written
+            );
+            Err(send_failed(
+                SendFailureStage::DeliveryAckTimeout,
+                bytes_written,
+                format!(
+                    "peer did not acknowledge receipt of stream data within {:?}",
+                    STREAM_DELIVERY_ACK_TIMEOUT
+                ),
+            ))
+        }
+    }
 }
 
 /// Broadcast `P2pEvent::PeerConnected` for `addr` exactly once per
@@ -2628,6 +2703,25 @@ impl P2pEndpoint {
     /// - No suitable transport provider is available
     /// - The send operation fails
     pub async fn send(&self, addr: &SocketAddr, data: &[u8]) -> Result<(), EndpointError> {
+        self.send_inner(addr, data, false).await
+    }
+
+    /// Send data to a peer by address and wait for QUIC to confirm that the
+    /// peer received the full stream before returning.
+    pub async fn send_with_delivery_ack(
+        &self,
+        addr: &SocketAddr,
+        data: &[u8],
+    ) -> Result<(), EndpointError> {
+        self.send_inner(addr, data, true).await
+    }
+
+    async fn send_inner(
+        &self,
+        addr: &SocketAddr,
+        data: &[u8],
+        force_delivery_ack: bool,
+    ) -> Result<(), EndpointError> {
         if self.shutdown.is_cancelled() {
             return Err(EndpointError::ShuttingDown);
         }
@@ -2726,7 +2820,9 @@ impl P2pEndpoint {
 
                 let send_started = Instant::now();
 
-                let _large_send_permit = if data.len() >= LARGE_SEND_BACKPRESSURE_THRESHOLD {
+                let wait_for_delivery_ack =
+                    force_delivery_ack || data.len() >= LARGE_SEND_BACKPRESSURE_THRESHOLD;
+                let _delivery_ack_send_permit = if wait_for_delivery_ack {
                     let permit_key = match transport_addr {
                         TransportAddr::Quic(addr) => normalize_socket_addr(addr),
                         _ => normalize_socket_addr(*addr),
@@ -2738,21 +2834,23 @@ impl P2pEndpoint {
                         .clone();
                     let permit_wait_started = Instant::now();
                     debug!(
-                        "send({}): waiting for large-send permit ({} bytes, available_permits={}, max_per_addr={})",
+                        "send({}): waiting for delivery-ack send permit ({} bytes, available_permits={}, max_per_addr={}, forced_delivery_ack={})",
                         permit_key,
                         data.len(),
                         semaphore.available_permits(),
-                        LARGE_SEND_PER_ADDR_PERMITS
+                        LARGE_SEND_PER_ADDR_PERMITS,
+                        force_delivery_ack
                     );
                     let permit = semaphore
                         .acquire_owned()
                         .await
                         .map_err(|_| EndpointError::ShuttingDown)?;
                     debug!(
-                        "send({}): acquired large-send permit after {:?} ({} bytes)",
+                        "send({}): acquired delivery-ack send permit after {:?} ({} bytes, forced_delivery_ack={})",
                         permit_key,
                         permit_wait_started.elapsed(),
-                        data.len()
+                        data.len(),
+                        force_delivery_ack
                     );
                     Some(permit)
                 } else {
@@ -2817,6 +2915,10 @@ impl P2pEndpoint {
                     addr,
                     finish_started.elapsed()
                 );
+
+                if wait_for_delivery_ack {
+                    wait_for_stream_delivery_ack(&send_stream, *addr, bytes_written).await?;
+                }
 
                 debug!(
                     "Sent {} bytes to {} via QUIC (send path took {:?})",


### PR DESCRIPTION
## Summary
- **feat(p2p)**: add `send_with_delivery_ack` and make large (>=1MiB) sends wait for the peer to acknowledge receipt of the full QUIC uni stream via `SendStream::stopped()` after `finish`. The per-address permit is held until delivery is confirmed or `STREAM_DELIVERY_ACK_TIMEOUT` (120s) fires. Surfaces failure modes via new `SendFailureStage::DeliveryAck` / `DeliveryAckTimeout`.
- **fix(relay)**: lower `MAX_RELAY_CLIENTS_PER_PUBLIC_PEER` from 4 to 3 so popular public peers shed load sooner and private peers walk further across XOR close-group candidates before settling on a relayer.
- **chore(p2p)**: add debug-level timing instrumentation across the QUIC send path (large-send permit wait, `open_uni`, stream write, finish, total) to help diagnose slow sends.

## Test plan
- [ ] `cargo nextest run --locked`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo fmt --all -- --check`
- [ ] Verify large-send delivery-ack path against a real peer (>=1MiB payload) and confirm permit is released only after peer ack
- [ ] Verify relay rebalancing under load — clients beyond cap of 3 walk to next XOR-close candidate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `send_with_delivery_ack` API that explicitly waits for the remote peer to acknowledge receipt of a full QUIC uni-stream via `stopped()`, extends the same delivery-ack wait to all large (≥1 MiB) sends through the existing `send()` path, adds debug timing instrumentation throughout the QUIC send path, and lowers `MAX_RELAY_CLIENTS_PER_PUBLIC_PEER` from 4 to 3.

- **`send_with_delivery_ack`**: New public method that routes through the refactored `send_inner(force_delivery_ack=true)` and holds the per-address semaphore permit until `stopped()` resolves (`Ok(None)` = all data ACKed at QUIC transport level) or `STREAM_DELIVERY_ACK_TIMEOUT` (120 s) fires.
- **Implicit delivery-ack for `send()`**: Any payload ≥ 1 MiB now also enters the delivery-ack wait, extending the permit hold time from "finish completes" to "peer ACKs all data or 120 s elapses" — a silent behavior change for existing large-payload callers.
- **Relay cap and timing**: `MAX_RELAY_CLIENTS_PER_PUBLIC_PEER` is reduced to 3, and debug-level timing spans are added around permit acquisition, `open_uni`, stream write, and finish.

<h3>Confidence Score: 3/5</h3>

The delivery-ack wait added silently to `send()` for large payloads warrants a close look before merging into a release candidate; the relay-cap reduction is safe.

The `send()` function now implicitly blocks for up to 120 s and can surface new timeout errors for any payload ≥ 1 MiB — behavior that did not exist before and that existing callers have no way to anticipate from the unchanged doc comment. The `send_with_delivery_ack` addition is clean, and the relay-cap and timing changes are low-risk, but the undocumented contract change on the long-standing `send()` path could cause latency regressions or unexpected failures in callers that already handle large sends.

src/p2p_endpoint.rs — specifically the interaction between the refactored `send_inner` and the existing `send()` public method for large payloads

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/p2p_endpoint.rs | Adds `send_with_delivery_ack`, refactors `send` into `send_inner` with a `force_delivery_ack` flag, adds `wait_for_stream_delivery_ack` using `stopped()`, and adds debug timing instrumentation throughout the QUIC send path. The implicit delivery-ack wait added to the existing `send()` for large payloads (≥1 MiB) is a meaningful behavior change not reflected in the public doc comment. |
| src/nat_traversal_api.rs | Lowers `MAX_RELAY_CLIENTS_PER_PUBLIC_PEER` from 4 to 3; straightforward constant change with no surrounding logic altered. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant send_inner
    participant Semaphore
    participant QUICStream
    participant RemotePeer

    Caller->>send_inner: send() / send_with_delivery_ack()
    send_inner->>send_inner: wait_for_delivery_ack = force_ack OR len >= 1MiB
    alt wait_for_delivery_ack
        send_inner->>Semaphore: acquire_owned() [blocks if permit taken]
        Semaphore-->>send_inner: permit held
    end
    send_inner->>QUICStream: open_uni()
    QUICStream-->>send_inner: SendStream
    send_inner->>QUICStream: write_stream_with_progress_timeout()
    QUICStream->>RemotePeer: STREAM frames
    send_inner->>QUICStream: finish()
    QUICStream->>RemotePeer: FIN
    alt wait_for_delivery_ack
        send_inner->>QUICStream: stopped() [timeout=120s]
        RemotePeer-->>QUICStream: ACKs all data
        QUICStream-->>send_inner: Ok(None) — delivered
        Note over send_inner,Semaphore: permit released
    else
        Note over send_inner,Semaphore: permit not held / already None
    end
    send_inner-->>Caller: Ok(()) or Err(DeliveryAck/Timeout)
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/p2p_endpoint.rs`, line 258-259 ([link](https://github.com/saorsa-labs/saorsa-transport/blob/d611cb81ee9adf298e044058cc4ff011beb741de/src/p2p_endpoint.rs#L258-L259)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> The doc comment on this field no longer reflects its full scope. Since the semaphore is now acquired for any `send_with_delivery_ack` call regardless of payload size (not only for sends above `LARGE_SEND_BACKPRESSURE_THRESHOLD`), the comment should be updated to avoid confusion for future maintainers.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/p2p_endpoint.rs
   Line: 258-259

   Comment:
   The doc comment on this field no longer reflects its full scope. Since the semaphore is now acquired for any `send_with_delivery_ack` call regardless of payload size (not only for sends above `LARGE_SEND_BACKPRESSURE_THRESHOLD`), the comment should be updated to avoid confusion for future maintainers.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/p2p_endpoint.rs:2703-2706
**Undocumented delivery-ack behavior change on `send()` for large payloads**

`send()` now implicitly enables the delivery-ack path (including the 120 s `STREAM_DELIVERY_ACK_TIMEOUT`) for any payload ≥ 1 MiB, because `wait_for_delivery_ack` is set by `force_delivery_ack || data.len() >= LARGE_SEND_BACKPRESSURE_THRESHOLD`. Before this PR, the semaphore was released immediately after `finish()`; now it is held for up to 120 s while the ACK is awaited. Callers using `send()` for large blobs will silently experience much higher latency and two new error codes (`DeliveryAck`, `DeliveryAckTimeout`) they cannot currently anticipate. The public-facing doc comment should explicitly say that payloads ≥ 1 MiB implicitly wait for delivery confirmation and can return these new error variants.

### Issue 2 of 2
src/p2p_endpoint.rs:258-259
The doc comment on this field no longer reflects its full scope. Since the semaphore is now acquired for any `send_with_delivery_ack` call regardless of payload size (not only for sends above `LARGE_SEND_BACKPRESSURE_THRESHOLD`), the comment should be updated to avoid confusion for future maintainers.

```suggestion
    /// Per-address semaphore used to serialize delivery-ack QUIC stream sends
    /// (large sends ≥ `LARGE_SEND_BACKPRESSURE_THRESHOLD` and any
    /// `send_with_delivery_ack` call regardless of payload size).
    large_send_permits: Arc<dashmap::DashMap<SocketAddr, Arc<Semaphore>>>,
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(p2p): add send\_with\_delivery\_ack an..."](https://github.com/saorsa-labs/saorsa-transport/commit/d611cb81ee9adf298e044058cc4ff011beb741de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30864050)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->