### PR TITLE
fix(p2p): improve send, dial, and relay stability

### DIFF
--- a/src/masque/relay_server.rs
+++ b/src/masque/relay_server.rs
@@ -60,6 +60,8 @@ use crate::upnp::{UpnpConfig, UpnpMappingService};
 /// `nf_conntrack_udp_timeout_stream` is 120 s on Linux) and prevents
 /// the QUIC idle timeout from firing on the underlying connection.
 const RELAY_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(15);
+const RELAY_STREAM_BATCH_MAX_FRAMES: usize = 64;
+const RELAY_STREAM_BATCH_MAX_BYTES: usize = 64 * 1024;
 
 /// Capacity of the bounded channel between the UDP reader task and the
 /// stream writer task in Direction 1 (external → NATted node).  Sized
@@ -202,6 +204,19 @@ enum WriterItem {
     /// `[CONTROL_FRAME_MARKER][body_len]` header).  The writer
     /// prepends the header before sending.
     Control(Bytes),
+}
+
+fn append_relay_frame(out: &mut Vec<u8>, encoded: &Bytes) {
+    let frame_len = encoded.len() as u32;
+    out.extend_from_slice(&frame_len.to_be_bytes());
+    out.extend_from_slice(encoded);
+}
+
+fn append_control_frame(out: &mut Vec<u8>, body: &Bytes) {
+    let body_len = body.len() as u32;
+    out.extend_from_slice(&CONTROL_FRAME_MARKER.to_be_bytes());
+    out.extend_from_slice(&body_len.to_be_bytes());
+    out.extend_from_slice(body);
 }
 
 /// Configuration for the MASQUE relay server
@@ -1043,7 +1058,7 @@ impl MasqueRelayServer {
                     match socket.recv_from(&mut buf).await {
                         Ok((len, source)) => {
                             let payload = Bytes::copy_from_slice(&buf[..len]);
-                            tracing::debug!(
+                            tracing::trace!(
                                 session_id,
                                 source = %source,
                                 len,
@@ -1116,7 +1131,7 @@ impl MasqueRelayServer {
                             };
                             match resolved {
                                 Some((target, payload)) => {
-                                    tracing::debug!(
+                                    tracing::trace!(
                                         session_id,
                                         target = %target,
                                         len = payload.len(),
@@ -1126,7 +1141,7 @@ impl MasqueRelayServer {
                                     server2.stats.record_datagram();
                                     match socket2.send_to(&payload, target).await {
                                         Ok(n) => {
-                                            tracing::debug!(
+                                            tracing::trace!(
                                                 session_id,
                                                 target = %target,
                                                 len = payload.len(),
@@ -1244,7 +1259,7 @@ impl MasqueRelayServer {
                 match socket.recv_from(&mut buf).await {
                     Ok((len, source)) => {
                         let payload = Bytes::copy_from_slice(&buf[..len]);
-                        tracing::debug!(
+                        tracing::trace!(
                             session_id, source = %source, len,
                             "RELAY_TUNNEL[srv]: stream-loop dir1 recv UDP → forwarding to relay-client"
                         );
@@ -1276,32 +1291,44 @@ impl MasqueRelayServer {
                         let Some(item) = item else { break };
                         match item {
                             WriterItem::Data(encoded) => {
-                                let frame_len = encoded.len() as u32;
-                                if let Err(e) = send_stream.write_all(&frame_len.to_be_bytes()).await {
-                                    tracing::debug!(session_id, error = %e, "Stream write error (length)");
-                                    break;
+                                let mut batch = Vec::with_capacity(
+                                    encoded
+                                        .len()
+                                        .saturating_add(std::mem::size_of::<u32>()),
+                                );
+                                append_relay_frame(&mut batch, &encoded);
+
+                                let mut frames = 1usize;
+                                while frames < RELAY_STREAM_BATCH_MAX_FRAMES
+                                    && batch.len() < RELAY_STREAM_BATCH_MAX_BYTES
+                                {
+                                    match fwd_rx.try_recv() {
+                                        Ok(WriterItem::Data(next)) => {
+                                            append_relay_frame(&mut batch, &next);
+                                            frames += 1;
+                                        }
+                                        Ok(WriterItem::Control(body)) => {
+                                            append_control_frame(&mut batch, &body);
+                                            break;
+                                        }
+                                        Err(tokio::sync::mpsc::error::TryRecvError::Empty) => break,
+                                        Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => break,
+                                    }
                                 }
-                                if let Err(e) = send_stream.write_all(&encoded).await {
-                                    tracing::debug!(session_id, error = %e, "Stream write error (data)");
+
+                                if let Err(e) = send_stream.write_all(&batch).await {
+                                    tracing::debug!(session_id, error = %e, frames, bytes = batch.len(), "Stream batch write error");
                                     break;
                                 }
                             }
                             WriterItem::Control(body) => {
-                                // Wire format: [4-byte BE marker][4-byte BE body_len][body]
-                                let body_len = body.len() as u32;
-                                if let Err(e) = send_stream
-                                    .write_all(&CONTROL_FRAME_MARKER.to_be_bytes())
-                                    .await
-                                {
-                                    tracing::debug!(session_id, error = %e, "Stream write error (control marker)");
-                                    break;
-                                }
-                                if let Err(e) = send_stream.write_all(&body_len.to_be_bytes()).await {
-                                    tracing::debug!(session_id, error = %e, "Stream write error (control len)");
-                                    break;
-                                }
-                                if let Err(e) = send_stream.write_all(&body).await {
-                                    tracing::debug!(session_id, error = %e, "Stream write error (control body)");
+                                let mut frame = Vec::with_capacity(
+                                    body.len()
+                                        .saturating_add(std::mem::size_of::<u64>()),
+                                );
+                                append_control_frame(&mut frame, &body);
+                                if let Err(e) = send_stream.write_all(&frame).await {
+                                    tracing::debug!(session_id, error = %e, "Stream write error (control frame)");
                                     break;
                                 }
                             }
@@ -1362,7 +1389,7 @@ impl MasqueRelayServer {
                     let mut cursor = Bytes::from(frame_buf);
                     match UncompressedDatagram::decode(&mut cursor) {
                         Ok(datagram) => {
-                            tracing::debug!(
+                            tracing::trace!(
                                 session_id, target = %datagram.target,
                                 len = datagram.payload.len(),
                                 "RELAY_TUNNEL[srv]: stream-loop dir2 recv from relay-client → sendto target"
@@ -1373,7 +1400,7 @@ impl MasqueRelayServer {
                             let payload_len = datagram.payload.len();
                             match socket2.send_to(&datagram.payload, target).await {
                                 Ok(n) => {
-                                    tracing::debug!(
+                                    tracing::trace!(
                                         session_id,
                                         target = %target,
                                         len = payload_len,

--- a/src/masque/relay_server.rs
+++ b/src/masque/relay_server.rs
@@ -1269,12 +1269,12 @@ impl MasqueRelayServer {
                         stats.record_bytes(encoded.len() as u64);
                         stats.record_datagram();
                         if fwd_tx.send(WriterItem::Data(encoded)).await.is_err() {
-                            break; // writer closed
+                            return "writer_channel_closed";
                         }
                     }
                     Err(e) => {
                         tracing::debug!(session_id, error = %e, "UDP recv error");
-                        break;
+                        return "udp_recv_error";
                     }
                 }
             }
@@ -1288,7 +1288,9 @@ impl MasqueRelayServer {
             loop {
                 tokio::select! {
                     item = fwd_rx.recv() => {
-                        let Some(item) = item else { break };
+                        let Some(item) = item else {
+                            return "forward_channel_closed";
+                        };
                         match item {
                             WriterItem::Data(encoded) => {
                                 let mut batch = Vec::with_capacity(
@@ -1318,7 +1320,7 @@ impl MasqueRelayServer {
 
                                 if let Err(e) = send_stream.write_all(&batch).await {
                                     tracing::debug!(session_id, error = %e, frames, bytes = batch.len(), "Stream batch write error");
-                                    break;
+                                    return "stream_batch_write_error";
                                 }
                             }
                             WriterItem::Control(body) => {
@@ -1329,7 +1331,7 @@ impl MasqueRelayServer {
                                 append_control_frame(&mut frame, &body);
                                 if let Err(e) = send_stream.write_all(&frame).await {
                                     tracing::debug!(session_id, error = %e, "Stream write error (control frame)");
-                                    break;
+                                    return "stream_control_write_error";
                                 }
                             }
                         }
@@ -1337,25 +1339,41 @@ impl MasqueRelayServer {
                     _ = keepalive.tick() => {
                         if let Err(e) = send_stream.write_all(&keepalive_bytes).await {
                             tracing::debug!(session_id, error = %e, "Keepalive write error");
-                            break;
+                            return "keepalive_write_error";
                         }
                     }
                 }
             }
         });
 
-        tokio::select! {
-            _ = reader_handle => {},
-            _ = writer_handle => {},
+        let close_reason = tokio::select! {
+            result = reader_handle => {
+                match result {
+                    Ok(reason) => reason,
+                    Err(e) => {
+                        tracing::debug!(session_id, error = %e, "Relay UDP reader task join error");
+                        "reader_task_join_error"
+                    }
+                }
+            },
+            result = writer_handle => {
+                match result {
+                    Ok(reason) => reason,
+                    Err(e) => {
+                        tracing::debug!(session_id, error = %e, "Relay stream writer task join error");
+                        "writer_task_join_error"
+                    }
+                }
+            },
 
             // Direction 2: Stream → UDP (client → relay → target)
-            _ = async {
+            reason = async {
                 loop {
                     // Read 4-byte length prefix
                     let mut len_buf = [0u8; 4];
                     if let Err(e) = recv_stream.read_exact(&mut len_buf).await {
                         tracing::debug!(session_id, error = %e, "Stream read error (length)");
-                        break;
+                        return "stream_read_length_error";
                     }
                     let frame_len = u32::from_be_bytes(len_buf) as usize;
 
@@ -1375,14 +1393,14 @@ impl MasqueRelayServer {
                             frame_len,
                             "Corrupt stream frame length, closing session"
                         );
-                        break;
+                        return "corrupt_frame_length";
                     }
 
                     // Read frame data
                     let mut frame_buf = vec![0u8; frame_len];
                     if let Err(e) = recv_stream.read_exact(&mut frame_buf).await {
                         tracing::debug!(session_id, error = %e, "Stream read error (data)");
-                        break;
+                        return "stream_read_data_error";
                     }
 
                     // Decode and forward
@@ -1452,10 +1470,14 @@ impl MasqueRelayServer {
                         }
                     }
                 }
-            } => {},
-        }
+            } => reason,
+        };
 
-        tracing::info!(session_id, "Stream-based relay forwarding loop ended");
+        tracing::info!(
+            session_id,
+            close_reason,
+            "Stream-based relay forwarding loop ended"
+        );
         if let Err(e) = self.close_session(session_id).await {
             tracing::debug!(session_id, error = %e, "Error closing session");
         }

--- a/src/masque/relay_socket.rs
+++ b/src/masque/relay_socket.rs
@@ -70,6 +70,8 @@ const RELAY_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(15);
 /// docs), which matches UDP's lossy semantics.  8192 × ~1200 B ≈ 10 MB
 /// of worst-case buffering before drops begin.
 const SEND_QUEUE_CAPACITY: usize = 8192;
+const RELAY_STREAM_BATCH_MAX_FRAMES: usize = 64;
+const RELAY_STREAM_BATCH_MAX_BYTES: usize = 64 * 1024;
 
 /// Upper bound on decoded inbound packets queued for `poll_recv`.
 /// The reader task awaits on `Sender::send`, so when this fills up the
@@ -80,6 +82,12 @@ const RECV_QUEUE_CAPACITY: usize = 8192;
 /// Legitimate QUIC packets are ≤65535 bytes; anything above this is a
 /// framing error or corruption and closes the session.
 const MAX_RELAY_FRAME: usize = 512 * 1024;
+
+fn append_relay_frame(out: &mut Vec<u8>, encoded: &Bytes) {
+    let frame_len = encoded.len() as u32;
+    out.extend_from_slice(&frame_len.to_be_bytes());
+    out.extend_from_slice(encoded);
+}
 
 /// Raw QUIC streams from a relay session, before socket construction.
 ///
@@ -274,7 +282,7 @@ impl MasqueRelaySocket {
                         // the original frame buffer — no clone needed.
                         let inbound_source = datagram.target;
                         let inbound_len = datagram.payload.len();
-                        tracing::debug!(
+                        tracing::trace!(
                             relay = %relay_public_addr,
                             source = %inbound_source,
                             len = inbound_len,
@@ -315,20 +323,29 @@ impl MasqueRelaySocket {
                 // slow) stream write — so the Quinn endpoint can start
                 // assembling the next packet concurrently with this
                 // frame going out on the wire.
+                let mut batch =
+                    Vec::with_capacity(encoded.len().saturating_add(std::mem::size_of::<u32>()));
+                append_relay_frame(&mut batch, &encoded);
                 writer_capacity.notify_one();
 
-                let frame_len = encoded.len() as u32;
-                if let Err(e) = send_stream.write_all(&frame_len.to_be_bytes()).await {
-                    tracing::debug!(error = %e, "MasqueRelaySocket: stream write error (length)");
-                    break;
-                }
-                // Zero-length frames (keepalives) need only the length
-                // prefix — skip the empty write_all.
-                if !encoded.is_empty() {
-                    if let Err(e) = send_stream.write_all(&encoded).await {
-                        tracing::debug!(error = %e, "MasqueRelaySocket: stream write error (data)");
-                        break;
+                let mut frames = 1usize;
+                while frames < RELAY_STREAM_BATCH_MAX_FRAMES
+                    && batch.len() < RELAY_STREAM_BATCH_MAX_BYTES
+                {
+                    match send_rx.try_recv() {
+                        Ok(next) => {
+                            append_relay_frame(&mut batch, &next);
+                            writer_capacity.notify_one();
+                            frames += 1;
+                        }
+                        Err(mpsc::error::TryRecvError::Empty) => break,
+                        Err(mpsc::error::TryRecvError::Disconnected) => break,
                     }
+                }
+
+                if let Err(e) = send_stream.write_all(&batch).await {
+                    tracing::debug!(error = %e, frames, bytes = batch.len(), "MasqueRelaySocket: stream batch write error");
+                    break;
                 }
             }
             // Writer exited (stream error or receiver dropped). Dropping
@@ -410,7 +427,7 @@ impl AsyncUdpSocket for MasqueRelaySocket {
         // of `segment_size` bytes.  Each segment must be sent as its
         // own tunnel frame — the relay server has a per-frame size
         // limit and cannot handle the entire batch as one.
-        tracing::debug!(
+        tracing::trace!(
             relay = %self.relay_public_addr,
             destination = %transmit.destination,
             len = transmit.contents.len(),

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -3903,7 +3903,7 @@ impl NatTraversalEndpoint {
     fn next_relay_generation(&self) -> u64 {
         self.relay_generation
             .fetch_add(1, std::sync::atomic::Ordering::AcqRel)
-            .saturating_add(1)
+            .wrapping_add(1)
     }
 
     fn relay_generation_matches(&self, generation: u64, relay_addr: SocketAddr) -> bool {

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -25,7 +25,7 @@ use crate::SHUTDOWN_DRAIN_TIMEOUT;
 /// infrastructure for the whole network. The cap bounds relay load while still
 /// giving private peers enough choice to find an accepting relayer within their
 /// XOR close-group walk.
-const MAX_RELAY_CLIENTS_PER_PUBLIC_PEER: usize = 3;
+const MAX_RELAY_CLIENTS_PER_PUBLIC_PEER: usize = 4;
 
 /// HTTP-like status code returned by a MASQUE relay when it refuses a new
 /// CONNECT-UDP Bind request because its relay client slots are full.

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -450,6 +450,12 @@ pub struct NatTraversalEndpoint {
     bootstrap_complete: Arc<std::sync::atomic::AtomicBool>,
     /// Relay address to re-advertise to new peers (set after proactive relay setup)
     relay_public_addr: Arc<std::sync::Mutex<Option<SocketAddr>>>,
+    /// Monotonic generation for proactive relay state.
+    ///
+    /// Incremented whenever relay state is established or reset. Any
+    /// advertise/re-advertise path that snapshots a relay address also carries
+    /// this generation and drops work if a newer relay state superseded it.
+    relay_generation: Arc<std::sync::atomic::AtomicU64>,
     /// Peers already advertised the relay address to
     relay_advertised_peers: Arc<std::sync::Mutex<std::collections::HashSet<SocketAddr>>>,
     /// Task handles for transport listener tasks
@@ -1691,6 +1697,7 @@ impl NatTraversalEndpoint {
             relay_setup_attempted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             bootstrap_complete: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             relay_public_addr: Arc::new(std::sync::Mutex::new(None)),
+            relay_generation: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             relay_advertised_peers: Arc::new(std::sync::Mutex::new(
                 std::collections::HashSet::new(),
             )),
@@ -2130,6 +2137,7 @@ impl NatTraversalEndpoint {
             relay_setup_attempted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             bootstrap_complete: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             relay_public_addr: Arc::new(std::sync::Mutex::new(None)),
+            relay_generation: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             relay_advertised_peers: Arc::new(std::sync::Mutex::new(
                 std::collections::HashSet::new(),
             )),
@@ -3887,6 +3895,22 @@ impl NatTraversalEndpoint {
         self.relay_public_addr.lock().ok().and_then(|g| *g)
     }
 
+    fn current_relay_generation(&self) -> u64 {
+        self.relay_generation
+            .load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    fn next_relay_generation(&self) -> u64 {
+        self.relay_generation
+            .fetch_add(1, std::sync::atomic::Ordering::AcqRel)
+            .saturating_add(1)
+    }
+
+    fn relay_generation_matches(&self, generation: u64, relay_addr: SocketAddr) -> bool {
+        self.current_relay_generation() == generation
+            && self.relay_public_addr.lock().ok().and_then(|g| *g) == Some(relay_addr)
+    }
+
     /// Check if the proactive relay session is still alive. Returns true if
     /// no relay was established (nothing to monitor) or the relay is healthy.
     /// Returns false if a relay was established but the underlying QUIC
@@ -3917,6 +3941,7 @@ impl NatTraversalEndpoint {
     /// Reset relay state so the next poll cycle can re-establish. Called when
     /// the relay session is detected as dead.
     pub fn reset_relay_state(&self) {
+        let generation = self.next_relay_generation();
         self.relay_setup_attempted
             .store(false, std::sync::atomic::Ordering::Relaxed);
         if let Ok(mut addr) = self.relay_public_addr.lock() {
@@ -3927,7 +3952,10 @@ impl NatTraversalEndpoint {
         }
         // Remove dead sessions
         self.relay_sessions.retain(|_, session| session.is_active());
-        info!("Relay state reset — will re-establish on next poll cycle");
+        info!(
+            generation,
+            "Relay state reset — will re-establish on next poll cycle"
+        );
     }
 
     /// Check if relay fallback is available
@@ -4916,6 +4944,21 @@ impl NatTraversalEndpoint {
 
         info!("Relay endpoint created (relay addr: {})", relay_public_addr);
 
+        let relay_generation = self.next_relay_generation();
+        self.relay_setup_attempted
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        if let Ok(mut addr) = self.relay_public_addr.lock() {
+            *addr = Some(relay_public_addr);
+        }
+        if let Ok(mut peers) = self.relay_advertised_peers.lock() {
+            peers.clear();
+        }
+        info!(
+            relay_generation,
+            relay_addr = %relay_public_addr,
+            "Proactive relay generation established"
+        );
+
         // Share the relay endpoint between the accept loop and the
         // graceful-close watcher.
         let relay_endpoint = Arc::new(relay_endpoint);
@@ -4951,9 +4994,22 @@ impl NatTraversalEndpoint {
         // Step 5: Advertise the relay address to all connected peers
         let mut advertised = 0;
         for entry in self.connections.iter() {
+            if !self.relay_generation_matches(relay_generation, relay_public_addr) {
+                debug!(
+                    relay_generation,
+                    relay_addr = %relay_public_addr,
+                    "Skipping stale relay advertisement after relay generation changed"
+                );
+                break;
+            }
             let conn = entry.value().clone();
             match conn.send_nat_address_advertisement(relay_public_addr, 100) {
-                Ok(_) => advertised += 1,
+                Ok(_) => {
+                    advertised += 1;
+                    if let Ok(mut peers) = self.relay_advertised_peers.lock() {
+                        peers.insert(*entry.key());
+                    }
+                }
                 Err(e) => {
                     debug!(
                         "Failed to advertise relay address to {}: {}",
@@ -4968,14 +5024,6 @@ impl NatTraversalEndpoint {
             "Advertised relay address {} to {} peers",
             relay_public_addr, advertised
         );
-
-        // Record the session as active so the rest of the endpoint
-        // suppresses conflicting broadcasts.
-        self.relay_setup_attempted
-            .store(true, std::sync::atomic::Ordering::Relaxed);
-        if let Ok(mut addr) = self.relay_public_addr.lock() {
-            *addr = Some(relay_public_addr);
-        }
 
         Ok(relay_public_addr)
     }
@@ -6339,6 +6387,7 @@ impl NatTraversalEndpoint {
         {
             let relay_addr = self.relay_public_addr.lock().ok().and_then(|g| *g);
             if let Some(relay_addr) = relay_addr {
+                let relay_generation = self.current_relay_generation();
                 let unadvertised: Vec<SocketAddr> = {
                     let advertised = self
                         .relay_advertised_peers
@@ -6360,6 +6409,14 @@ impl NatTraversalEndpoint {
                     );
                 }
                 for peer_addr in unadvertised {
+                    if !self.relay_generation_matches(relay_generation, relay_addr) {
+                        debug!(
+                            relay_generation,
+                            relay_addr = %relay_addr,
+                            "Relay re-advertise: dropping stale generation"
+                        );
+                        break;
+                    }
                     if let Some(mut entry) = self.connections.get_mut(&peer_addr) {
                         match entry
                             .value_mut()

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -397,6 +397,14 @@ pub struct NatTraversalEndpoint {
     /// Active connections keyed by remote SocketAddr
     /// Uses DashMap for fine-grained concurrent access without blocking workers
     connections: Arc<dashmap::DashMap<SocketAddr, InnerConnection>>,
+    /// Owning QUIC endpoint for each tracked connection.
+    ///
+    /// Most connections are owned by `inner_endpoint`, but inbound
+    /// connections to a proactive MASQUE relay land on a separate relay
+    /// endpoint. Peer-id registration must update the endpoint that actually
+    /// owns the QUIC connection rather than assuming every connection belongs
+    /// to the main endpoint.
+    connection_endpoints: Arc<dashmap::DashMap<SocketAddr, InnerEndpoint>>,
     /// Timeout configuration
     timeout_config: crate::config::nat_timeouts::TimeoutConfig,
     /// Track remote addresses for which ConnectionEstablished has already been emitted
@@ -1397,6 +1405,40 @@ impl NatTraversalEndpoint {
 
         config
     }
+
+    fn track_connection_endpoint(
+        connection_endpoints: &Arc<dashmap::DashMap<SocketAddr, InnerEndpoint>>,
+        addr: SocketAddr,
+        endpoint: &InnerEndpoint,
+    ) {
+        for candidate in socket_addr_variants(addr) {
+            connection_endpoints.insert(candidate, endpoint.clone());
+        }
+    }
+
+    fn untrack_connection_endpoint(
+        connection_endpoints: &Arc<dashmap::DashMap<SocketAddr, InnerEndpoint>>,
+        addr: SocketAddr,
+    ) {
+        for candidate in socket_addr_variants(addr) {
+            connection_endpoints.remove(&candidate);
+        }
+    }
+
+    fn register_peer_id_on_endpoint(
+        endpoint: &InnerEndpoint,
+        addr: SocketAddr,
+        peer_id: PeerId,
+    ) -> bool {
+        for candidate in socket_addr_variants(addr) {
+            if endpoint.connection_stable_id_for_addr(&candidate).is_some() {
+                endpoint.register_connection_peer_id(candidate, peer_id);
+                return true;
+            }
+        }
+        false
+    }
+
     /// Create a new NAT traversal endpoint with proper UDP socket sharing
     ///
     /// This is the recommended constructor for most use cases. It:
@@ -1635,6 +1677,7 @@ impl NatTraversalEndpoint {
             accepted_addrs_rx: Arc::new(TokioMutex::new(accepted_addrs_rx)),
             shutdown_notify: Arc::new(tokio::sync::Notify::new()),
             connections: Arc::new(dashmap::DashMap::new()),
+            connection_endpoints: Arc::new(dashmap::DashMap::new()),
             timeout_config: config.timeouts.clone(),
             emitted_established_events: emitted_established_events.clone(),
             relay_manager,
@@ -2073,6 +2116,7 @@ impl NatTraversalEndpoint {
             accepted_addrs_rx: Arc::new(TokioMutex::new(accepted_addrs_rx)),
             shutdown_notify: Arc::new(tokio::sync::Notify::new()),
             connections: Arc::new(dashmap::DashMap::new()),
+            connection_endpoints: Arc::new(dashmap::DashMap::new()),
             timeout_config: config.timeouts.clone(),
             emitted_established_events: emitted_established_events.clone(),
             relay_manager,
@@ -2315,9 +2359,31 @@ impl NatTraversalEndpoint {
 
     /// Register a peer ID at the low-level endpoint for PUNCH_ME_NOW routing.
     pub fn register_connection_peer_id(&self, addr: SocketAddr, peer_id: PeerId) {
-        if let Some(ep) = &self.inner_endpoint {
-            ep.register_connection_peer_id(addr, peer_id);
+        for candidate in socket_addr_variants(addr) {
+            let Some(owner) = self.connection_endpoints.get(&candidate) else {
+                continue;
+            };
+            let endpoint = owner.value().clone();
+            drop(owner);
+
+            if Self::register_peer_id_on_endpoint(&endpoint, candidate, peer_id) {
+                return;
+            }
+
+            Self::untrack_connection_endpoint(&self.connection_endpoints, candidate);
         }
+
+        if let Some(ep) = &self.inner_endpoint
+            && Self::register_peer_id_on_endpoint(ep, addr, peer_id)
+        {
+            Self::track_connection_endpoint(&self.connection_endpoints, addr, ep);
+            return;
+        }
+
+        debug!(
+            "No connection owner found while registering peer ID {} for {}",
+            peer_id, addr
+        );
     }
 
     /// Get the event callback
@@ -3113,6 +3179,7 @@ impl NatTraversalEndpoint {
             }
         };
         let connections_clone = self.connections.clone();
+        let connection_endpoints_clone = self.connection_endpoints.clone();
         let emitted_events_clone = self.emitted_established_events.clone();
         let relay_server_clone = self.relay_server.clone();
         let relay_handler_connections_clone = self.relay_handler_connections.clone();
@@ -3125,6 +3192,7 @@ impl NatTraversalEndpoint {
                 shutdown_clone,
                 event_tx,
                 connections_clone,
+                connection_endpoints_clone,
                 emitted_events_clone,
                 relay_server_clone,
                 relay_handler_connections_clone,
@@ -3143,6 +3211,7 @@ impl NatTraversalEndpoint {
         shutdown: Arc<AtomicBool>,
         event_tx: mpsc::UnboundedSender<NatTraversalEvent>,
         connections: Arc<dashmap::DashMap<SocketAddr, InnerConnection>>,
+        connection_endpoints: Arc<dashmap::DashMap<SocketAddr, InnerEndpoint>>,
         emitted_events: Arc<dashmap::DashSet<SocketAddr>>,
         relay_server: Option<Arc<MasqueRelayServer>>,
         relay_handler_connections: Arc<dashmap::DashSet<usize>>,
@@ -3152,8 +3221,10 @@ impl NatTraversalEndpoint {
         while !shutdown.load(Ordering::Relaxed) {
             match endpoint.accept().await {
                 Some(connecting) => {
+                    let owner_endpoint = endpoint.clone();
                     let event_tx = event_tx.clone();
                     let connections = connections.clone();
+                    let connection_endpoints = connection_endpoints.clone();
                     let emitted_events = emitted_events.clone();
                     let relay_server = relay_server.clone();
                     let relay_handler_connections = relay_handler_connections.clone();
@@ -3175,6 +3246,11 @@ impl NatTraversalEndpoint {
                                 // dead duplicate from simultaneous-open.
                                 let connection_key = normalize_socket_addr(remote_address);
                                 connections.insert(connection_key, connection.clone());
+                                Self::track_connection_endpoint(
+                                    &connection_endpoints,
+                                    connection_key,
+                                    &owner_endpoint,
+                                );
 
                                 // Notify the P2pEndpoint's forwarder about the new connection
                                 match accepted_addrs_tx.send(connection_key) {
@@ -4206,6 +4282,7 @@ impl NatTraversalEndpoint {
         };
         let tx = self.handshake_tx.clone();
         let connections = self.connections.clone();
+        let connection_endpoints = self.connection_endpoints.clone();
         let emitted = self.emitted_established_events.clone();
         let relay_server = self.relay_server.clone();
         let relay_handler_connections = self.relay_handler_connections.clone();
@@ -4253,10 +4330,12 @@ impl NatTraversalEndpoint {
                 // to accept the next incoming connection.
                 let tx2 = tx.clone();
                 let connections2 = connections.clone();
+                let connection_endpoints2 = connection_endpoints.clone();
                 let emitted2 = emitted.clone();
                 let relay_server2 = relay_server.clone();
                 let relay_handler_connections2 = relay_handler_connections.clone();
                 let event_tx2 = event_tx_opt.clone();
+                let owner_endpoint = endpoint.clone();
                 tokio::spawn(async move {
                     let connection = match connecting.await {
                         Ok(conn) => conn,
@@ -4322,6 +4401,11 @@ impl NatTraversalEndpoint {
                     }
                     let connection_key = normalize_socket_addr(remote_address);
                     connections2.insert(connection_key, connection.clone());
+                    Self::track_connection_endpoint(
+                        &connection_endpoints2,
+                        connection_key,
+                        &owner_endpoint,
+                    );
 
                     // Only forward to handshake_tx if this is the first time
                     // we've seen this address. Without this guard, a
@@ -4383,6 +4467,14 @@ impl NatTraversalEndpoint {
     /// for symmetric NAT where the peer's address in the DHT differs
     /// from the connection's actual address.
     pub fn find_connection_by_peer_id(&self, peer_id: &[u8; 32]) -> Option<SocketAddr> {
+        for owner in self.connection_endpoints.iter() {
+            let endpoint = owner.value().clone();
+            drop(owner);
+            if let Some(addr) = endpoint.peer_connection_addr_by_id(peer_id) {
+                return Some(addr);
+            }
+        }
+
         if let Some(ep) = &self.inner_endpoint {
             return ep.peer_connection_addr_by_id(peer_id);
         }
@@ -4402,6 +4494,7 @@ impl NatTraversalEndpoint {
                 );
                 drop(entry); // release the DashMap ref before removing
                 self.connections.remove(&candidate);
+                Self::untrack_connection_endpoint(&self.connection_endpoints, candidate);
                 return false;
             }
             return true;
@@ -4478,6 +4571,9 @@ impl NatTraversalEndpoint {
             &connection,
         );
         self.connections.insert(key, connection);
+        if let Some(endpoint) = &self.inner_endpoint {
+            Self::track_connection_endpoint(&self.connection_endpoints, key, endpoint);
+        }
         info!(
             "add_connection: now have {} connections",
             self.connections.len()
@@ -4610,6 +4706,7 @@ impl NatTraversalEndpoint {
             self.active_sessions.remove(candidate);
             self.closed_at.remove(candidate);
             self.transport_candidates.remove(candidate);
+            Self::untrack_connection_endpoint(&self.connection_endpoints, *candidate);
             remove_keys.push(*candidate);
         }
 
@@ -4899,6 +4996,7 @@ impl NatTraversalEndpoint {
     ) {
         let tx = self.handshake_tx.clone();
         let connections = self.connections.clone();
+        let connection_endpoints = self.connection_endpoints.clone();
         let emitted = self.emitted_established_events.clone();
         let relay_server = self.relay_server.clone();
         let relay_handler_connections = self.relay_handler_connections.clone();
@@ -4928,10 +5026,12 @@ impl NatTraversalEndpoint {
 
                 let tx2 = tx.clone();
                 let connections2 = connections.clone();
+                let connection_endpoints2 = connection_endpoints.clone();
                 let emitted2 = emitted.clone();
                 let relay_server2 = relay_server.clone();
                 let relay_handler_connections2 = relay_handler_connections.clone();
                 let event_tx2 = event_tx_opt.clone();
+                let owner_endpoint = Arc::clone(&endpoint);
                 tokio::spawn(async move {
                     let connection = match connecting.await {
                         Ok(conn) => conn,
@@ -4974,6 +5074,11 @@ impl NatTraversalEndpoint {
                         return;
                     }
                     connections2.insert(remote_address, connection.clone());
+                    Self::track_connection_endpoint(
+                        &connection_endpoints2,
+                        remote_address,
+                        owner_endpoint.as_ref(),
+                    );
 
                     if emitted2.insert(remote_address) {
                         if let Some(ref server) = relay_server2 {
@@ -5433,6 +5538,7 @@ impl NatTraversalEndpoint {
         let addrs: Vec<SocketAddr> = self.connections.iter().map(|e| *e.key()).collect();
         for addr in addrs {
             if let Some((_, connection)) = self.connections.remove(&addr) {
+                Self::untrack_connection_endpoint(&self.connection_endpoints, addr);
                 info!("Closing connection to {}", addr);
                 connection.close(crate::VarInt::from_u32(0), b"Shutdown");
             }
@@ -5684,11 +5790,13 @@ impl NatTraversalEndpoint {
                     if let Some(event_tx) = &self.event_tx {
                         let event_tx = event_tx.clone();
                         let connections = self.connections.clone();
+                        let connection_endpoints = self.connection_endpoints.clone();
                         let incoming_notify = self.incoming_notify.clone();
                         let accepted_addrs_tx = self.accepted_addrs_tx.clone();
                         let relay_server = self.relay_server.clone();
                         let relay_handler_connections = self.relay_handler_connections.clone();
                         let address = candidate.address;
+                        let owner_endpoint = endpoint.clone();
 
                         tokio::spawn(async move {
                             match connecting.await {
@@ -5733,6 +5841,11 @@ impl NatTraversalEndpoint {
                                         inserted = true;
                                     }
                                     if inserted {
+                                        Self::track_connection_endpoint(
+                                            &connection_endpoints,
+                                            key,
+                                            &owner_endpoint,
+                                        );
                                         // Symmetric P2P: spawn the relay handler on this
                                         // outbound hole-punch connection so the remote (which
                                         // was the accept-side) can open CONNECT-UDP bidi
@@ -5827,6 +5940,7 @@ impl NatTraversalEndpoint {
             if now.duration_since(first_seen_closed) >= grace_period {
                 // Grace period elapsed — remove the dead connection.
                 self.connections.remove(&addr);
+                Self::untrack_connection_endpoint(&self.connection_endpoints, addr);
                 self.closed_at.remove(&addr);
                 debug!(
                     "Connection to {} closed: {}, removed after grace period",
@@ -6426,6 +6540,10 @@ impl NatTraversalEndpoint {
             if is_stale {
                 drop(entry);
                 self.connections.remove(&normalized_coordinator);
+                Self::untrack_connection_endpoint(
+                    &self.connection_endpoints,
+                    normalized_coordinator,
+                );
                 // Fall through to "establish new connection" below
             } else {
                 info!(
@@ -6473,9 +6591,11 @@ impl NatTraversalEndpoint {
 
                     // Spawn task to handle connection and send coordination
                     let connections = self.connections.clone();
+                    let connection_endpoints = self.connection_endpoints.clone();
                     let relay_server = self.relay_server.clone();
                     let relay_handler_connections = self.relay_handler_connections.clone();
                     let external_addr = our_external_address;
+                    let owner_endpoint = endpoint.clone();
 
                     tokio::spawn(async move {
                         // Use 10-second timeout to prevent indefinite waiting if coordinator is frozen
@@ -6499,6 +6619,11 @@ impl NatTraversalEndpoint {
                                 // Store the connection keyed by SocketAddr
                                 // DashMap provides lock-free .insert()
                                 connections.insert(coordinator_key, connection.clone());
+                                Self::track_connection_endpoint(
+                                    &connection_endpoints,
+                                    coordinator_key,
+                                    &owner_endpoint,
+                                );
                                 // Symmetric P2P: ensure the coordinator (which accepted)
                                 // can open CONNECT-UDP bidi streams toward us too.
                                 Self::spawn_relay_handler_task(
@@ -7212,6 +7337,7 @@ impl NatTraversalEndpoint {
         let remote_address = connection.remote_address();
         let connection_key = normalize_socket_addr(remote_address);
         self.connections.insert(connection_key, connection.clone());
+        Self::track_connection_endpoint(&self.connection_endpoints, connection_key, endpoint);
         // Symmetric P2P: this is a dial-side insert (we initiated via
         // `endpoint.connect`), so spawn the relay handler to mirror what
         // the accept-side does. Without this, a later

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -2903,6 +2903,8 @@ impl NatTraversalEndpoint {
     > {
         use std::sync::Arc;
 
+        const INITIAL_CONGESTION_WINDOW: u64 = 1024 * 1024;
+
         // v0.13.0+: All nodes are symmetric P2P nodes - always create server config
         let server_config = {
             info!("Creating server config using Raw Public Keys (RFC 7250) for symmetric P2P node");
@@ -2967,7 +2969,6 @@ impl NatTraversalEndpoint {
             // (208 KB on Linux).  1 MB balances fast starts (4 MB chunk
             // completes in ~2 RTTs through slow-start) with pacing that
             // receivers can absorb.
-            const INITIAL_CONGESTION_WINDOW: u64 = 1024 * 1024;
             transport_config.congestion_controller_factory(build_congestion_factory(
                 config.congestion_algorithm,
                 INITIAL_CONGESTION_WINDOW,
@@ -3045,13 +3046,13 @@ impl NatTraversalEndpoint {
             transport_config.stream_receive_window(window);
             transport_config.send_window(config.max_message_size as u64);
 
-            // Set the initial congestion window to max_message_size so
-            // relay-tunnelled connections can push a full chunk without
-            // waiting for slow-start.  See the server config comment for
-            // the full rationale.
+            // Keep client and server sends on the same bounded startup
+            // window. Uploads originate from client configs, so using
+            // max_message_size here recreates the burst/loss problem that
+            // the server config above avoids.
             transport_config.congestion_controller_factory(build_congestion_factory(
                 config.congestion_algorithm,
-                config.max_message_size as u64,
+                INITIAL_CONGESTION_WINDOW,
                 transport_config.initial_rtt,
             ));
 

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -25,7 +25,7 @@ use crate::SHUTDOWN_DRAIN_TIMEOUT;
 /// infrastructure for the whole network. The cap bounds relay load while still
 /// giving private peers enough choice to find an accepting relayer within their
 /// XOR close-group walk.
-const MAX_RELAY_CLIENTS_PER_PUBLIC_PEER: usize = 4;
+const MAX_RELAY_CLIENTS_PER_PUBLIC_PEER: usize = 3;
 
 /// HTTP-like status code returned by a MASQUE relay when it refuses a new
 /// CONNECT-UDP Bind request because its relay client slots are full.

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -882,9 +882,10 @@ async fn read_stream(
     loop {
         match recv_stream.read_chunk(usize::MAX, false).await {
             Ok(Some(chunk)) => {
-                start = start.min(chunk.offset);
+                let new_start = start.min(chunk.offset);
                 let chunk_end = chunk.offset.saturating_add(chunk.bytes.len() as u64);
-                if chunk_end.saturating_sub(start) > size_limit as u64 {
+                let new_end = end.max(chunk_end);
+                if new_end.saturating_sub(new_start) > size_limit as u64 {
                     warn!(
                         "recv({}): stream exceeded read limit (limit {} bytes)",
                         addr, size_limit
@@ -893,7 +894,8 @@ async fn read_stream(
                         "incoming stream exceeded read limit of {size_limit} bytes"
                     )));
                 }
-                end = end.max(chunk_end);
+                start = new_start;
+                end = new_end;
                 read.push((chunk.bytes, chunk.offset));
             }
             Ok(None) => {

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -52,6 +52,7 @@
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use tokio::sync::{RwLock, broadcast, mpsc};
@@ -115,7 +116,148 @@ const STREAM_RESET_ABORT_CODE: u32 = 0;
 /// through the pinhole needs only 1-2 RTTs (~600ms at 300ms worst-case RTT).
 const POST_HOLEPUNCH_DIRECT_RETRY_TIMEOUT: Duration = Duration::from_secs(1);
 
+/// Extra time subscribers wait beyond the normal fallback strategy budget
+/// before treating an in-flight dial entry as stale.
+const PENDING_DIAL_WAIT_SLACK: Duration = Duration::from_secs(5);
+
+/// Capacity of the broadcast channel that fans an in-flight dial's outcome
+/// out to subscribers waiting on the same target. Sized for the small
+/// number of concurrent waiters we observe in practice; the channel only
+/// needs to hold the single result message the owner sends on completion.
+const PENDING_DIAL_BROADCAST_CAPACITY: usize = 4;
+
+static NEXT_PENDING_DIAL_ID: AtomicU64 = AtomicU64::new(1);
+
 use crate::SHUTDOWN_DRAIN_TIMEOUT;
+
+type PendingDialResult = Result<(PeerConnection, ConnectionMethod), String>;
+type PendingDialMap = HashMap<SocketAddr, PendingDial>;
+
+struct PendingDial {
+    id: u64,
+    tx: broadcast::Sender<PendingDialResult>,
+    started_at: Instant,
+}
+
+/// Remove the pending-dial entry for `target` only if it is still the entry
+/// with the matching `id` (i.e. the caller still owns that slot). Returns the
+/// removed entry, or `None` if the slot was already gone or had been claimed
+/// by a newer dial.
+async fn remove_pending_dial_if_owned(
+    pending_dials: &tokio::sync::Mutex<PendingDialMap>,
+    target: SocketAddr,
+    id: u64,
+) -> Option<PendingDial> {
+    let mut pending = pending_dials.lock().await;
+    match pending.get(&target) {
+        Some(entry) if entry.id == id => pending.remove(&target),
+        _ => None,
+    }
+}
+
+struct PendingDialGuard {
+    pending_dials: Arc<tokio::sync::Mutex<PendingDialMap>>,
+    target: SocketAddr,
+    id: u64,
+    active: bool,
+}
+
+impl PendingDialGuard {
+    fn new(
+        pending_dials: Arc<tokio::sync::Mutex<PendingDialMap>>,
+        target: SocketAddr,
+        id: u64,
+    ) -> Self {
+        Self {
+            pending_dials,
+            target,
+            id,
+            active: true,
+        }
+    }
+
+    async fn complete(
+        &mut self,
+        result: &Result<(PeerConnection, ConnectionMethod), EndpointError>,
+    ) {
+        if !self.active {
+            return;
+        }
+        self.active = false;
+
+        let Some(entry) =
+            remove_pending_dial_if_owned(&self.pending_dials, self.target, self.id).await
+        else {
+            return;
+        };
+
+        match result {
+            Ok((conn, method)) => {
+                let _ = entry.tx.send(Ok((conn.clone(), method.clone())));
+            }
+            Err(e) => {
+                let _ = entry.tx.send(Err(e.to_string()));
+            }
+        }
+    }
+}
+
+impl Drop for PendingDialGuard {
+    fn drop(&mut self) {
+        if !self.active {
+            return;
+        }
+
+        let pending_dials = Arc::clone(&self.pending_dials);
+        let target = self.target;
+        let id = self.id;
+
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(async move {
+                if remove_pending_dial_if_owned(&pending_dials, target, id)
+                    .await
+                    .is_some()
+                {
+                    debug!(
+                        "connect_with_fallback: cleared cancelled in-flight dial to {}",
+                        target
+                    );
+                }
+            });
+        }
+    }
+}
+
+fn pending_dial_wait_timeout(strategy_config: Option<&StrategyConfig>) -> Duration {
+    let strategy = strategy_config.cloned().unwrap_or_default();
+    let direct_budget = strategy
+        .direct_connect_timeout
+        .saturating_add(strategy.direct_handshake_timeout);
+    let holepunch_round_budget = strategy
+        .holepunch_timeout
+        .saturating_add(POST_HOLEPUNCH_DIRECT_RETRY_TIMEOUT);
+    let holepunch_budget = if strategy.holepunch_enabled {
+        holepunch_round_budget.saturating_mul(strategy.max_holepunch_rounds)
+    } else {
+        Duration::ZERO
+    };
+    let relay_budget = if strategy.relay_enabled {
+        strategy.relay_timeout
+    } else {
+        Duration::ZERO
+    };
+
+    direct_budget
+        .saturating_add(holepunch_budget)
+        .saturating_add(relay_budget)
+        .saturating_add(PENDING_DIAL_WAIT_SLACK)
+}
+
+fn pending_dial_remaining_wait(wait_timeout: Duration, age: Duration) -> Option<Duration> {
+    wait_timeout
+        .checked_sub(age)
+        .filter(|remaining| !remaining.is_zero())
+}
 
 /// Extract the raw SPKI (SubjectPublicKeyInfo) bytes from a QUIC connection's
 /// peer identity, if TLS-based authentication was used.
@@ -249,9 +391,7 @@ pub struct P2pEndpoint {
     /// call does the actual connection work. Subsequent callers subscribe to a
     /// broadcast channel and wait for the result instead of starting parallel
     /// hole-punch attempts that deadlock the runtime.
-    pending_dials: Arc<
-        tokio::sync::Mutex<HashMap<SocketAddr, broadcast::Sender<Result<PeerConnection, String>>>>,
-    >,
+    pending_dials: Arc<tokio::sync::Mutex<PendingDialMap>>,
 }
 
 impl std::fmt::Debug for P2pEndpoint {
@@ -1862,37 +2002,89 @@ impl P2pEndpoint {
         }
 
         // Dedup: if another task is already connecting to this target, wait for
-        // its result instead of starting a parallel attempt. This prevents
-        // multiple concurrent hole-punch sessions that deadlock the runtime.
+        // its result instead of starting a parallel attempt. The wait is
+        // bounded and the owner installs a cancellation guard, so a dropped
+        // owner future cannot leave a permanent in-flight entry behind.
         let target = target_ipv4.or(target_ipv6);
+        let mut pending_guard = None;
         if let Some(target_addr) = target {
-            let mut pending = self.pending_dials.lock().await;
-            if let Some(tx) = pending.get(&target_addr) {
-                // Another task is already connecting — subscribe and wait
-                let mut rx = tx.subscribe();
-                drop(pending);
-                info!(
-                    "connect_with_fallback: waiting for in-flight dial to {}",
-                    target_addr
-                );
-                match rx.recv().await {
-                    Ok(Ok(conn)) => {
-                        return Ok((
-                            conn,
-                            ConnectionMethod::HolePunched {
-                                coordinator: target_addr,
-                            },
-                        ));
+            let wait_timeout = pending_dial_wait_timeout(strategy_config.as_ref());
+
+            loop {
+                let mut pending = self.pending_dials.lock().await;
+                if let Some(entry) = pending.get(&target_addr) {
+                    let pending_id = entry.id;
+                    let started_at = entry.started_at;
+                    let age = started_at.elapsed();
+                    let Some(remaining_wait) = pending_dial_remaining_wait(wait_timeout, age)
+                    else {
+                        pending.remove(&target_addr);
+                        drop(pending);
+                        warn!(
+                            "connect_with_fallback: in-flight dial to {} already stale (age {:?}, timeout {:?}); retrying locally",
+                            target_addr, age, wait_timeout
+                        );
+                        continue;
+                    };
+                    let mut rx = entry.tx.subscribe();
+                    drop(pending);
+
+                    info!(
+                        "connect_with_fallback: waiting for in-flight dial to {} (age {:?}, remaining {:?}, timeout {:?})",
+                        target_addr, age, remaining_wait, wait_timeout
+                    );
+
+                    match timeout(remaining_wait, rx.recv()).await {
+                        Ok(Ok(Ok(result))) => return Ok(result),
+                        Ok(Ok(Err(err))) => {
+                            debug!(
+                                "connect_with_fallback: in-flight dial to {} failed: {}; retrying locally",
+                                target_addr, err
+                            );
+                        }
+                        Ok(Err(err)) => {
+                            debug!(
+                                "connect_with_fallback: in-flight dial to {} ended without a result: {}; retrying locally",
+                                target_addr, err
+                            );
+                        }
+                        Err(_) => {
+                            let total_age = started_at.elapsed();
+                            warn!(
+                                "connect_with_fallback: in-flight dial to {} stale after {:?} (timeout {:?}); retrying locally",
+                                target_addr, total_age, wait_timeout
+                            );
+                            remove_pending_dial_if_owned(
+                                &self.pending_dials,
+                                target_addr,
+                                pending_id,
+                            )
+                            .await;
+                        }
                     }
-                    Ok(Err(_)) | Err(_) => {
-                        // Primary dial failed — fall through and try ourselves
-                    }
+
+                    continue;
                 }
-            } else {
-                // We're the first — register ourselves
-                let (tx, _) = broadcast::channel(4);
-                pending.insert(target_addr, tx);
+
+                // We're the first — register ourselves.
+                let (tx, _) = broadcast::channel(PENDING_DIAL_BROADCAST_CAPACITY);
+                let id = NEXT_PENDING_DIAL_ID.fetch_add(1, Ordering::Relaxed);
+                pending.insert(
+                    target_addr,
+                    PendingDial {
+                        id,
+                        tx,
+                        started_at: Instant::now(),
+                    },
+                );
                 drop(pending);
+
+                pending_guard = Some(PendingDialGuard::new(
+                    Arc::clone(&self.pending_dials),
+                    target_addr,
+                    id,
+                ));
+                break;
             }
         }
 
@@ -1902,18 +2094,8 @@ impl P2pEndpoint {
             .await;
 
         // Broadcast result to any waiters and clean up pending entry
-        if let Some(target_addr) = target {
-            let mut pending = self.pending_dials.lock().await;
-            if let Some(tx) = pending.remove(&target_addr) {
-                match &result {
-                    Ok((conn, _)) => {
-                        let _ = tx.send(Ok(conn.clone()));
-                    }
-                    Err(e) => {
-                        let _ = tx.send(Err(e.to_string()));
-                    }
-                }
-            }
+        if let Some(guard) = pending_guard.as_mut() {
+            guard.complete(&result).await;
         }
 
         result
@@ -3987,6 +4169,132 @@ impl Clone for P2pEndpoint {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_pending_dial_wait_timeout_covers_default_strategy_budget() {
+        let strategy = StrategyConfig::default();
+        let wait = pending_dial_wait_timeout(Some(&strategy));
+
+        let direct = strategy.direct_connect_timeout + strategy.direct_handshake_timeout;
+        let holepunch_round = strategy.holepunch_timeout + POST_HOLEPUNCH_DIRECT_RETRY_TIMEOUT;
+        let holepunch = holepunch_round * strategy.max_holepunch_rounds;
+        let expected = direct + holepunch + strategy.relay_timeout + PENDING_DIAL_WAIT_SLACK;
+        assert_eq!(wait, expected);
+    }
+
+    #[test]
+    fn test_pending_dial_wait_timeout_excludes_disabled_stages() {
+        let strategy = StrategyConfig {
+            holepunch_enabled: false,
+            relay_enabled: false,
+            ..StrategyConfig::default()
+        };
+        let wait = pending_dial_wait_timeout(Some(&strategy));
+
+        let direct = strategy.direct_connect_timeout + strategy.direct_handshake_timeout;
+        assert_eq!(wait, direct + PENDING_DIAL_WAIT_SLACK);
+    }
+
+    #[test]
+    fn test_pending_dial_remaining_wait_subtracts_age() {
+        let wait_timeout = Duration::from_secs(30);
+        let age = Duration::from_secs(12);
+
+        assert_eq!(
+            pending_dial_remaining_wait(wait_timeout, age),
+            Some(Duration::from_secs(18))
+        );
+    }
+
+    #[test]
+    fn test_pending_dial_remaining_wait_expires_stale_entries() {
+        let wait_timeout = Duration::from_secs(30);
+
+        assert_eq!(
+            pending_dial_remaining_wait(wait_timeout, wait_timeout),
+            None
+        );
+        assert_eq!(
+            pending_dial_remaining_wait(wait_timeout, wait_timeout + Duration::from_secs(1)),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn test_pending_dial_guard_complete_broadcasts_and_clears_entry() {
+        let target: SocketAddr = "127.0.0.1:12345".parse().expect("valid addr");
+        let pending_dials = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        let (tx, _) = broadcast::channel(PENDING_DIAL_BROADCAST_CAPACITY);
+        let mut rx = tx.subscribe();
+        let id = 42;
+
+        {
+            let mut pending = pending_dials.lock().await;
+            pending.insert(
+                target,
+                PendingDial {
+                    id,
+                    tx,
+                    started_at: Instant::now(),
+                },
+            );
+        }
+
+        let mut guard = PendingDialGuard::new(Arc::clone(&pending_dials), target, id);
+        let conn = PeerConnection {
+            public_key: None,
+            remote_addr: TransportAddr::Quic(target),
+            authenticated: true,
+            connected_at: Instant::now(),
+            last_activity: Instant::now(),
+        };
+        let result = Ok((conn.clone(), ConnectionMethod::DirectIPv4));
+
+        guard.complete(&result).await;
+
+        assert!(pending_dials.lock().await.is_empty());
+        let (received_conn, received_method) = timeout(Duration::from_millis(100), rx.recv())
+            .await
+            .expect("pending dial result sent")
+            .expect("pending dial broadcast open")
+            .expect("pending dial succeeded");
+        assert_eq!(received_conn.remote_addr, conn.remote_addr);
+        assert_eq!(received_method, ConnectionMethod::DirectIPv4);
+    }
+
+    #[tokio::test]
+    async fn test_pending_dial_guard_drop_clears_owned_entry() {
+        let target: SocketAddr = "127.0.0.1:12346".parse().expect("valid addr");
+        let pending_dials = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        let (tx, _) = broadcast::channel(PENDING_DIAL_BROADCAST_CAPACITY);
+        let id = 43;
+
+        {
+            let mut pending = pending_dials.lock().await;
+            pending.insert(
+                target,
+                PendingDial {
+                    id,
+                    tx,
+                    started_at: Instant::now(),
+                },
+            );
+        }
+
+        let guard = PendingDialGuard::new(Arc::clone(&pending_dials), target, id);
+        drop(guard);
+
+        timeout(Duration::from_secs(1), async {
+            loop {
+                if pending_dials.lock().await.is_empty() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("pending dial guard cleared entry");
+    }
 
     #[test]
     fn test_endpoint_stats_default() {

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -94,7 +94,10 @@ const STALE_REAPER_INTERVAL: Duration = Duration::from_secs(10);
 const STREAM_WRITE_PROGRESS_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Maximum time a QUIC stream read may make no forward progress.
-const STREAM_READ_PROGRESS_TIMEOUT: Duration = Duration::from_secs(2);
+const STREAM_READ_PROGRESS_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Maximum number of inbound uni streams read concurrently per QUIC connection.
+const MAX_CONCURRENT_INBOUND_STREAM_READS_PER_CONNECTION: usize = 32;
 
 /// Application error code used when aborting a stuck/failed send stream.
 /// `0` is the conventional "generic abort, no specific application error"
@@ -839,6 +842,165 @@ async fn wait_for_stream_delivery_ack(
             ))
         }
     }
+}
+
+#[derive(Clone, Copy)]
+enum InboundDataSendMode {
+    TrySendWithTimeout,
+    AwaitSend,
+}
+
+async fn dispatch_inbound_stream(
+    mut recv_stream: crate::high_level::RecvStream,
+    addr: SocketAddr,
+    data_tx: mpsc::Sender<(SocketAddr, Vec<u8>)>,
+    event_tx: broadcast::Sender<P2pEvent>,
+    max_read_bytes: usize,
+    reader_label: &'static str,
+    send_mode: InboundDataSendMode,
+) {
+    let data = match read_stream_with_progress_timeout(&mut recv_stream, addr, max_read_bytes).await
+    {
+        Ok(data) if data.is_empty() => return,
+        Ok(data) => data,
+        Err(e) => {
+            info!(
+                "Reader task for {}{}: stream read error: {}",
+                addr, reader_label, e
+            );
+            let _ = recv_stream.stop(crate::VarInt::from_u32(STREAM_RESET_ABORT_CODE));
+            return;
+        }
+    };
+
+    let data_len = data.len();
+    debug!(
+        "Reader task{}: {} bytes from {}",
+        reader_label, data_len, addr
+    );
+
+    // Note: last_activity update moved out of the hot path to avoid
+    // RwLock write contention. With N reader tasks all acquiring
+    // write locks on every message, the lock becomes a bottleneck
+    // that can starve other tasks and deadlock the runtime.
+    // The DataReceived event below serves as a liveness signal.
+    let _ = event_tx.send(P2pEvent::DataReceived {
+        addr,
+        bytes: data_len,
+    });
+
+    match send_mode {
+        InboundDataSendMode::TrySendWithTimeout => {
+            // Send through channel without blocking the reader task's event loop.
+            // If the channel is full, wait briefly in this per-stream task. This
+            // keeps the accept loop free to keep accepting other QUIC uni streams.
+            match data_tx.try_send((addr, data)) {
+                Ok(()) => {}
+                Err(mpsc::error::TrySendError::Full((addr, data))) => {
+                    let data_len = data.len();
+                    if tokio::time::timeout(Duration::from_secs(5), data_tx.send((addr, data)))
+                        .await
+                        .is_err()
+                    {
+                        warn!(
+                            "Reader task for {}{}: data channel send timed out, dropping {} bytes",
+                            addr, reader_label, data_len
+                        );
+                    }
+                }
+                Err(mpsc::error::TrySendError::Closed(_)) => {
+                    debug!(
+                        "Reader task for {}{}: channel closed, dropping {} bytes",
+                        addr, reader_label, data_len
+                    );
+                }
+            }
+        }
+        InboundDataSendMode::AwaitSend => {
+            if data_tx.send((addr, data)).await.is_err() {
+                debug!(
+                    "Reader task for {}{}: channel closed, dropping {} bytes",
+                    addr, reader_label, data_len
+                );
+            }
+        }
+    }
+}
+
+async fn run_quic_reader_task(
+    addr: SocketAddr,
+    connection: crate::high_level::Connection,
+    data_tx: mpsc::Sender<(SocketAddr, Vec<u8>)>,
+    event_tx: broadcast::Sender<P2pEvent>,
+    exit_tx: mpsc::UnboundedSender<(SocketAddr, usize)>,
+    max_read_bytes: usize,
+    reader_label: &'static str,
+    send_mode: InboundDataSendMode,
+) -> SocketAddr {
+    info!("Reader task STARTED for {}{}", addr, reader_label);
+
+    let stable_id = connection.stable_id();
+    let stream_permits = Arc::new(tokio::sync::Semaphore::new(
+        MAX_CONCURRENT_INBOUND_STREAM_READS_PER_CONNECTION,
+    ));
+    let mut stream_tasks = tokio::task::JoinSet::new();
+
+    loop {
+        while let Some(result) = stream_tasks.try_join_next() {
+            if let Err(e) = result {
+                warn!(
+                    "Reader task for {}{}: stream worker failed: {}",
+                    addr, reader_label, e
+                );
+            }
+        }
+
+        if data_tx.is_closed() {
+            debug!(
+                "Reader task for {}{}: channel closed, exiting",
+                addr, reader_label
+            );
+            break;
+        }
+
+        let permit = match Arc::clone(&stream_permits).acquire_owned().await {
+            Ok(permit) => permit,
+            Err(_) => break,
+        };
+
+        let recv_stream = match connection.accept_uni().await {
+            Ok(stream) => stream,
+            Err(e) => {
+                info!(
+                    "Reader task for {}{} ending: accept_uni error: {}",
+                    addr, reader_label, e
+                );
+                break;
+            }
+        };
+
+        let data_tx = data_tx.clone();
+        let event_tx = event_tx.clone();
+        stream_tasks.spawn(async move {
+            let _permit = permit;
+            dispatch_inbound_stream(
+                recv_stream,
+                addr,
+                data_tx,
+                event_tx,
+                max_read_bytes,
+                reader_label,
+                send_mode,
+            )
+            .await;
+        });
+    }
+
+    stream_tasks.abort_all();
+
+    // Notify the reader-exit handler for immediate cleanup.
+    let _ = exit_tx.send((addr, stable_id));
+    addr
 }
 
 /// Broadcast `P2pEvent::PeerConnected` for `addr` exactly once per
@@ -3265,82 +3427,16 @@ impl P2pEndpoint {
         let max_read_bytes = self.config.max_message_size;
         let exit_tx = self.reader_exit_tx.clone();
 
-        let abort_handle = self.reader_tasks.lock().await.spawn(async move {
-            info!("Reader task STARTED for {}", addr);
-
-            loop {
-                // Accept the next unidirectional stream
-                let mut recv_stream = match connection.accept_uni().await {
-                    Ok(stream) => stream,
-                    Err(e) => {
-                        info!("Reader task for {} ending: accept_uni error: {}", addr, e);
-                        break;
-                    }
-                };
-
-                let data =
-                    match read_stream_with_progress_timeout(&mut recv_stream, addr, max_read_bytes)
-                        .await
-                    {
-                    Ok(data) if data.is_empty() => continue,
-                    Ok(data) => data,
-                    Err(e) => {
-                        info!("Reader task for {}: stream read error: {}", addr, e);
-                        break;
-                    }
-                };
-
-                let data_len = data.len();
-                debug!("Reader task: {} bytes from {}", data_len, addr);
-
-                // Note: last_activity update moved out of the hot path to avoid
-                // RwLock write contention. With N reader tasks all acquiring
-                // write locks on every message, the lock becomes a bottleneck
-                // that can starve other tasks and deadlock the runtime.
-                // The DataReceived event below serves as a liveness signal.
-
-                // Emit DataReceived event
-                let _ = event_tx.send(P2pEvent::DataReceived {
-                    addr,
-                    bytes: data_len,
-                });
-
-                // Send through channel without blocking the reader task's
-                // event loop. Using try_send avoids holding a tokio worker
-                // thread when the channel is full. If the channel is full,
-                // spawn a short-lived task that retries with a timeout instead
-                // of dropping data immediately.
-                match data_tx.try_send((addr, data)) {
-                    Ok(()) => {}
-                    Err(mpsc::error::TrySendError::Full((addr, data))) => {
-                        let tx = data_tx.clone();
-                        let data_len = data.len();
-                        tokio::spawn(async move {
-                            if tokio::time::timeout(
-                                Duration::from_secs(5),
-                                tx.send((addr, data)),
-                            )
-                            .await
-                            .is_err()
-                            {
-                                warn!(
-                                    "Reader task for {}: data channel send timed out, dropping {} bytes",
-                                    addr, data_len
-                                );
-                            }
-                        });
-                    }
-                    Err(mpsc::error::TrySendError::Closed(_)) => {
-                        debug!("Reader task for {}: channel closed, exiting", addr);
-                        break;
-                    }
-                }
-            }
-
-            // Notify the reader-exit handler for immediate cleanup.
-            let _ = exit_tx.send((addr, connection.stable_id()));
-            addr
-        });
+        let abort_handle = self.reader_tasks.lock().await.spawn(run_quic_reader_task(
+            addr,
+            connection,
+            data_tx,
+            event_tx,
+            exit_tx,
+            max_read_bytes,
+            "",
+            InboundDataSendMode::TrySendWithTimeout,
+        ));
 
         let key = normalize_socket_addr(addr);
         if let Some(old) = self.reader_handles.write().await.insert(key, abort_handle) {
@@ -3807,50 +3903,16 @@ impl P2pEndpoint {
                     let event_tx = event_tx.clone();
                     let exit_tx = reader_exit_tx.clone();
 
-                    let abort_handle = reader_tasks.lock().await.spawn(async move {
-                        info!("Reader task STARTED for {} (via forwarder)", addr);
-
-                        loop {
-                            let mut recv_stream = match conn.accept_uni().await {
-                                Ok(stream) => stream,
-                                Err(e) => {
-                                    info!("Reader task for {} (forwarder) ending: accept_uni error: {}", addr, e);
-                                    break;
-                                }
-                            };
-
-                            let data = match read_stream_with_progress_timeout(
-                                &mut recv_stream,
-                                addr,
-                                max_read_bytes,
-                            )
-                            .await
-                            {
-                                Ok(data) if data.is_empty() => continue,
-                                Ok(data) => data,
-                                Err(e) => {
-                                    info!("Reader task for {} (forwarder): stream read error: {}", addr, e);
-                                    break;
-                                }
-                            };
-
-                            let data_len = data.len();
-                            debug!("Reader task (forwarder): {} bytes from {}", data_len, addr);
-
-                            let _ = event_tx.send(P2pEvent::DataReceived {
-                                addr,
-                                bytes: data_len,
-                            });
-
-                            if data_tx.send((addr, data)).await.is_err() {
-                                debug!("Reader task for {} (forwarder): channel closed, exiting", addr);
-                                break;
-                            }
-                        }
-
-                        let _ = exit_tx.send((addr, conn.stable_id()));
-                        addr
-                    });
+                    let abort_handle = reader_tasks.lock().await.spawn(run_quic_reader_task(
+                        addr,
+                        conn,
+                        data_tx,
+                        event_tx,
+                        exit_tx,
+                        max_read_bytes,
+                        " (forwarder)",
+                        InboundDataSendMode::AwaitSend,
+                    ));
 
                     let key = normalize_socket_addr(addr);
                     if let Some(old) = reader_handles.write().await.insert(key, abort_handle) {

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -655,6 +655,13 @@ async fn write_stream_with_progress_timeout(
     data: &[u8],
 ) -> Result<usize, EndpointError> {
     let mut bytes_written = 0usize;
+    let write_started = Instant::now();
+
+    debug!(
+        "send({}): starting QUIC stream write ({} bytes)",
+        addr,
+        data.len()
+    );
 
     while bytes_written < data.len() {
         let end = bytes_written
@@ -706,6 +713,13 @@ async fn write_stream_with_progress_timeout(
             }
         }
     }
+
+    debug!(
+        "send({}): QUIC stream write completed ({} bytes in {:?})",
+        addr,
+        bytes_written,
+        write_started.elapsed()
+    );
 
     Ok(bytes_written)
 }
@@ -2710,6 +2724,8 @@ impl P2pEndpoint {
                     return Err(EndpointError::PeerNotFound(*addr));
                 }
 
+                let send_started = Instant::now();
+
                 let _large_send_permit = if data.len() >= LARGE_SEND_BACKPRESSURE_THRESHOLD {
                     let permit_key = match transport_addr {
                         TransportAddr::Quic(addr) => normalize_socket_addr(addr),
@@ -2720,21 +2736,31 @@ impl P2pEndpoint {
                         .entry(permit_key)
                         .or_insert_with(|| Arc::new(Semaphore::new(LARGE_SEND_PER_ADDR_PERMITS)))
                         .clone();
+                    let permit_wait_started = Instant::now();
                     debug!(
-                        "send({}): waiting for large-send permit ({} bytes)",
+                        "send({}): waiting for large-send permit ({} bytes, available_permits={}, max_per_addr={})",
                         permit_key,
+                        data.len(),
+                        semaphore.available_permits(),
+                        LARGE_SEND_PER_ADDR_PERMITS
+                    );
+                    let permit = semaphore
+                        .acquire_owned()
+                        .await
+                        .map_err(|_| EndpointError::ShuttingDown)?;
+                    debug!(
+                        "send({}): acquired large-send permit after {:?} ({} bytes)",
+                        permit_key,
+                        permit_wait_started.elapsed(),
                         data.len()
                     );
-                    Some(
-                        semaphore
-                            .acquire_owned()
-                            .await
-                            .map_err(|_| EndpointError::ShuttingDown)?,
-                    )
+                    Some(permit)
                 } else {
                     None
                 };
 
+                let open_uni_started = Instant::now();
+                debug!("send({}): opening QUIC uni stream", addr);
                 let mut send_stream =
                     match timeout(STREAM_WRITE_PROGRESS_TIMEOUT, connection.open_uni()).await {
                         Ok(Ok(stream)) => stream,
@@ -2761,6 +2787,11 @@ impl P2pEndpoint {
                             ));
                         }
                     };
+                debug!(
+                    "send({}): opened QUIC uni stream in {:?}",
+                    addr,
+                    open_uni_started.elapsed()
+                );
 
                 let bytes_written =
                     match write_stream_with_progress_timeout(&mut send_stream, *addr, data).await {
@@ -2772,12 +2803,27 @@ impl P2pEndpoint {
                         }
                     };
 
+                let finish_started = Instant::now();
+                debug!(
+                    "send({}): finishing QUIC uni stream after writing {} bytes",
+                    addr, bytes_written
+                );
                 send_stream.finish().map_err(|e| {
                     warn!("send({}): finish failed: {}", addr, e);
                     send_failed(SendFailureStage::Finish, bytes_written, e.to_string())
                 })?;
+                debug!(
+                    "send({}): finished QUIC uni stream in {:?}",
+                    addr,
+                    finish_started.elapsed()
+                );
 
-                debug!("Sent {} bytes to {} via QUIC", data.len(), addr);
+                debug!(
+                    "Sent {} bytes to {} via QUIC (send path took {:?})",
+                    data.len(),
+                    addr,
+                    send_started.elapsed()
+                );
             }
             crate::transport::ProtocolEngine::Constrained => {
                 // Check if we have an established constrained connection for this address

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -90,10 +90,11 @@ const EVENT_CHANNEL_CAPACITY: usize = 256;
 /// event-driven reader-exit detection.
 const STALE_REAPER_INTERVAL: Duration = Duration::from_secs(10);
 
-/// Payload size above which QUIC sends are serialized per remote address.
+/// Payload size above which QUIC sends are serialized per remote address and
+/// wait for the peer to acknowledge receipt after the stream is finished.
 const LARGE_SEND_BACKPRESSURE_THRESHOLD: usize = 1024 * 1024;
 
-/// Number of large sends allowed in flight per remote address.
+/// Number of delivery-ack sends allowed in flight per remote address.
 const LARGE_SEND_PER_ADDR_PERMITS: usize = 1;
 
 /// Per-write chunk size used for stream write progress accounting.
@@ -101,6 +102,10 @@ const STREAM_WRITE_CHUNK_SIZE: usize = 64 * 1024;
 
 /// Maximum time a QUIC stream write may make no forward progress.
 const STREAM_WRITE_PROGRESS_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Maximum time a delivery-ack QUIC send may wait for the peer to acknowledge
+/// receipt of all stream data after the local stream is finished.
+const STREAM_DELIVERY_ACK_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// Application error code used when aborting a stuck/failed send stream.
 /// `0` is the conventional "generic abort, no specific application error"
@@ -567,6 +572,10 @@ pub enum SendFailureStage {
     Write,
     /// The stream could not be finished after all bytes were queued.
     Finish,
+    /// The peer stopped the stream or the connection failed before delivery was acknowledged.
+    DeliveryAck,
+    /// The peer did not acknowledge delivery of the finished stream in time.
+    DeliveryAckTimeout,
 }
 
 impl std::fmt::Display for SendFailureStage {
@@ -577,6 +586,8 @@ impl std::fmt::Display for SendFailureStage {
             Self::WriteProgressTimeout => "write_progress_timeout",
             Self::Write => "write",
             Self::Finish => "finish",
+            Self::DeliveryAck => "delivery_ack",
+            Self::DeliveryAckTimeout => "delivery_ack_timeout",
         };
         f.write_str(label)
     }
@@ -722,6 +733,70 @@ async fn write_stream_with_progress_timeout(
     );
 
     Ok(bytes_written)
+}
+
+async fn wait_for_stream_delivery_ack(
+    send_stream: &crate::high_level::SendStream,
+    addr: SocketAddr,
+    bytes_written: usize,
+) -> Result<(), EndpointError> {
+    let ack_started = Instant::now();
+
+    debug!(
+        "send({}): waiting for peer to acknowledge QUIC stream delivery ({} bytes, timeout {:?})",
+        addr, bytes_written, STREAM_DELIVERY_ACK_TIMEOUT
+    );
+
+    match timeout(STREAM_DELIVERY_ACK_TIMEOUT, send_stream.stopped()).await {
+        Ok(Ok(None)) => {
+            debug!(
+                "send({}): peer acknowledged QUIC stream delivery in {:?}",
+                addr,
+                ack_started.elapsed()
+            );
+            Ok(())
+        }
+        Ok(Ok(Some(error_code))) => {
+            warn!(
+                "send({}): peer stopped QUIC stream before delivery was acknowledged after {:?} (error_code={:?})",
+                addr,
+                ack_started.elapsed(),
+                error_code
+            );
+            Err(send_failed(
+                SendFailureStage::DeliveryAck,
+                bytes_written,
+                format!("peer stopped QUIC stream with error code {error_code:?}"),
+            ))
+        }
+        Ok(Err(e)) => {
+            warn!(
+                "send({}): failed while waiting for QUIC stream delivery ack after {:?}: {}",
+                addr,
+                ack_started.elapsed(),
+                e
+            );
+            Err(send_failed(
+                SendFailureStage::DeliveryAck,
+                bytes_written,
+                e.to_string(),
+            ))
+        }
+        Err(_elapsed) => {
+            warn!(
+                "send({}): timed out after {:?} waiting for peer to acknowledge QUIC stream delivery ({} bytes)",
+                addr, STREAM_DELIVERY_ACK_TIMEOUT, bytes_written
+            );
+            Err(send_failed(
+                SendFailureStage::DeliveryAckTimeout,
+                bytes_written,
+                format!(
+                    "peer did not acknowledge receipt of stream data within {:?}",
+                    STREAM_DELIVERY_ACK_TIMEOUT
+                ),
+            ))
+        }
+    }
 }
 
 /// Broadcast `P2pEvent::PeerConnected` for `addr` exactly once per
@@ -2628,6 +2703,25 @@ impl P2pEndpoint {
     /// - No suitable transport provider is available
     /// - The send operation fails
     pub async fn send(&self, addr: &SocketAddr, data: &[u8]) -> Result<(), EndpointError> {
+        self.send_inner(addr, data, false).await
+    }
+
+    /// Send data to a peer by address and wait for QUIC to confirm that the
+    /// peer received the full stream before returning.
+    pub async fn send_with_delivery_ack(
+        &self,
+        addr: &SocketAddr,
+        data: &[u8],
+    ) -> Result<(), EndpointError> {
+        self.send_inner(addr, data, true).await
+    }
+
+    async fn send_inner(
+        &self,
+        addr: &SocketAddr,
+        data: &[u8],
+        force_delivery_ack: bool,
+    ) -> Result<(), EndpointError> {
         if self.shutdown.is_cancelled() {
             return Err(EndpointError::ShuttingDown);
         }
@@ -2726,7 +2820,9 @@ impl P2pEndpoint {
 
                 let send_started = Instant::now();
 
-                let _large_send_permit = if data.len() >= LARGE_SEND_BACKPRESSURE_THRESHOLD {
+                let wait_for_delivery_ack =
+                    force_delivery_ack || data.len() >= LARGE_SEND_BACKPRESSURE_THRESHOLD;
+                let _delivery_ack_send_permit = if wait_for_delivery_ack {
                     let permit_key = match transport_addr {
                         TransportAddr::Quic(addr) => normalize_socket_addr(addr),
                         _ => normalize_socket_addr(*addr),
@@ -2738,21 +2834,23 @@ impl P2pEndpoint {
                         .clone();
                     let permit_wait_started = Instant::now();
                     debug!(
-                        "send({}): waiting for large-send permit ({} bytes, available_permits={}, max_per_addr={})",
+                        "send({}): waiting for delivery-ack send permit ({} bytes, available_permits={}, max_per_addr={}, forced_delivery_ack={})",
                         permit_key,
                         data.len(),
                         semaphore.available_permits(),
-                        LARGE_SEND_PER_ADDR_PERMITS
+                        LARGE_SEND_PER_ADDR_PERMITS,
+                        force_delivery_ack
                     );
                     let permit = semaphore
                         .acquire_owned()
                         .await
                         .map_err(|_| EndpointError::ShuttingDown)?;
                     debug!(
-                        "send({}): acquired large-send permit after {:?} ({} bytes)",
+                        "send({}): acquired delivery-ack send permit after {:?} ({} bytes, forced_delivery_ack={})",
                         permit_key,
                         permit_wait_started.elapsed(),
-                        data.len()
+                        data.len(),
+                        force_delivery_ack
                     );
                     Some(permit)
                 } else {
@@ -2817,6 +2915,10 @@ impl P2pEndpoint {
                     addr,
                     finish_started.elapsed()
                 );
+
+                if wait_for_delivery_ack {
+                    wait_for_stream_delivery_ack(&send_stream, *addr, bytes_written).await?;
+                }
 
                 debug!(
                     "Sent {} bytes to {} via QUIC (send path took {:?})",

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -54,7 +54,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use tokio::sync::{RwLock, Semaphore, broadcast, mpsc};
+use tokio::sync::{RwLock, broadcast, mpsc};
 use tokio::time::timeout;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
@@ -90,22 +90,11 @@ const EVENT_CHANNEL_CAPACITY: usize = 256;
 /// event-driven reader-exit detection.
 const STALE_REAPER_INTERVAL: Duration = Duration::from_secs(10);
 
-/// Payload size above which QUIC sends are serialized per remote address and
-/// wait for the peer to acknowledge receipt after the stream is finished.
-const LARGE_SEND_BACKPRESSURE_THRESHOLD: usize = 1024 * 1024;
-
-/// Number of delivery-ack sends allowed in flight per remote address.
-const LARGE_SEND_PER_ADDR_PERMITS: usize = 1;
-
-/// Per-write chunk size used for stream write progress accounting.
-const STREAM_WRITE_CHUNK_SIZE: usize = 64 * 1024;
-
 /// Maximum time a QUIC stream write may make no forward progress.
 const STREAM_WRITE_PROGRESS_TIMEOUT: Duration = Duration::from_secs(2);
 
-/// Maximum time a delivery-ack QUIC send may wait for the peer to acknowledge
-/// receipt of all stream data after the local stream is finished.
-const STREAM_DELIVERY_ACK_TIMEOUT: Duration = Duration::from_secs(120);
+/// Maximum time a QUIC stream read may make no forward progress.
+const STREAM_READ_PROGRESS_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Application error code used when aborting a stuck/failed send stream.
 /// `0` is the conventional "generic abort, no specific application error"
@@ -254,9 +243,6 @@ pub struct P2pEndpoint {
     pending_dials: Arc<
         tokio::sync::Mutex<HashMap<SocketAddr, broadcast::Sender<Result<PeerConnection, String>>>>,
     >,
-
-    /// Per-address semaphore used to serialize large QUIC stream messages.
-    large_send_permits: Arc<dashmap::DashMap<SocketAddr, Arc<Semaphore>>>,
 }
 
 impl std::fmt::Debug for P2pEndpoint {
@@ -574,8 +560,6 @@ pub enum SendFailureStage {
     Finish,
     /// The peer stopped the stream or the connection failed before delivery was acknowledged.
     DeliveryAck,
-    /// The peer did not acknowledge delivery of the finished stream in time.
-    DeliveryAckTimeout,
 }
 
 impl std::fmt::Display for SendFailureStage {
@@ -587,7 +571,6 @@ impl std::fmt::Display for SendFailureStage {
             Self::Write => "write",
             Self::Finish => "finish",
             Self::DeliveryAck => "delivery_ack",
-            Self::DeliveryAckTimeout => "delivery_ack_timeout",
         };
         f.write_str(label)
     }
@@ -675,12 +658,12 @@ async fn write_stream_with_progress_timeout(
     );
 
     while bytes_written < data.len() {
-        let end = bytes_written
-            .saturating_add(STREAM_WRITE_CHUNK_SIZE)
-            .min(data.len());
-        let slice = &data[bytes_written..end];
-
-        match timeout(STREAM_WRITE_PROGRESS_TIMEOUT, send_stream.write(slice)).await {
+        match timeout(
+            STREAM_WRITE_PROGRESS_TIMEOUT,
+            send_stream.write(&data[bytes_written..]),
+        )
+        .await
+        {
             Ok(Ok(0)) => {
                 return Err(send_failed(
                     SendFailureStage::Write,
@@ -735,6 +718,79 @@ async fn write_stream_with_progress_timeout(
     Ok(bytes_written)
 }
 
+async fn read_stream_with_progress_timeout(
+    recv_stream: &mut crate::high_level::RecvStream,
+    addr: SocketAddr,
+    size_limit: usize,
+) -> Result<Vec<u8>, EndpointError> {
+    let mut read = Vec::new();
+    let mut start = u64::MAX;
+    let mut end = 0u64;
+    let read_started = Instant::now();
+
+    debug!(
+        "recv({}): starting QUIC stream read (limit {} bytes)",
+        addr, size_limit
+    );
+
+    loop {
+        match timeout(
+            STREAM_READ_PROGRESS_TIMEOUT,
+            recv_stream.read_chunk(usize::MAX, false),
+        )
+        .await
+        {
+            Ok(Ok(Some(chunk))) => {
+                start = start.min(chunk.offset);
+                let chunk_end = chunk.offset.saturating_add(chunk.bytes.len() as u64);
+                if chunk_end.saturating_sub(start) > size_limit as u64 {
+                    warn!(
+                        "recv({}): stream exceeded read limit (limit {} bytes)",
+                        addr, size_limit
+                    );
+                    return Err(EndpointError::Connection(format!(
+                        "incoming stream exceeded read limit of {size_limit} bytes"
+                    )));
+                }
+                end = end.max(chunk_end);
+                read.push((chunk.bytes, chunk.offset));
+            }
+            Ok(Ok(None)) => {
+                if end == 0 {
+                    debug!("recv({}): QUIC stream read completed empty", addr);
+                    return Ok(Vec::new());
+                }
+
+                let mut buffer = vec![0; end.saturating_sub(start) as usize];
+                for (data, offset) in read {
+                    let offset = offset.saturating_sub(start) as usize;
+                    buffer[offset..offset + data.len()].copy_from_slice(&data);
+                }
+                debug!(
+                    "recv({}): QUIC stream read completed ({} bytes in {:?})",
+                    addr,
+                    buffer.len(),
+                    read_started.elapsed()
+                );
+                return Ok(buffer);
+            }
+            Ok(Err(e)) => {
+                warn!("recv({}): stream read failed: {}", addr, e);
+                return Err(EndpointError::Connection(format!(
+                    "stream read failed: {e}"
+                )));
+            }
+            Err(_elapsed) => {
+                warn!(
+                    "recv({}): stream read made no progress for {:?}",
+                    addr, STREAM_READ_PROGRESS_TIMEOUT
+                );
+                return Err(EndpointError::Timeout);
+            }
+        }
+    }
+}
+
 async fn wait_for_stream_delivery_ack(
     send_stream: &crate::high_level::SendStream,
     addr: SocketAddr,
@@ -743,12 +799,12 @@ async fn wait_for_stream_delivery_ack(
     let ack_started = Instant::now();
 
     debug!(
-        "send({}): waiting for peer to acknowledge QUIC stream delivery ({} bytes, timeout {:?})",
-        addr, bytes_written, STREAM_DELIVERY_ACK_TIMEOUT
+        "send({}): waiting for peer to acknowledge QUIC stream delivery ({} bytes)",
+        addr, bytes_written
     );
 
-    match timeout(STREAM_DELIVERY_ACK_TIMEOUT, send_stream.stopped()).await {
-        Ok(Ok(None)) => {
+    match send_stream.stopped().await {
+        Ok(None) => {
             debug!(
                 "send({}): peer acknowledged QUIC stream delivery in {:?}",
                 addr,
@@ -756,7 +812,7 @@ async fn wait_for_stream_delivery_ack(
             );
             Ok(())
         }
-        Ok(Ok(Some(error_code))) => {
+        Ok(Some(error_code)) => {
             warn!(
                 "send({}): peer stopped QUIC stream before delivery was acknowledged after {:?} (error_code={:?})",
                 addr,
@@ -769,7 +825,7 @@ async fn wait_for_stream_delivery_ack(
                 format!("peer stopped QUIC stream with error code {error_code:?}"),
             ))
         }
-        Ok(Err(e)) => {
+        Err(e) => {
             warn!(
                 "send({}): failed while waiting for QUIC stream delivery ack after {:?}: {}",
                 addr,
@@ -780,20 +836,6 @@ async fn wait_for_stream_delivery_ack(
                 SendFailureStage::DeliveryAck,
                 bytes_written,
                 e.to_string(),
-            ))
-        }
-        Err(_elapsed) => {
-            warn!(
-                "send({}): timed out after {:?} waiting for peer to acknowledge QUIC stream delivery ({} bytes)",
-                addr, STREAM_DELIVERY_ACK_TIMEOUT, bytes_written
-            );
-            Err(send_failed(
-                SendFailureStage::DeliveryAckTimeout,
-                bytes_written,
-                format!(
-                    "peer did not acknowledge receipt of stream data within {:?}",
-                    STREAM_DELIVERY_ACK_TIMEOUT
-                ),
             ))
         }
     }
@@ -865,7 +907,6 @@ async fn do_cleanup_connection(
     stats: &RwLock<EndpointStats>,
     event_tx: &broadcast::Sender<P2pEvent>,
     emitted_peer_connected: &dashmap::DashSet<SocketAddr>,
-    large_send_permits: &dashmap::DashMap<SocketAddr, Arc<Semaphore>>,
     addr: &SocketAddr,
     reason: DisconnectReason,
     expected_stable_id: Option<usize>,
@@ -921,7 +962,6 @@ async fn do_cleanup_connection(
     // Allow a future reconnect to broadcast a fresh PeerConnected event.
     for candidate in &variants {
         emitted_peer_connected.remove(candidate);
-        large_send_permits.remove(candidate);
     }
 
     // Step 3: Remove and abort reader task (canonical lock #2)
@@ -1171,7 +1211,6 @@ impl P2pEndpoint {
             reader_handles,
             reader_exit_tx,
             pending_dials: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
-            large_send_permits: Arc::new(dashmap::DashMap::new()),
         };
 
         // Spawn background constrained poller task
@@ -2637,7 +2676,6 @@ impl P2pEndpoint {
             &*self.stats,
             &self.event_tx,
             &self.emitted_peer_connected,
-            &self.large_send_permits,
             addr,
             reason,
             None,
@@ -2666,6 +2704,9 @@ impl P2pEndpoint {
     // === Messaging ===
 
     /// Send data to a peer
+    ///
+    /// For QUIC connections, this waits for the peer to acknowledge receipt of
+    /// the full stream before returning.
     ///
     /// # Transport Selection
     ///
@@ -2703,25 +2744,10 @@ impl P2pEndpoint {
     /// - No suitable transport provider is available
     /// - The send operation fails
     pub async fn send(&self, addr: &SocketAddr, data: &[u8]) -> Result<(), EndpointError> {
-        self.send_inner(addr, data, false).await
+        self.send_inner(addr, data).await
     }
 
-    /// Send data to a peer by address and wait for QUIC to confirm that the
-    /// peer received the full stream before returning.
-    pub async fn send_with_delivery_ack(
-        &self,
-        addr: &SocketAddr,
-        data: &[u8],
-    ) -> Result<(), EndpointError> {
-        self.send_inner(addr, data, true).await
-    }
-
-    async fn send_inner(
-        &self,
-        addr: &SocketAddr,
-        data: &[u8],
-        force_delivery_ack: bool,
-    ) -> Result<(), EndpointError> {
+    async fn send_inner(&self, addr: &SocketAddr, data: &[u8]) -> Result<(), EndpointError> {
         if self.shutdown.is_cancelled() {
             return Err(EndpointError::ShuttingDown);
         }
@@ -2820,43 +2846,6 @@ impl P2pEndpoint {
 
                 let send_started = Instant::now();
 
-                let wait_for_delivery_ack =
-                    force_delivery_ack || data.len() >= LARGE_SEND_BACKPRESSURE_THRESHOLD;
-                let _delivery_ack_send_permit = if wait_for_delivery_ack {
-                    let permit_key = match transport_addr {
-                        TransportAddr::Quic(addr) => normalize_socket_addr(addr),
-                        _ => normalize_socket_addr(*addr),
-                    };
-                    let semaphore = self
-                        .large_send_permits
-                        .entry(permit_key)
-                        .or_insert_with(|| Arc::new(Semaphore::new(LARGE_SEND_PER_ADDR_PERMITS)))
-                        .clone();
-                    let permit_wait_started = Instant::now();
-                    debug!(
-                        "send({}): waiting for delivery-ack send permit ({} bytes, available_permits={}, max_per_addr={}, forced_delivery_ack={})",
-                        permit_key,
-                        data.len(),
-                        semaphore.available_permits(),
-                        LARGE_SEND_PER_ADDR_PERMITS,
-                        force_delivery_ack
-                    );
-                    let permit = semaphore
-                        .acquire_owned()
-                        .await
-                        .map_err(|_| EndpointError::ShuttingDown)?;
-                    debug!(
-                        "send({}): acquired delivery-ack send permit after {:?} ({} bytes, forced_delivery_ack={})",
-                        permit_key,
-                        permit_wait_started.elapsed(),
-                        data.len(),
-                        force_delivery_ack
-                    );
-                    Some(permit)
-                } else {
-                    None
-                };
-
                 let open_uni_started = Instant::now();
                 debug!("send({}): opening QUIC uni stream", addr);
                 let mut send_stream =
@@ -2916,9 +2905,7 @@ impl P2pEndpoint {
                     finish_started.elapsed()
                 );
 
-                if wait_for_delivery_ack {
-                    wait_for_stream_delivery_ack(&send_stream, *addr, bytes_written).await?;
-                }
+                wait_for_stream_delivery_ack(&send_stream, *addr, bytes_written).await?;
 
                 debug!(
                     "Sent {} bytes to {} via QUIC (send path took {:?})",
@@ -3241,7 +3228,6 @@ impl P2pEndpoint {
         // Abort all background reader tasks
         self.reader_tasks.lock().await.abort_all();
         self.reader_handles.write().await.clear();
-        self.large_send_permits.clear();
 
         // Disconnect all peers
         let addrs: Vec<SocketAddr> = self.connected_peers.read().await.keys().copied().collect();
@@ -3292,11 +3278,14 @@ impl P2pEndpoint {
                     }
                 };
 
-                let data = match recv_stream.read_to_end(max_read_bytes).await {
+                let data =
+                    match read_stream_with_progress_timeout(&mut recv_stream, addr, max_read_bytes)
+                        .await
+                    {
                     Ok(data) if data.is_empty() => continue,
                     Ok(data) => data,
                     Err(e) => {
-                        info!("Reader task for {}: read_to_end error: {}", addr, e);
+                        info!("Reader task for {}: stream read error: {}", addr, e);
                         break;
                     }
                 };
@@ -3550,7 +3539,6 @@ impl P2pEndpoint {
         let stats = Arc::clone(&self.stats);
         let reader_handles = Arc::clone(&self.reader_handles);
         let emitted_peer_connected = Arc::clone(&self.emitted_peer_connected);
-        let large_send_permits = Arc::clone(&self.large_send_permits);
         let shutdown = self.shutdown.clone();
 
         tokio::spawn(async move {
@@ -3580,7 +3568,6 @@ impl P2pEndpoint {
                     &stats,
                     &event_tx,
                     &emitted_peer_connected,
-                    &large_send_permits,
                     &addr,
                     DisconnectReason::Timeout,
                     Some(stable_id),
@@ -3611,7 +3598,6 @@ impl P2pEndpoint {
         let stats = Arc::clone(&self.stats);
         let reader_handles = Arc::clone(&self.reader_handles);
         let emitted_peer_connected = Arc::clone(&self.emitted_peer_connected);
-        let large_send_permits = Arc::clone(&self.large_send_permits);
         let shutdown = self.shutdown.clone();
 
         tokio::spawn(async move {
@@ -3653,7 +3639,6 @@ impl P2pEndpoint {
                         &stats,
                         &event_tx,
                         &emitted_peer_connected,
-                        &large_send_permits,
                         addr,
                         DisconnectReason::Timeout,
                         None,
@@ -3834,11 +3819,17 @@ impl P2pEndpoint {
                                 }
                             };
 
-                            let data = match recv_stream.read_to_end(max_read_bytes).await {
+                            let data = match read_stream_with_progress_timeout(
+                                &mut recv_stream,
+                                addr,
+                                max_read_bytes,
+                            )
+                            .await
+                            {
                                 Ok(data) if data.is_empty() => continue,
                                 Ok(data) => data,
                                 Err(e) => {
-                                    info!("Reader task for {} (forwarder): read_to_end error: {}", addr, e);
+                                    info!("Reader task for {} (forwarder): stream read error: {}", addr, e);
                                     break;
                                 }
                             };
@@ -3917,7 +3908,6 @@ impl Clone for P2pEndpoint {
             reader_handles: Arc::clone(&self.reader_handles),
             reader_exit_tx: self.reader_exit_tx.clone(),
             pending_dials: Arc::clone(&self.pending_dials),
-            large_send_permits: Arc::clone(&self.large_send_permits),
         }
     }
 }

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -94,9 +94,6 @@ const STALE_REAPER_INTERVAL: Duration = Duration::from_secs(10);
 /// Maximum time a QUIC stream write may make no forward progress.
 const STREAM_WRITE_PROGRESS_TIMEOUT: Duration = Duration::from_secs(2);
 
-/// Maximum time a QUIC stream read may make no forward progress.
-const STREAM_READ_PROGRESS_TIMEOUT: Duration = Duration::from_secs(10);
-
 /// Payload size at or above which QUIC sends wait for the peer to acknowledge
 /// receipt of the full stream after `finish()`. Smaller payloads return as
 /// soon as the local stack has accepted the data, avoiding an extra RTT for
@@ -867,7 +864,7 @@ async fn write_stream_with_progress_timeout(
     Ok(bytes_written)
 }
 
-async fn read_stream_with_progress_timeout(
+async fn read_stream(
     recv_stream: &mut crate::high_level::RecvStream,
     addr: SocketAddr,
     size_limit: usize,
@@ -883,13 +880,8 @@ async fn read_stream_with_progress_timeout(
     );
 
     loop {
-        match timeout(
-            STREAM_READ_PROGRESS_TIMEOUT,
-            recv_stream.read_chunk(usize::MAX, false),
-        )
-        .await
-        {
-            Ok(Ok(Some(chunk))) => {
+        match recv_stream.read_chunk(usize::MAX, false).await {
+            Ok(Some(chunk)) => {
                 start = start.min(chunk.offset);
                 let chunk_end = chunk.offset.saturating_add(chunk.bytes.len() as u64);
                 if chunk_end.saturating_sub(start) > size_limit as u64 {
@@ -904,7 +896,7 @@ async fn read_stream_with_progress_timeout(
                 end = end.max(chunk_end);
                 read.push((chunk.bytes, chunk.offset));
             }
-            Ok(Ok(None)) => {
+            Ok(None) => {
                 if end == 0 {
                     debug!("recv({}): QUIC stream read completed empty", addr);
                     return Ok(Vec::new());
@@ -923,18 +915,11 @@ async fn read_stream_with_progress_timeout(
                 );
                 return Ok(buffer);
             }
-            Ok(Err(e)) => {
+            Err(e) => {
                 warn!("recv({}): stream read failed: {}", addr, e);
                 return Err(EndpointError::Connection(format!(
                     "stream read failed: {e}"
                 )));
-            }
-            Err(_elapsed) => {
-                warn!(
-                    "recv({}): stream read made no progress for {:?}",
-                    addr, STREAM_READ_PROGRESS_TIMEOUT
-                );
-                return Err(EndpointError::Timeout);
             }
         }
     }
@@ -1005,8 +990,7 @@ async fn dispatch_inbound_stream(
     reader_label: &'static str,
     send_mode: InboundDataSendMode,
 ) {
-    let data = match read_stream_with_progress_timeout(&mut recv_stream, addr, max_read_bytes).await
-    {
+    let data = match read_stream(&mut recv_stream, addr, max_read_bytes).await {
         Ok(data) if data.is_empty() => return,
         Ok(data) => data,
         Err(e) => {

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -96,6 +96,12 @@ const STREAM_WRITE_PROGRESS_TIMEOUT: Duration = Duration::from_secs(2);
 /// Maximum time a QUIC stream read may make no forward progress.
 const STREAM_READ_PROGRESS_TIMEOUT: Duration = Duration::from_secs(10);
 
+/// Payload size at or above which QUIC sends wait for the peer to acknowledge
+/// receipt of the full stream after `finish()`. Smaller payloads return as
+/// soon as the local stack has accepted the data, avoiding an extra RTT for
+/// small request/response traffic.
+const LARGE_SEND_DELIVERY_ACK_THRESHOLD: usize = 64 * 1024;
+
 /// Maximum number of inbound uni streams read concurrently per QUIC connection.
 const MAX_CONCURRENT_INBOUND_STREAM_READS_PER_CONNECTION: usize = 32;
 
@@ -2867,8 +2873,10 @@ impl P2pEndpoint {
 
     /// Send data to a peer
     ///
-    /// For QUIC connections, this waits for the peer to acknowledge receipt of
-    /// the full stream before returning.
+    /// For QUIC connections with payloads at or above
+    /// `LARGE_SEND_DELIVERY_ACK_THRESHOLD` bytes, this waits for the peer to
+    /// acknowledge receipt of the full stream before returning. Smaller
+    /// payloads return as soon as the local stack has accepted the data.
     ///
     /// # Transport Selection
     ///
@@ -3067,7 +3075,9 @@ impl P2pEndpoint {
                     finish_started.elapsed()
                 );
 
-                wait_for_stream_delivery_ack(&send_stream, *addr, bytes_written).await?;
+                if data.len() >= LARGE_SEND_DELIVERY_ACK_THRESHOLD {
+                    wait_for_stream_delivery_ack(&send_stream, *addr, bytes_written).await?;
+                }
 
                 debug!(
                     "Sent {} bytes to {} via QUIC (send path took {:?})",

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -101,7 +101,7 @@ const STREAM_READ_PROGRESS_TIMEOUT: Duration = Duration::from_secs(10);
 /// receipt of the full stream after `finish()`. Smaller payloads return as
 /// soon as the local stack has accepted the data, avoiding an extra RTT for
 /// small request/response traffic.
-const LARGE_SEND_DELIVERY_ACK_THRESHOLD: usize = 64 * 1024;
+const LARGE_SEND_DELIVERY_ACK_THRESHOLD: usize = 16 * 1024;
 
 /// Maximum number of inbound uni streams read concurrently per QUIC connection.
 const MAX_CONCURRENT_INBOUND_STREAM_READS_PER_CONNECTION: usize = 32;

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -180,11 +180,11 @@ impl PendingDialGuard {
         if !self.active {
             return;
         }
+
+        let entry = remove_pending_dial_if_owned(&self.pending_dials, self.target, self.id).await;
         self.active = false;
 
-        let Some(entry) =
-            remove_pending_dial_if_owned(&self.pending_dials, self.target, self.id).await
-        else {
+        let Some(entry) = entry else {
             return;
         };
 
@@ -4280,6 +4280,50 @@ mod tests {
         })
         .await
         .expect("pending dial guard cleared entry");
+    }
+
+    #[tokio::test]
+    async fn test_pending_dial_guard_abort_during_complete_clears_owned_entry() {
+        let target: SocketAddr = "127.0.0.1:12347".parse().expect("valid addr");
+        let pending_dials = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        let (tx, _) = broadcast::channel(PENDING_DIAL_BROADCAST_CAPACITY);
+        let id = 44;
+
+        {
+            let mut pending = pending_dials.lock().await;
+            pending.insert(
+                target,
+                PendingDial {
+                    id,
+                    tx,
+                    started_at: Instant::now(),
+                },
+            );
+        }
+
+        let pending_lock = pending_dials.lock().await;
+        let pending_dials_for_task = Arc::clone(&pending_dials);
+        let handle = tokio::spawn(async move {
+            let mut guard = PendingDialGuard::new(pending_dials_for_task, target, id);
+            let result: Result<(PeerConnection, ConnectionMethod), EndpointError> =
+                Err(EndpointError::Timeout);
+            guard.complete(&result).await;
+        });
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        handle.abort();
+        drop(pending_lock);
+
+        timeout(Duration::from_secs(1), async {
+            loop {
+                if pending_dials.lock().await.is_empty() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("aborted pending dial guard cleared entry");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add delivery acknowledgement handling for larger QUIC sends while keeping small sends fast.
- Bound shared pending-dial waits and clean up stale or cancelled in-flight dial entries.
- Dispatch inbound QUIC stream reads concurrently with per-connection limits to avoid reader stalls.
- Track the owning endpoint for NAT peer-id registration, including proactive MASQUE relay connections.
- Batch MASQUE relay stream frames and add relay generation checks so stale advertisements are ignored.
- Cap the client initial congestion window at 1 MB to avoid large startup bursts.

## Testing
- Not run in this metadata-only update.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bundles a set of stability and performance improvements across the QUIC P2P layer, MASQUE relay server, and NAT traversal API. The most significant changes are a new concurrent inbound stream reader, delivery-ack gating for large sends, bounded pending-dial deduplication, relay frame batching on both client and server sides, and proper per-endpoint routing of peer-id registration.

- **`p2p_endpoint.rs`**: Replaces the serial `read_to_end` reader loop with a `run_quic_reader_task` that dispatches up to 32 concurrent per-stream reads via a `JoinSet`, removes the `large_send_permits` semaphore in favour of `stopped()`-based delivery acknowledgment for payloads \u2265 16 KB, and rewrites pending-dial deduplication with `PendingDialGuard` and bounded timeouts.
- **`nat_traversal_api.rs`**: Introduces `connection_endpoints` to track which QUIC endpoint owns each connection so that `register_connection_peer_id` and `find_connection_by_peer_id` route to the correct endpoint; adds a `relay_generation` counter to guard relay advertisement against stale state after a reset; caps the client initial congestion window at 1 MB.
- **`masque/relay_server.rs` & `relay_socket.rs`**: Batches outbound relay frames into a single `write_all` call (up to 64 frames or 64 KB), adds structured `close_reason` logging, and reduces hot-path log levels from `debug` to `trace`.

<h3>Confidence Score: 3/5</h3>

The relay batching and NAT traversal changes are solid, but the new `read_stream` function has a memory-limit bypass reachable by any peer sending non-contiguous out-of-order chunks — should be fixed before merging.

The new `read_stream` function reads with `ordered=false`, which allows out-of-order chunk delivery. The size-limit check compares per-chunk span rather than the full accumulated span, so two chunks that each individually pass can together cause a buffer allocation up to 2× the configured limit. Every inbound QUIC connection goes through this path.

src/p2p_endpoint.rs — specifically the `read_stream` function and its per-chunk size limit check.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/p2p_endpoint.rs | Large refactor: replaces serial read-to-end with a concurrent per-stream `run_quic_reader_task`, removes the `large_send_permits` semaphore in favour of a delivery-ack wait, rewrites pending-dial deduplication with bounded timeouts and a `PendingDialGuard`. Contains a size-limit bypass in `read_stream` when unordered chunks span non-contiguous offsets. |
| src/nat_traversal_api.rs | Adds `connection_endpoints` map to route peer-id registration to the correct owning QUIC endpoint, introduces `relay_generation` counter to guard relay advertisement lifecycle against stale state, and caps the client initial congestion window at 1 MB. Minor inconsistency in `next_relay_generation` on u64 wrap. |
| src/masque/relay_server.rs | Optimizes relay-stream writes by batching up to 64 frames or 64 KB per `write_all` call, adds structured close-reason logging, and reduces hot-path log level from `debug` to `trace`. No logical issues found. |
| src/masque/relay_socket.rs | Client-side relay-socket write path receives the same batch optimisation as the server, coalescing outbound relay frames into a single `write_all`. Hot-path `debug` logs downgraded to `trace`. No issues found. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App
    participant P2pEndpoint
    participant ReaderTask
    participant NatTraversal
    participant RelayServer
    participant RelaySocket

    App->>P2pEndpoint: send(addr, data)
    P2pEndpoint->>P2pEndpoint: open_uni()
    P2pEndpoint->>P2pEndpoint: write_stream_with_progress_timeout()
    P2pEndpoint->>P2pEndpoint: finish()
    alt "data.len() >= 16 KB"
        P2pEndpoint->>P2pEndpoint: wait_for_stream_delivery_ack stopped()
        P2pEndpoint-->>App: Ok after transport ACK
    else small payload
        P2pEndpoint-->>App: Ok immediately after finish
    end

    NatTraversal->>NatTraversal: accept new connection
    NatTraversal->>NatTraversal: track_connection_endpoint
    NatTraversal->>P2pEndpoint: spawn run_quic_reader_task
    loop per inbound stream up to 32 concurrent
        ReaderTask->>ReaderTask: accept_uni
        ReaderTask->>ReaderTask: "read_stream ordered=false"
        ReaderTask-->>App: data_tx.send
    end

    App->>P2pEndpoint: connect_with_fallback
    alt in-flight dial exists
        P2pEndpoint->>P2pEndpoint: subscribe PendingDial broadcast
        P2pEndpoint->>P2pEndpoint: timeout remaining_wait rx.recv
        P2pEndpoint-->>App: Ok result or retry locally
    else first dial
        P2pEndpoint->>P2pEndpoint: PendingDialGuard new
        P2pEndpoint->>NatTraversal: run_fallback_strategy
        P2pEndpoint->>P2pEndpoint: guard.complete result
        P2pEndpoint-->>App: Ok conn method
    end

    RelaySocket->>RelaySocket: send_rx.recv first frame
    RelaySocket->>RelaySocket: batch up to 64 frames via try_recv
    RelaySocket->>RelaySocket: send_stream.write_all batch

    RelayServer->>RelayServer: fwd_rx.recv first WriterItem
    RelayServer->>RelayServer: batch frames via try_recv
    RelayServer->>RelayServer: send_stream.write_all batch
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/p2p_endpoint.rs:884-897
The size-limit guard only compares `chunk_end – start` for the current chunk, but does not account for the full span accumulated across all out-of-order chunks. Because `read_chunk` is called with `ordered=false`, a peer can send two non-contiguous chunks that each pass the individual check yet together span up to `2 × size_limit` bytes. The `vec![0; end - start]` allocation at the end will then exceed the limit. Concretely, with `size_limit=100`: chunk at offset 60 len 60 → check passes (60 ≤ 100); chunk at offset 0 len 60 → check passes (60 ≤ 100); buffer = 120 bytes.

```suggestion
            Ok(Some(chunk)) => {
                let new_start = start.min(chunk.offset);
                let chunk_end = chunk.offset.saturating_add(chunk.bytes.len() as u64);
                let new_end = end.max(chunk_end);
                if new_end.saturating_sub(new_start) > size_limit as u64 {
                    warn!(
                        "recv({}): stream exceeded read limit (limit {} bytes)",
                        addr, size_limit
                    );
                    return Err(EndpointError::Connection(format!(
                        "incoming stream exceeded read limit of {size_limit} bytes"
                    )));
                }
                start = new_start;
                end = new_end;
                read.push((chunk.bytes, chunk.offset));
```

### Issue 2 of 2
src/nat_traversal_api.rs:3903-3907
`fetch_add` returns the **previous** value, so on u64 wrap-around `fetch_add(1)` returns `u64::MAX` and the atomic rolls over to `0`. `saturating_add(1)` on `u64::MAX` stays at `u64::MAX`, so the returned generation becomes `u64::MAX` while `current_relay_generation()` returns `0`. Any subsequent `relay_generation_matches` call would fail, silently dropping all relay advertisements until a new relay is established. Using `wrapping_add` keeps the returned value in sync with the atomic.

```suggestion
    fn next_relay_generation(&self) -> u64 {
        self.relay_generation
            .fetch_add(1, std::sync::atomic::Ordering::AcqRel)
            .wrapping_add(1)
    }
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: guard relay advertisement lifecycle"](https://github.com/saorsa-labs/saorsa-transport/commit/d9da2be230c72fda2da3fccb92f2b42f08c7df6e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31459772)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->