### PR TITLE
feat(nat): opt-in reachability gate for ADD_ADDRESS-derived candidates

### DIFF
--- a/src/config/transport.rs
+++ b/src/config/transport.rs
@@ -75,6 +75,17 @@ pub struct TransportConfig {
 
     /// Allow loopback addresses as valid NAT traversal candidates
     pub(crate) allow_loopback: bool,
+
+    /// When true, candidates received via `ADD_ADDRESS` frames are gated on
+    /// an out-of-band reachability probe before being eligible for
+    /// `PATH_CHALLENGE` validation. This closes the amplification vector
+    /// where a single peer can advertise an unreachable IP and cause every
+    /// other peer to spend dial budget on it (see prod log 2026-05-15:
+    /// `5.250.190.226 → 75.48.86.24`, 35 592 dials across 24 nodes).
+    ///
+    /// Defaults to `false` for backwards compatibility. Loopback addresses
+    /// always skip the probe (devnet correctness).
+    pub(crate) probe_advertised_addresses: bool,
 }
 
 impl TransportConfig {
@@ -480,6 +491,18 @@ impl TransportConfig {
         self.allow_loopback = allow;
         self
     }
+
+    /// Gate `ADD_ADDRESS`-derived candidates on a reachability probe before
+    /// allowing `PATH_CHALLENGE` validation. When `false` (default) the
+    /// previous behaviour is preserved: candidates are dialed immediately.
+    ///
+    /// Loopback addresses always skip the probe regardless of this setting.
+    ///
+    /// Default: `false`
+    pub fn probe_advertised_addresses(&mut self, enabled: bool) -> &mut Self {
+        self.probe_advertised_addresses = enabled;
+        self
+    }
 }
 
 impl Default for TransportConfig {
@@ -533,6 +556,7 @@ impl Default for TransportConfig {
                 ml_dsa_65: false,
             }),
             allow_loopback: false,
+            probe_advertised_addresses: false,
         }
     }
 }
@@ -569,6 +593,7 @@ impl fmt::Debug for TransportConfig {
             address_discovery_config,
             pqc_algorithms,
             allow_loopback,
+            probe_advertised_addresses,
         } = self;
         fmt.debug_struct("TransportConfig")
             .field("max_concurrent_bidi_streams", max_concurrent_bidi_streams)
@@ -601,6 +626,7 @@ impl fmt::Debug for TransportConfig {
             .field("address_discovery_config", address_discovery_config)
             .field("pqc_algorithms", pqc_algorithms)
             .field("allow_loopback", allow_loopback)
+            .field("probe_advertised_addresses", probe_advertised_addresses)
             .finish_non_exhaustive()
     }
 }

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -1780,6 +1780,71 @@ impl Connection {
                 // Enqueue PunchMeNow frame for transmission
                 self.spaces[SpaceId::Data].pending.punch_me_now.push(punch);
             }
+            AdvertisedAddressProbeResult {
+                candidate_addr,
+                reachable,
+            } => {
+                self.handle_advertised_address_probe_result(
+                    candidate_addr,
+                    reachable,
+                    Instant::now(),
+                );
+            }
+        }
+    }
+
+    /// Handle the result of an out-of-band reachability probe issued for an
+    /// `ADD_ADDRESS`-derived candidate. Promotes a `Probing` candidate to
+    /// `New` (so the existing `PATH_CHALLENGE` machinery picks it up) on
+    /// success, or removes it on failure.
+    fn handle_advertised_address_probe_result(
+        &mut self,
+        candidate_addr: SocketAddr,
+        reachable: bool,
+        now: Instant,
+    ) {
+        let nat_state = match self.nat_traversal.as_mut() {
+            Some(state) => state,
+            None => {
+                trace!(
+                    "AdvertisedAddressProbeResult ignored — NAT traversal not initialized for {}",
+                    candidate_addr
+                );
+                return;
+            }
+        };
+        if reachable {
+            if nat_state.promote_probed_candidate(candidate_addr, now) {
+                info!(
+                    "Probe succeeded — promoted advertised candidate {} to New",
+                    candidate_addr
+                );
+                // Trigger validation on the now-eligible candidate. Errors
+                // here are non-fatal: the candidate is in `New` state and
+                // will be picked up by `send_nat_traversal_challenge` on
+                // the next opportunity.
+                if let Err(e) = self.trigger_candidate_validation(candidate_addr, now) {
+                    debug!(
+                        "trigger_candidate_validation after probe-success deferred: {}",
+                        e
+                    );
+                }
+            } else {
+                trace!(
+                    "AdvertisedAddressProbeResult(reachable=true) had no Probing candidate for {}",
+                    candidate_addr
+                );
+            }
+        } else if nat_state.drop_unreachable_candidate(candidate_addr) {
+            info!(
+                "Probe failed — dropped advertised candidate {} without dialing",
+                candidate_addr
+            );
+        } else {
+            trace!(
+                "AdvertisedAddressProbeResult(reachable=false) had no Probing candidate for {}",
+                candidate_addr
+            );
         }
     }
 
@@ -4768,6 +4833,7 @@ impl Connection {
             max_candidates,
             coordination_timeout,
             self.config.allow_loopback,
+            self.config.probe_advertised_addresses,
         ));
 
         trace!("NAT traversal initialized for symmetric P2P node");
@@ -4966,6 +5032,7 @@ impl Connection {
             8,
             Duration::from_secs(10),
             self.config.allow_loopback,
+            self.config.probe_advertised_addresses,
         ));
     }
 
@@ -4994,6 +5061,26 @@ impl Connection {
         add_address: &crate::frame::AddAddress,
         now: Instant,
     ) -> Result<(), TransportError> {
+        // Decide probe-gate state up front. When the gate is off we want
+        // BYTE-IDENTICAL behaviour to the pre-patch path: no advertiser
+        // hashing, no log format changes, no extra endpoint events.
+        let probe_gate_enabled = self
+            .nat_traversal
+            .as_ref()
+            .map(|s| s.probe_advertised_addresses)
+            .unwrap_or(false);
+
+        // Compute the advertiser fingerprint ONLY when the gate is on (it
+        // is used as the source-attribution key for the eventual probe
+        // result). Computing it eagerly under the off path would add a
+        // per-frame heap allocation (path.remote.to_string().into_bytes())
+        // for no benefit.
+        let advertiser = if probe_gate_enabled {
+            Some(self.derive_peer_id_from_connection())
+        } else {
+            None
+        };
+
         let nat_state = self.nat_traversal.as_mut().ok_or_else(|| {
             TransportError::PROTOCOL_VIOLATION("AddAddress frame without NAT traversal negotiation")
         })?;
@@ -5016,19 +5103,43 @@ impl Connection {
             return Ok(());
         }
 
+        // Decide whether to defer validation behind a reachability probe.
+        //
+        // Skip-conditions (apply probe = false, current behaviour preserved):
+        //   - The probe-gate is disabled in transport config.
+        //   - The advertised IP is loopback (devnet/local-test correctness).
+        //
+        // The peer-IP-matches-advertised-IP case is already short-circuited
+        // by the `peer_addr.ip() == normalized_addr.ip()` early-return
+        // above, so it cannot reach this point.
+        let is_loopback = normalized_addr.ip().is_loopback();
+        let probing = probe_gate_enabled && !is_loopback;
+
         match nat_state.add_remote_candidate(
             add_address.sequence,
             normalized_addr,
             add_address.priority,
             now,
+            advertiser,
+            probing,
         ) {
             Ok(()) => {
-                info!(
-                    "Added remote candidate: {} (seq={}, priority={})",
-                    normalized_addr, add_address.sequence, add_address.priority
-                );
+                if probing {
+                    info!(
+                        "Added remote candidate: {} (seq={}, priority={}, probing=true)",
+                        normalized_addr, add_address.sequence, add_address.priority
+                    );
+                } else {
+                    info!(
+                        "Added remote candidate: {} (seq={}, priority={})",
+                        normalized_addr, add_address.sequence, add_address.priority
+                    );
+                }
 
-                // Notify the endpoint so the DHT routing table can be updated
+                // Notify the endpoint so the DHT routing table can be updated.
+                // We emit this regardless of probe-gate state — the upper
+                // layer (saorsa-core) may still want to learn about the
+                // advertisement even if we don't dial it.
                 self.endpoint_events.push_back(
                     crate::shared::EndpointEventInner::PeerAddressAdvertised {
                         peer_addr: self.path.remote,
@@ -5036,8 +5147,31 @@ impl Connection {
                     },
                 );
 
-                // Trigger validation of this new candidate
-                self.trigger_candidate_validation(normalized_addr, now)?;
+                if probing {
+                    // Invariant: when `probing` is true, `probe_gate_enabled`
+                    // is true, so we computed `advertiser = Some(_)` above.
+                    // Unwrap safely with default for the impossible None
+                    // case; if a future refactor changes the invariant the
+                    // probe target loses its source-attribution rather
+                    // than panicking.
+                    let advertiser_id = advertiser.unwrap_or_default();
+                    // Defer PATH_CHALLENGE: ask the high-level endpoint to
+                    // run an out-of-band reachability probe. The connection
+                    // will either receive an `AdvertisedAddressProbeResult`
+                    // event promoting the candidate to `New`, or no event
+                    // at all (in which case the candidate stays in
+                    // `Probing` and is never dialed).
+                    self.endpoint_events.push_back(
+                        crate::shared::EndpointEventInner::ProbeAdvertisedAddress {
+                            peer_addr: self.path.remote,
+                            candidate_addr: normalized_addr,
+                            advertiser: advertiser_id,
+                        },
+                    );
+                } else {
+                    // Trigger validation of this new candidate
+                    self.trigger_candidate_validation(normalized_addr, now)?;
+                }
                 Ok(())
             }
             Err(NatTraversalError::TooManyCandidates) => Err(TransportError::PROTOCOL_VIOLATION(
@@ -5722,6 +5856,7 @@ impl Connection {
                 state: nat_traversal::CandidateState::New,
                 attempt_count: 0,
                 last_attempt: None,
+                advertiser: None,
             },
         );
 

--- a/src/connection/nat_traversal.rs
+++ b/src/connection/nat_traversal.rs
@@ -57,6 +57,14 @@ pub(super) struct NatTraversalState {
     pub(super) bootstrap_coordinator: Option<BootstrapCoordinator>,
     /// Port predictor for symmetric NAT traversal
     pub(super) port_predictor: PortPredictor,
+    /// When true, ADD_ADDRESS-derived candidates are placed in
+    /// `CandidateState::Probing` rather than `New`, deferring `PATH_CHALLENGE`
+    /// validation until an out-of-band reachability probe (run by the
+    /// high-level endpoint) reports success. Defaults to `false` for
+    /// backwards compatibility — flipping this on closes the
+    /// `5.250.190.226 → 75.48.86.24`-style amplification vector where one
+    /// peer can cause many peers to dial an unreachable address.
+    pub(super) probe_advertised_addresses: bool,
 }
 // v0.13.0: NatTraversalRole enum removed - all nodes are symmetric P2P nodes
 // Every node can initiate, accept, and coordinate NAT traversal without role distinction.
@@ -77,6 +85,17 @@ pub(super) struct AddressCandidate {
     pub(super) attempt_count: u32,
     /// Last validation attempt time
     pub(super) last_attempt: Option<Instant>,
+    /// PeerId fingerprint of the connected peer that advertised this
+    /// address via an `ADD_ADDRESS` frame. `None` for locally-derived
+    /// candidates (Local, Predicted, PortMapped, Observed). Local-only
+    /// state — never serialized over the wire.
+    ///
+    /// Used to attribute reachability-probe failures back to the source.
+    /// A future PR may wire this into trust/reputation events; today it is
+    /// purely informational and accessed only via the test helper
+    /// `advertiser()` below.
+    #[allow(dead_code)]
+    pub(super) advertiser: Option<[u8; 32]>,
 }
 /// How an address candidate was discovered
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -106,6 +125,13 @@ pub enum CandidateSource {
 pub enum CandidateState {
     /// Newly discovered, not yet tested
     New,
+    /// ADD_ADDRESS-derived candidate awaiting an out-of-band reachability
+    /// probe before being promoted to `New` (and therefore eligible for
+    /// `PATH_CHALLENGE` validation). Used only when the receiving connection
+    /// has `probe_advertised_addresses` enabled. While in this state the
+    /// candidate is invisible to `get_validation_candidates`, so no budget
+    /// is spent dialing the address.
+    Probing,
     /// Currently being validated
     Validating,
     /// Successfully validated and usable
@@ -1824,6 +1850,7 @@ impl NatTraversalState {
         max_candidates: u32,
         coordination_timeout: Duration,
         allow_loopback: bool,
+        probe_advertised_addresses: bool,
     ) -> Self {
         // v0.13.0: All nodes can coordinate - always create coordinator
         let bootstrap_coordinator = Some(BootstrapCoordinator::new(
@@ -1848,6 +1875,7 @@ impl NatTraversalState {
             resource_manager: ResourceCleanupCoordinator::new(),
             bootstrap_coordinator,
             port_predictor: PortPredictor::new(PortPredictorConfig::default()),
+            probe_advertised_addresses,
         }
     }
 
@@ -1870,13 +1898,22 @@ impl NatTraversalState {
         VarInt::from_u32(current)
     }
 
-    /// Add a remote candidate from AddAddress frame with security validation
+    /// Add a remote candidate from AddAddress frame with security validation.
+    ///
+    /// `advertiser` is the PeerId fingerprint of the connected peer that sent
+    /// the `ADD_ADDRESS` frame. Stored for source attribution; never sent on
+    /// the wire. `probing` selects the initial state: when `true` the
+    /// candidate enters `CandidateState::Probing` (gated by an out-of-band
+    /// reachability probe), otherwise it enters `CandidateState::New` and is
+    /// immediately eligible for `PATH_CHALLENGE` validation.
     pub(super) fn add_remote_candidate(
         &mut self,
         sequence: VarInt,
         address: SocketAddr,
         priority: VarInt,
         now: Instant,
+        advertiser: Option<[u8; 32]>,
+        probing: bool,
     ) -> Result<(), NatTraversalError> {
         // Resource management: Check if we should reject new resources
         if self.should_reject_new_resources(now) {
@@ -1925,14 +1962,20 @@ impl NatTraversalState {
             return Err(NatTraversalError::DuplicateAddress);
         }
 
+        let initial_state = if probing {
+            CandidateState::Probing
+        } else {
+            CandidateState::New
+        };
         let candidate = AddressCandidate {
             address,
             priority: priority.into_inner() as u32,
             source: CandidateSource::Peer,
             discovered_at: now,
-            state: CandidateState::New,
+            state: initial_state,
             attempt_count: 0,
             last_attempt: None,
+            advertiser,
         };
 
         self.remote_candidates.insert(sequence, candidate);
@@ -1941,21 +1984,100 @@ impl NatTraversalState {
         // Incrementally add pairs for this new remote candidate (O(n) vs O(n*m))
         self.add_pairs_for_remote_candidate(sequence, now);
 
-        // Feed the predictor and potentially generate new candidates
-        // Only consider global unicast addresses (public IPs) for prediction
-        if !address.ip().is_loopback() && !address.ip().is_unspecified() {
-            // Record the observation
+        // Feed the port predictor only for candidates we have NOT deferred
+        // behind a reachability probe. An attacker advertising garbage IPs
+        // could otherwise pollute the predictor with predictions that
+        // generate new candidates outside the probe gate. Probed
+        // candidates feed the predictor in `promote_probed_candidate`
+        // after the probe succeeds.
+        // Only consider global unicast addresses (public IPs) for prediction.
+        if !probing && !address.ip().is_loopback() && !address.ip().is_unspecified() {
             self.port_predictor.record_observation(address, now);
-
-            // Try to generate predictions immediately
             self.generate_predicted_candidates(address.ip(), now);
         }
 
         trace!(
-            "Added remote candidate: {} with priority {}",
-            address, priority
+            "Added remote candidate: {} with priority {} probing={}",
+            address, priority, probing
         );
         Ok(())
+    }
+
+    /// Promote a candidate from `Probing` → `New` after a successful
+    /// reachability probe, generating candidate pairs so it becomes eligible
+    /// for `PATH_CHALLENGE` validation.
+    ///
+    /// Returns `true` if a candidate was promoted, `false` otherwise (no
+    /// matching candidate, or it had already moved to a different state — e.g.
+    /// a duplicate ADD_ADDRESS arrived in the meantime that already promoted
+    /// it).
+    pub(super) fn promote_probed_candidate(
+        &mut self,
+        candidate_addr: SocketAddr,
+        now: Instant,
+    ) -> bool {
+        // Find the sequence id for the probing candidate matching this address.
+        let target_seq = self.remote_candidates.iter().find_map(|(seq, c)| {
+            if c.address == candidate_addr && c.state == CandidateState::Probing {
+                Some(*seq)
+            } else {
+                None
+            }
+        });
+        let Some(seq) = target_seq else {
+            return false;
+        };
+        // Snapshot the address before promotion so we can feed the port
+        // predictor (which we deliberately skipped at admission time —
+        // see add_remote_candidate). Doing it here means a malicious
+        // advertiser cannot pollute the predictor with garbage IPs.
+        let promoted_addr = self.remote_candidates.get(&seq).map(|c| c.address);
+        if let Some(c) = self.remote_candidates.get_mut(&seq) {
+            c.state = CandidateState::New;
+        }
+        // Generate pairs now that the candidate is eligible for validation.
+        self.add_pairs_for_remote_candidate(seq, now);
+        if let Some(addr) = promoted_addr
+            && !addr.ip().is_loopback()
+            && !addr.ip().is_unspecified()
+        {
+            self.port_predictor.record_observation(addr, now);
+            self.generate_predicted_candidates(addr.ip(), now);
+        }
+        true
+    }
+
+    /// Drop a candidate that failed its reachability probe. Marks the entry
+    /// `Removed` (preserving sequence-number history) and removes any pairs
+    /// referencing it. The probe failure is NOT counted as a security
+    /// rejection because the address may simply be transiently unreachable.
+    pub(super) fn drop_unreachable_candidate(&mut self, candidate_addr: SocketAddr) -> bool {
+        let target_seq = self.remote_candidates.iter().find_map(|(seq, c)| {
+            if c.address == candidate_addr && c.state == CandidateState::Probing {
+                Some(*seq)
+            } else {
+                None
+            }
+        });
+        let Some(seq) = target_seq else {
+            return false;
+        };
+        if let Some(c) = self.remote_candidates.get_mut(&seq) {
+            c.state = CandidateState::Removed;
+        }
+        // Remove any pairs referencing this address (defensive — pair
+        // generation already skips Probing candidates).
+        let before = self.candidate_pairs.len();
+        self.candidate_pairs
+            .retain(|p| p.remote_addr != candidate_addr);
+        if self.candidate_pairs.len() != before {
+            // pair_index needs rebuild after retain.
+            self.pair_index.clear();
+            for (idx, pair) in self.candidate_pairs.iter().enumerate().rev() {
+                self.pair_index.insert(pair.remote_addr, idx);
+            }
+        }
+        true
     }
 
     /// Generate predicted candidates based on observation history
@@ -1996,6 +2118,7 @@ impl NatTraversalState {
                 state: CandidateState::New,
                 attempt_count: 0,
                 last_attempt: None,
+                advertiser: None,
             };
 
             debug!("Added predicted candidate: {}", predicted_addr);
@@ -2040,6 +2163,7 @@ impl NatTraversalState {
             state: CandidateState::New,
             attempt_count: 0,
             last_attempt: None,
+            advertiser: None,
         };
 
         self.local_candidates.insert(sequence, candidate);
@@ -2103,6 +2227,11 @@ impl NatTraversalState {
             for (remote_seq, remote_candidate) in &self.remote_candidates {
                 // Skip removed candidates
                 if remote_candidate.state == CandidateState::Removed {
+                    continue;
+                }
+                // Skip Probing candidates: a reachability probe must complete
+                // before this address consumes any validation budget.
+                if remote_candidate.state == CandidateState::Probing {
                     continue;
                 }
 
@@ -2195,6 +2324,9 @@ impl NatTraversalState {
             .remote_candidates
             .iter()
             .filter(|(_, rc)| rc.state != CandidateState::Removed)
+            // Skip Probing candidates: pair generation deferred until probe
+            // success promotes them to `New`.
+            .filter(|(_, rc)| rc.state != CandidateState::Probing)
             .filter(|(_, rc)| {
                 // Check compatibility inline to avoid needing local_candidate borrow
                 let local_is_v4 = local_addr.is_ipv4();
@@ -2243,7 +2375,13 @@ impl NatTraversalState {
         }
 
         let remote_candidate = match self.remote_candidates.get(&remote_seq) {
-            Some(c) if c.state != CandidateState::Removed => c,
+            Some(c) if c.state != CandidateState::Removed && c.state != CandidateState::Probing => {
+                c
+            }
+            // Skip pair generation for Probing candidates: until the
+            // reachability probe completes, no validation budget should
+            // be spent on this address. Once promoted to `New` (via
+            // `promote_probed_candidate`) pairs are generated then.
             _ => return,
         };
 
@@ -3455,6 +3593,7 @@ impl NatTraversalState {
             state: CandidateState::New,
             attempt_count: 0,
             last_attempt: None,
+            advertiser: None,
         };
 
         // Check if candidate already exists
@@ -3904,7 +4043,15 @@ mod tests {
             10,                      // max_candidates
             Duration::from_secs(30), // coordination_timeout
             true,                    // allow_loopback for tests
+            false,                   // probe_advertised_addresses (off by default)
         )
+    }
+
+    /// Create a test NAT traversal state with the probe gate explicitly
+    /// configured. Used by reachability-probe regression tests.
+    #[allow(dead_code)]
+    fn create_test_state_with_probe(probe: bool) -> NatTraversalState {
+        NatTraversalState::new(10, Duration::from_secs(30), true, probe)
     }
 
     #[test]
@@ -3995,7 +4142,7 @@ mod tests {
         let remote_addr = SocketAddr::from(([1, 2, 3, 4], 6000));
         let priority = VarInt::from_u32(100);
         state
-            .add_remote_candidate(VarInt::from_u32(1), remote_addr, priority, now)
+            .add_remote_candidate(VarInt::from_u32(1), remote_addr, priority, now, None, false)
             .expect("add remote candidate should succeed");
 
         // Generate candidate pairs
@@ -4062,10 +4209,10 @@ mod tests {
         let remote2 = SocketAddr::from(([172, 217, 16, 34], 7000));
         let priority = VarInt::from_u32(100);
         state
-            .add_remote_candidate(VarInt::from_u32(1), remote1, priority, now)
+            .add_remote_candidate(VarInt::from_u32(1), remote1, priority, now, None, false)
             .expect("add remote candidate should succeed");
         state
-            .add_remote_candidate(VarInt::from_u32(2), remote2, priority, now)
+            .add_remote_candidate(VarInt::from_u32(2), remote2, priority, now, None, false)
             .expect("add remote candidate should succeed");
 
         // Generate candidate pairs
@@ -4093,10 +4240,24 @@ mod tests {
         let remote1 = SocketAddr::from(([93, 184, 215, 1], 6000));
         let remote2 = SocketAddr::from(([93, 184, 215, 2], 7000));
         state
-            .add_remote_candidate(VarInt::from_u32(1), remote1, VarInt::from_u32(100), now)
+            .add_remote_candidate(
+                VarInt::from_u32(1),
+                remote1,
+                VarInt::from_u32(100),
+                now,
+                None,
+                false,
+            )
             .expect("add remote candidate should succeed");
         state
-            .add_remote_candidate(VarInt::from_u32(2), remote2, VarInt::from_u32(200), now)
+            .add_remote_candidate(
+                VarInt::from_u32(2),
+                remote2,
+                VarInt::from_u32(200),
+                now,
+                None,
+                false,
+            )
             .expect("add remote candidate should succeed");
 
         // Now add a local candidate - this triggers incremental pair generation
@@ -4149,7 +4310,14 @@ mod tests {
         // Add a remote candidate - this triggers incremental pair generation
         let remote_addr = SocketAddr::from(([93, 184, 215, 1], 6000));
         state
-            .add_remote_candidate(VarInt::from_u32(1), remote_addr, VarInt::from_u32(100), now)
+            .add_remote_candidate(
+                VarInt::from_u32(1),
+                remote_addr,
+                VarInt::from_u32(100),
+                now,
+                None,
+                false,
+            )
             .expect("add remote candidate should succeed");
 
         // Should have 2 pairs (2 local × 1 remote)
@@ -4178,7 +4346,14 @@ mod tests {
         // Add one remote candidate (both local candidates will pair with it)
         let remote_addr = SocketAddr::from(([93, 184, 215, 1], 6000));
         state
-            .add_remote_candidate(VarInt::from_u32(1), remote_addr, VarInt::from_u32(100), now)
+            .add_remote_candidate(
+                VarInt::from_u32(1),
+                remote_addr,
+                VarInt::from_u32(100),
+                now,
+                None,
+                false,
+            )
             .expect("add remote candidate should succeed");
 
         // Should have 2 pairs with the same remote_addr
@@ -4226,10 +4401,24 @@ mod tests {
         state_incremental.add_local_candidate(local1, CandidateSource::Local, now);
         state_incremental.add_local_candidate(local2, CandidateSource::Local, now);
         state_incremental
-            .add_remote_candidate(VarInt::from_u32(1), remote1, VarInt::from_u32(100), now)
+            .add_remote_candidate(
+                VarInt::from_u32(1),
+                remote1,
+                VarInt::from_u32(100),
+                now,
+                None,
+                false,
+            )
             .unwrap();
         state_incremental
-            .add_remote_candidate(VarInt::from_u32(2), remote2, VarInt::from_u32(200), now)
+            .add_remote_candidate(
+                VarInt::from_u32(2),
+                remote2,
+                VarInt::from_u32(200),
+                now,
+                None,
+                false,
+            )
             .unwrap();
 
         // Create another state and do full regeneration
@@ -4237,10 +4426,24 @@ mod tests {
         state_full.add_local_candidate(local1, CandidateSource::Local, now);
         state_full.add_local_candidate(local2, CandidateSource::Local, now);
         state_full
-            .add_remote_candidate(VarInt::from_u32(1), remote1, VarInt::from_u32(100), now)
+            .add_remote_candidate(
+                VarInt::from_u32(1),
+                remote1,
+                VarInt::from_u32(100),
+                now,
+                None,
+                false,
+            )
             .unwrap();
         state_full
-            .add_remote_candidate(VarInt::from_u32(2), remote2, VarInt::from_u32(200), now)
+            .add_remote_candidate(
+                VarInt::from_u32(2),
+                remote2,
+                VarInt::from_u32(200),
+                now,
+                None,
+                false,
+            )
             .unwrap();
         // Force full regeneration
         state_full.generate_candidate_pairs(now);
@@ -4285,7 +4488,8 @@ mod tests {
         let mut state = NatTraversalState::new(
             100, // max_candidates (high enough to not limit)
             Duration::from_secs(30),
-            true, // allow_loopback for tests
+            true,  // allow_loopback for tests
+            false, // probe_advertised_addresses
         );
         let now = Instant::now();
 
@@ -4299,8 +4503,14 @@ mod tests {
 
         for i in 0..15u32 {
             let remote = SocketAddr::from(([93, 184, 215, i as u8], 6000 + i as u16));
-            let _ =
-                state.add_remote_candidate(VarInt::from_u32(i), remote, VarInt::from_u32(100), now);
+            let _ = state.add_remote_candidate(
+                VarInt::from_u32(i),
+                remote,
+                VarInt::from_u32(100),
+                now,
+                None,
+                false,
+            );
         }
 
         // Should be capped at max_candidate_pairs (200)
@@ -4316,7 +4526,7 @@ mod tests {
     #[test]
     fn test_add_pairs_at_exact_limit() {
         // Test behavior when exactly at the limit
-        let mut state = NatTraversalState::new(100, Duration::from_secs(30), true);
+        let mut state = NatTraversalState::new(100, Duration::from_secs(30), true, false);
         let now = Instant::now();
 
         // Add candidates to get close to limit (14 × 14 = 196 pairs)
@@ -4326,8 +4536,14 @@ mod tests {
         }
         for i in 0..14u32 {
             let remote = SocketAddr::from(([93, 184, 215, i as u8], 6000 + i as u16));
-            let _ =
-                state.add_remote_candidate(VarInt::from_u32(i), remote, VarInt::from_u32(100), now);
+            let _ = state.add_remote_candidate(
+                VarInt::from_u32(i),
+                remote,
+                VarInt::from_u32(100),
+                now,
+                None,
+                false,
+            );
         }
 
         let pairs_at_limit = state.candidate_pairs.len();
@@ -4362,7 +4578,14 @@ mod tests {
         // Add one remote - creates 3 pairs with same remote_addr
         let remote = SocketAddr::from(([93, 184, 215, 1], 6000));
         state
-            .add_remote_candidate(VarInt::from_u32(1), remote, VarInt::from_u32(100), now)
+            .add_remote_candidate(
+                VarInt::from_u32(1),
+                remote,
+                VarInt::from_u32(100),
+                now,
+                None,
+                false,
+            )
             .unwrap();
 
         // Should have 3 pairs
@@ -4396,7 +4619,7 @@ mod tests {
     #[test]
     fn test_incremental_add_with_zero_remaining_capacity() {
         // Test that incremental add gracefully handles zero capacity
-        let mut state = NatTraversalState::new(100, Duration::from_secs(30), true);
+        let mut state = NatTraversalState::new(100, Duration::from_secs(30), true, false);
         let now = Instant::now();
 
         // Fill up to the limit
@@ -4406,8 +4629,14 @@ mod tests {
         }
         for i in 0..14u32 {
             let remote = SocketAddr::from(([93, 184, 215, i as u8], 6000 + i as u16));
-            let _ =
-                state.add_remote_candidate(VarInt::from_u32(i), remote, VarInt::from_u32(100), now);
+            let _ = state.add_remote_candidate(
+                VarInt::from_u32(i),
+                remote,
+                VarInt::from_u32(100),
+                now,
+                None,
+                false,
+            );
         }
 
         // Record count at limit
@@ -4420,6 +4649,8 @@ mod tests {
             extra_remote,
             VarInt::from_u32(100),
             now,
+            None,
+            false,
         );
 
         // Should not panic, and count should not exceed limit
@@ -4427,5 +4658,194 @@ mod tests {
             state.candidate_pairs.len() <= 200,
             "Should handle limit gracefully without panic"
         );
+    }
+
+    // ---------- ADD_ADDRESS reachability-probe gate regression tests ----------
+
+    #[test]
+    fn probe_gate_disabled_admits_candidate_immediately() {
+        // Default behaviour: with the probe gate off, an ADD_ADDRESS-derived
+        // candidate enters CandidateState::New and shows up as a validation
+        // candidate (so PATH_CHALLENGE will be sent on the next opportunity).
+        let mut state = create_test_state_with_probe(false);
+        let now = Instant::now();
+        // Add a local candidate so pair generation has something to work with.
+        state.add_local_candidate(
+            SocketAddr::from(([192, 168, 1, 1], 5000)),
+            CandidateSource::Local,
+            now,
+        );
+
+        let advertiser = [7u8; 32];
+        let advertised = SocketAddr::from(([1, 2, 3, 4], 9000));
+        state
+            .add_remote_candidate(
+                VarInt::from_u32(1),
+                advertised,
+                VarInt::from_u32(100),
+                now,
+                Some(advertiser),
+                false,
+            )
+            .expect("add_remote_candidate should succeed");
+
+        let candidate = state
+            .remote_candidates
+            .get(&VarInt::from_u32(1))
+            .expect("candidate should be present");
+        assert_eq!(
+            candidate.state,
+            CandidateState::New,
+            "probe-disabled should leave candidate in New"
+        );
+        assert_eq!(
+            candidate.advertiser,
+            Some(advertiser),
+            "advertiser fingerprint should be stored regardless of gate"
+        );
+        let validation_candidates = state.get_validation_candidates();
+        assert_eq!(
+            validation_candidates.len(),
+            1,
+            "candidate should be eligible for PATH_CHALLENGE"
+        );
+        assert_eq!(state.candidate_pairs.len(), 1, "pair should be generated");
+    }
+
+    #[test]
+    fn probe_gate_enabled_holds_candidate_in_probing() {
+        // With the probe gate on, an ADD_ADDRESS-derived candidate enters
+        // Probing — invisible to PATH_CHALLENGE selection and to pair
+        // generation, so no dial budget is consumed until a probe completes.
+        let mut state = create_test_state_with_probe(true);
+        let now = Instant::now();
+        state.add_local_candidate(
+            SocketAddr::from(([192, 168, 1, 1], 5000)),
+            CandidateSource::Local,
+            now,
+        );
+
+        let advertised = SocketAddr::from(([1, 2, 3, 4], 9000));
+        state
+            .add_remote_candidate(
+                VarInt::from_u32(1),
+                advertised,
+                VarInt::from_u32(100),
+                now,
+                Some([3u8; 32]),
+                true, // probing
+            )
+            .expect("add_remote_candidate should succeed");
+
+        let candidate = state
+            .remote_candidates
+            .get(&VarInt::from_u32(1))
+            .expect("candidate should be present");
+        assert_eq!(candidate.state, CandidateState::Probing);
+        assert!(
+            state.get_validation_candidates().is_empty(),
+            "Probing candidate must NOT be eligible for PATH_CHALLENGE"
+        );
+        assert!(
+            state.candidate_pairs.is_empty(),
+            "Probing candidate must NOT contribute to candidate pairs"
+        );
+    }
+
+    #[test]
+    fn probe_success_promotes_candidate_to_new() {
+        let mut state = create_test_state_with_probe(true);
+        let now = Instant::now();
+        state.add_local_candidate(
+            SocketAddr::from(([192, 168, 1, 1], 5000)),
+            CandidateSource::Local,
+            now,
+        );
+
+        let advertised = SocketAddr::from(([1, 2, 3, 4], 9000));
+        state
+            .add_remote_candidate(
+                VarInt::from_u32(1),
+                advertised,
+                VarInt::from_u32(100),
+                now,
+                Some([5u8; 32]),
+                true,
+            )
+            .expect("add_remote_candidate should succeed");
+
+        // Promote on probe success.
+        let promoted = state.promote_probed_candidate(advertised, now);
+        assert!(
+            promoted,
+            "promotion should succeed for an existing Probing candidate"
+        );
+        let candidate = state
+            .remote_candidates
+            .get(&VarInt::from_u32(1))
+            .expect("candidate should still exist");
+        assert_eq!(candidate.state, CandidateState::New);
+        assert_eq!(
+            state.get_validation_candidates().len(),
+            1,
+            "promoted candidate should now be eligible for PATH_CHALLENGE"
+        );
+        assert_eq!(
+            state.candidate_pairs.len(),
+            1,
+            "pair generated on promotion"
+        );
+    }
+
+    #[test]
+    fn probe_failure_drops_candidate_without_banning_advertiser() {
+        let mut state = create_test_state_with_probe(true);
+        let now = Instant::now();
+        state.add_local_candidate(
+            SocketAddr::from(([192, 168, 1, 1], 5000)),
+            CandidateSource::Local,
+            now,
+        );
+
+        let advertised = SocketAddr::from(([1, 2, 3, 4], 9000));
+        let advertiser = [42u8; 32];
+        state
+            .add_remote_candidate(
+                VarInt::from_u32(1),
+                advertised,
+                VarInt::from_u32(100),
+                now,
+                Some(advertiser),
+                true,
+            )
+            .expect("add_remote_candidate should succeed");
+
+        let dropped = state.drop_unreachable_candidate(advertised);
+        assert!(dropped, "should drop the Probing candidate");
+
+        let candidate = state
+            .remote_candidates
+            .get(&VarInt::from_u32(1))
+            .expect("entry preserved with Removed state");
+        assert_eq!(candidate.state, CandidateState::Removed);
+
+        // No security/rate-limit counters should be incremented — failed
+        // probes are not treated as attacks.
+        assert_eq!(state.stats.security_rejections, 0);
+        assert_eq!(state.stats.rate_limit_violations, 0);
+        assert_eq!(state.stats.invalid_address_rejections, 0);
+    }
+
+    #[test]
+    fn promote_probed_candidate_is_idempotent_on_missing() {
+        // Calling promote on an unknown address returns false and does not
+        // panic — guards against duplicate probe results racing with peer
+        // disconnect / candidate cleanup.
+        let mut state = create_test_state_with_probe(true);
+        let promoted =
+            state.promote_probed_candidate(SocketAddr::from(([1, 2, 3, 4], 9000)), Instant::now());
+        assert!(!promoted);
+        let dropped = state.drop_unreachable_candidate(SocketAddr::from(([1, 2, 3, 4], 9000)));
+        assert!(!dropped);
     }
 }

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -116,6 +116,30 @@ pub struct Endpoint {
     /// Pending peer address updates from ADD_ADDRESS frames.
     /// Each entry is (peer_connection_addr, new_advertised_addr).
     pending_peer_address_updates: Vec<(SocketAddr, SocketAddr)>,
+    /// Pending reachability-probe requests for `ADD_ADDRESS`-derived
+    /// candidates whose connection has the probe gate enabled. The
+    /// high-level layer drains these, runs a single short-timeout QUIC
+    /// Initial probe per entry, and delivers the result back via
+    /// `relay_event_to_connection` with an `AdvertisedAddressProbeResult`
+    /// connection event.
+    pending_address_probes: Vec<PendingAddressProbe>,
+}
+
+/// Queued reachability-probe request emitted by a connection that has the
+/// `probe_advertised_addresses` gate enabled.
+#[derive(Debug, Clone)]
+pub(crate) struct PendingAddressProbe {
+    /// Connection that asked for the probe (used to route the result back).
+    pub(crate) source: ConnectionHandle,
+    /// Connected peer that advertised this candidate.
+    pub(crate) peer_addr: SocketAddr,
+    /// Candidate address to probe.
+    pub(crate) candidate_addr: SocketAddr,
+    /// Local-only PeerId fingerprint of the advertiser. Carried so a
+    /// follow-up PR can wire failed probes into trust/reputation events.
+    /// Currently diagnostic only.
+    #[allow(dead_code)]
+    pub(crate) advertiser: [u8; 32],
 }
 
 /// Deterministic 32-byte wire ID from a SocketAddr, used to correlate
@@ -162,6 +186,7 @@ impl Endpoint {
             pending_relay_events: Vec::new(),
             pending_hole_punch_addrs: Vec::new(),
             pending_peer_address_updates: Vec::new(),
+            pending_address_probes: Vec::new(),
         }
     }
 
@@ -242,6 +267,36 @@ impl Endpoint {
         &mut self,
     ) -> impl Iterator<Item = (SocketAddr, SocketAddr)> + '_ {
         self.pending_peer_address_updates.drain(..)
+    }
+
+    /// Drain pending reachability-probe requests for ADD_ADDRESS-derived
+    /// candidates. The high-level layer is expected to dispatch a single
+    /// short-timeout QUIC Initial probe per entry and feed the result back
+    /// via [`Endpoint::deliver_advertised_address_probe_result`].
+    pub(crate) fn drain_address_probes(
+        &mut self,
+    ) -> impl Iterator<Item = PendingAddressProbe> + '_ {
+        self.pending_address_probes.drain(..)
+    }
+
+    /// Queue an `AdvertisedAddressProbeResult` connection event for the
+    /// originating connection. Returns `false` when the connection is no
+    /// longer alive (in which case the result is silently dropped).
+    pub(crate) fn deliver_advertised_address_probe_result(
+        &mut self,
+        ch: ConnectionHandle,
+        candidate_addr: SocketAddr,
+        reachable: bool,
+    ) -> bool {
+        if self.connections.get(ch.0).is_none() {
+            return false;
+        }
+        let event = ConnectionEvent(ConnectionEventInner::AdvertisedAddressProbeResult {
+            candidate_addr,
+            reachable,
+        });
+        self.pending_relay_events.push((ch, event));
+        true
     }
 
     /// Set the peer ID for an existing connection
@@ -419,6 +474,52 @@ impl Endpoint {
                 );
                 self.pending_peer_address_updates
                     .push((peer_addr, advertised_addr));
+            }
+            ProbeAdvertisedAddress {
+                peer_addr,
+                candidate_addr,
+                advertiser,
+            } => {
+                // Cap the in-flight probe queue. With the gate enabled, a
+                // peer flooding ADD_ADDRESS frames would otherwise grow
+                // this Vec without bound until the next drain (and worse,
+                // each probe spawns a real QUIC handshake — see the
+                // KNOWN LIMITATION comment in
+                // `NatTraversalEndpoint::run_single_address_probe`).
+                //
+                // Per-address dedup short-circuits floods of the same
+                // candidate so retries cost O(1) per unique address.
+                const MAX_PENDING_ADDRESS_PROBES: usize = 256;
+                let already_queued = self
+                    .pending_address_probes
+                    .iter()
+                    .any(|p| p.candidate_addr == candidate_addr);
+                if already_queued {
+                    tracing::debug!(
+                        "address probe: already queued for {} (advertiser_conn={}), dropping duplicate",
+                        candidate_addr,
+                        peer_addr
+                    );
+                } else if self.pending_address_probes.len() >= MAX_PENDING_ADDRESS_PROBES {
+                    tracing::warn!(
+                        "address probe: queue full ({} pending), dropping probe for {} (advertiser_conn={})",
+                        self.pending_address_probes.len(),
+                        candidate_addr,
+                        peer_addr
+                    );
+                } else {
+                    tracing::info!(
+                        "Queueing reachability probe for ADD_ADDRESS candidate {} (advertiser_conn={})",
+                        candidate_addr,
+                        peer_addr
+                    );
+                    self.pending_address_probes.push(PendingAddressProbe {
+                        source: ch,
+                        peer_addr,
+                        candidate_addr,
+                        advertiser,
+                    });
+                }
             }
             InitiateHolePunch { peer_address } => {
                 // Queue a hole-punch connection attempt as a relay event.

--- a/src/high_level/endpoint.rs
+++ b/src/high_level/endpoint.rs
@@ -344,6 +344,44 @@ impl Endpoint {
         }
     }
 
+    /// Set the channel for forwarding ADD_ADDRESS reachability-probe
+    /// requests to the upper layer (NatTraversalEndpoint).
+    pub(crate) fn set_address_probe_tx(
+        &self,
+        tx: mpsc::UnboundedSender<crate::endpoint::PendingAddressProbe>,
+    ) {
+        if let Ok(mut state) = self.inner.0.state.lock() {
+            state.address_probe_tx = Some(tx);
+        }
+    }
+
+    /// Deliver the result of an ADD_ADDRESS reachability probe back to the
+    /// originating connection. The connection's state machine will promote
+    /// or remove the matching `Probing` candidate. Returns `false` if the
+    /// connection has gone away.
+    pub(crate) fn deliver_address_probe_result(
+        &self,
+        ch: ConnectionHandle,
+        candidate_addr: SocketAddr,
+        reachable: bool,
+    ) -> bool {
+        let Ok(mut state) = self.inner.0.state.lock() else {
+            return false;
+        };
+        let queued =
+            state
+                .inner
+                .deliver_advertised_address_probe_result(ch, candidate_addr, reachable);
+        if !queued {
+            return false;
+        }
+        // Wake the driver so it processes pending_relay_events.
+        if let Some(driver) = state.driver.as_ref() {
+            driver.wake_by_ref();
+        }
+        true
+    }
+
     /// Connect to a remote endpoint
     ///
     /// `server_name` must be covered by the certificate presented by the server. This prevents a
@@ -772,6 +810,11 @@ pub(crate) struct State {
     /// for full connection tracking instead of fire-and-forget.
     hole_punch_tx: Option<mpsc::UnboundedSender<SocketAddr>>,
     peer_address_update_tx: Option<mpsc::UnboundedSender<(SocketAddr, SocketAddr)>>,
+    /// Forward queued ADD_ADDRESS reachability-probe requests to the
+    /// NatTraversalEndpoint, which owns the async runtime needed to dial
+    /// the candidate. The receiver feeds [`Self::deliver_address_probe_result`]
+    /// back into the low-level endpoint when each probe completes.
+    address_probe_tx: Option<mpsc::UnboundedSender<crate::endpoint::PendingAddressProbe>>,
 }
 
 #[derive(Debug)]
@@ -923,6 +966,34 @@ impl State {
             did_work = true;
             if let Some(ref tx) = self.peer_address_update_tx {
                 let _ = tx.send((peer_addr, advertised_addr));
+            }
+        }
+
+        // Forward ADD_ADDRESS reachability-probe requests to the
+        // NatTraversalEndpoint. When the channel is unset (probe gate
+        // disabled or NatTraversalEndpoint not wired), each request is
+        // logged and dropped — the originating connection will leave the
+        // candidate in `Probing` state, which is intentionally invisible to
+        // PATH_CHALLENGE and pair-generation paths.
+        let probe_requests: Vec<crate::endpoint::PendingAddressProbe> =
+            self.inner.drain_address_probes().collect();
+        for probe in probe_requests {
+            did_work = true;
+            if let Some(ref tx) = self.address_probe_tx {
+                if let Err(e) = tx.send(probe.clone()) {
+                    tracing::debug!(
+                        "address probe channel closed: dropping probe for {} (advertiser_conn={}, err={})",
+                        probe.candidate_addr,
+                        probe.peer_addr,
+                        e,
+                    );
+                }
+            } else {
+                tracing::debug!(
+                    "address probe channel unset: dropping probe for {} (advertiser_conn={})",
+                    probe.candidate_addr,
+                    probe.peer_addr,
+                );
             }
         }
 
@@ -1136,6 +1207,7 @@ impl EndpointRef {
                 default_client_config: None,
                 hole_punch_tx: None,
                 peer_address_update_tx: None,
+                address_probe_tx: None,
             }),
         }))
     }

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -429,6 +429,12 @@ pub struct NatTraversalEndpoint {
     /// Channel for receiving peer address updates (ADD_ADDRESS → DHT bridge)
     pub(crate) peer_address_update_rx:
         TokioMutex<mpsc::UnboundedReceiver<(SocketAddr, SocketAddr)>>,
+    /// Channel for receiving ADD_ADDRESS reachability-probe requests from
+    /// the low-level endpoint. Drained by [`Self::run_address_probe_loop`],
+    /// which spawns one short-timeout dial per request and feeds the result
+    /// back via [`crate::high_level::Endpoint::deliver_address_probe_result`].
+    pub(crate) address_probe_rx:
+        TokioMutex<mpsc::UnboundedReceiver<crate::endpoint::PendingAddressProbe>>,
     /// Server config cloned at endpoint creation time for building the
     /// relay endpoint in [`setup_proactive_relay`].
     relay_server_config: Arc<std::sync::Mutex<Option<crate::ServerConfig>>>,
@@ -698,6 +704,26 @@ pub struct NatTraversalConfig {
     /// Default: [`CongestionAlgorithm::Bbr2`].
     #[serde(default)]
     pub congestion_algorithm: CongestionAlgorithm,
+
+    /// Gate `ADD_ADDRESS`-derived candidates on a sub-second QUIC Initial
+    /// reachability probe before allowing them to consume `PATH_CHALLENGE`
+    /// validation budget.
+    ///
+    /// Closes a measured amplification vector: in production (24 ant-node
+    /// v0.11.3 hosts, 3 h 47 m window) one peer (`5.250.190.226`) advertised
+    /// an unreachable BLAKE3-binding attacker IP (`75.48.86.24`) via
+    /// `ADD_ADDRESS`. Receivers admitted it with no reachability check and
+    /// dialed it 35 592 times across the fleet.
+    ///
+    /// Loopback addresses always skip the probe (devnet correctness). The
+    /// probe is fire-and-forget on a spawned task and does NOT block
+    /// `ADD_ADDRESS` frame processing.
+    ///
+    /// Default: `false` (preserves existing behaviour). Will be flipped to
+    /// `true` in a follow-up release once measurement confirms latency
+    /// impact is within budget.
+    #[serde(default)]
+    pub probe_advertised_addresses: bool,
 }
 
 fn default_advertise_external_addresses() -> bool {
@@ -1114,6 +1140,9 @@ impl CandidateAddress {
             CandidateState::Valid => self.priority,
             CandidateState::New => self.priority.saturating_sub(10),
             CandidateState::Validating => self.priority.saturating_sub(5),
+            // Probing candidates are awaiting an out-of-band reachability
+            // check and must not influence pair selection.
+            CandidateState::Probing => 0,
             CandidateState::Failed => 0,
             CandidateState::Removed => 0,
         }
@@ -1343,6 +1372,7 @@ impl Default for NatTraversalConfig {
             upnp: crate::upnp::UpnpConfig::default(),
             advertise_external_addresses: true,
             congestion_algorithm: CongestionAlgorithm::default(),
+            probe_advertised_addresses: false,
         }
     }
 }
@@ -1665,6 +1695,10 @@ impl NatTraversalEndpoint {
         let (peer_addr_tx, peer_addr_rx) = mpsc::unbounded_channel();
         inner_endpoint.set_peer_address_update_tx(peer_addr_tx);
 
+        // Channel for ADD_ADDRESS reachability-probe requests
+        let (probe_tx, probe_rx) = mpsc::unbounded_channel();
+        inner_endpoint.set_address_probe_tx(probe_tx);
+
         // Channel for background handshake completion (persistent across accept calls)
         let (hs_tx, hs_rx) = mpsc::channel(HANDSHAKE_CHANNEL_CAPACITY);
 
@@ -1692,6 +1726,7 @@ impl NatTraversalEndpoint {
             transport_candidates: Arc::new(dashmap::DashMap::new()),
             transport_registry,
             peer_address_update_rx: TokioMutex::new(peer_addr_rx),
+            address_probe_rx: TokioMutex::new(probe_rx),
             relay_server_config: Arc::new(std::sync::Mutex::new(relay_server_config)),
             relay_handler_connections: Arc::new(dashmap::DashSet::new()),
             relay_setup_attempted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
@@ -2105,6 +2140,10 @@ impl NatTraversalEndpoint {
         let (peer_addr_tx, peer_addr_rx) = mpsc::unbounded_channel();
         inner_endpoint.set_peer_address_update_tx(peer_addr_tx);
 
+        // Channel for ADD_ADDRESS reachability-probe requests
+        let (probe_tx, probe_rx) = mpsc::unbounded_channel();
+        inner_endpoint.set_address_probe_tx(probe_tx);
+
         // Channel for background handshake completion (persistent across accept calls)
         let (hs_tx, hs_rx) = mpsc::channel(HANDSHAKE_CHANNEL_CAPACITY);
 
@@ -2132,6 +2171,7 @@ impl NatTraversalEndpoint {
             transport_candidates: Arc::new(dashmap::DashMap::new()),
             transport_registry,
             peer_address_update_rx: TokioMutex::new(peer_addr_rx),
+            address_probe_rx: TokioMutex::new(probe_rx),
             relay_server_config: Arc::new(std::sync::Mutex::new(relay_server_config)),
             relay_handler_connections: Arc::new(dashmap::DashSet::new()),
             relay_setup_attempted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
@@ -2990,6 +3030,7 @@ impl NatTraversalEndpoint {
             };
             transport_config.nat_traversal_config(Some(nat_config));
             transport_config.allow_loopback(config.allow_loopback);
+            transport_config.probe_advertised_addresses(config.probe_advertised_addresses);
 
             server_config.transport_config(Arc::new(transport_config));
 
@@ -3071,6 +3112,7 @@ impl NatTraversalEndpoint {
             };
             transport_config.nat_traversal_config(Some(nat_config));
             transport_config.allow_loopback(config.allow_loopback);
+            transport_config.probe_advertised_addresses(config.probe_advertised_addresses);
 
             client_config.transport_config(Arc::new(transport_config));
 
@@ -6924,6 +6966,150 @@ impl NatTraversalEndpoint {
                 });
             }
         }
+    }
+
+    /// Drain queued ADD_ADDRESS reachability-probe requests and dispatch a
+    /// single short-timeout dial per candidate on a spawned task. Probe
+    /// completion delivers an `AdvertisedAddressProbeResult` ConnectionEvent
+    /// back to the originating connection.
+    ///
+    /// Called from the same poll cadence as
+    /// [`Self::process_pending_peer_address_updates`]. The dispatch loop
+    /// itself does not block on probe results — each probe runs on its own
+    /// `tokio::spawn` future with a 250 ms timeout.
+    pub async fn process_pending_address_probes(&self) {
+        let endpoint = match self.inner_endpoint.as_ref() {
+            Some(ep) => ep.clone(),
+            None => return,
+        };
+        let mut rx = self.address_probe_rx.lock().await;
+        while let Ok(probe) = rx.try_recv() {
+            let endpoint_for_task = endpoint.clone();
+            tokio::spawn(async move {
+                Self::run_single_address_probe(endpoint_for_task, probe).await;
+            });
+        }
+    }
+
+    /// Run a single ADD_ADDRESS reachability probe.
+    ///
+    /// Sends one QUIC Initial via `endpoint.connect()` and waits up to
+    /// 250 ms for the handshake to make progress. The result is delivered
+    /// back to the originating connection regardless of outcome:
+    ///
+    /// - Reachable → originating connection promotes the `Probing`
+    ///   candidate to `New` and triggers `PATH_CHALLENGE`.
+    /// - Unreachable → originating connection drops the candidate.
+    ///
+    /// If the connection is gone (peer disconnected before the probe
+    /// finished) the result is silently dropped.
+    async fn run_single_address_probe(
+        endpoint: crate::high_level::Endpoint,
+        probe: crate::endpoint::PendingAddressProbe,
+    ) {
+        // Match the existing cross-region connect budget rather than
+        // picking something tighter — saorsa-core's transport adapter uses
+        // 1250ms for `DIRECT_CONNECT_TIMEOUT` (see saorsa-core
+        // `src/transport/saorsa_transport_adapter.rs`). A tighter budget
+        // here would fail every legitimate cross-region candidate (lon1 →
+        // syd1 ~280ms one-way + ML-KEM-768 / ML-DSA-65 multi-packet
+        // handshake easily blows out 250ms).
+        const PROBE_TIMEOUT: Duration = Duration::from_millis(1250);
+        // Hard ceiling to also cover the case where a slow handshake
+        // races past PROBE_TIMEOUT. If the handshake genuinely takes
+        // longer than this we close the connection and report the
+        // candidate as unreachable — better to drop a slow legitimate
+        // peer than to leak a `ConnectionDriver` into the registry until
+        // QUIC's own idle timer reaps it.
+        const PROBE_HARD_CEILING: Duration = Duration::from_secs(5);
+
+        let candidate = probe.candidate_addr;
+        let source = probe.source;
+
+        // Defensive: re-check loopback on the consumer side. Loopback
+        // probes should never reach this code (the connection layer
+        // short-circuits them) but we never want to spawn a probe at
+        // ourselves.
+        if candidate.ip().is_loopback() {
+            debug!(
+                "address probe: skipping loopback candidate {} (advertiser_conn={})",
+                candidate, probe.peer_addr
+            );
+            // Treat loopback-as-reachable so the connection promotes it
+            // (matches the loopback-skip path in handle_add_address).
+            endpoint.deliver_address_probe_result(source, candidate, true);
+            return;
+        }
+
+        // Use "localhost" as the SNI: saorsa uses Pure PQC Raw Public Key
+        // authentication, so the SNI is purely a placeholder and matches
+        // the convention of other internal `endpoint.connect()` callers
+        // (`attempt_connection_to_candidate`, hole-punch dials, etc.).
+        let connecting = match endpoint.connect(candidate, "localhost") {
+            Ok(c) => c,
+            Err(e) => {
+                debug!(
+                    "address probe: connect() rejected for {} (advertiser_conn={}): {}",
+                    candidate, probe.peer_addr, e
+                );
+                endpoint.deliver_address_probe_result(source, candidate, false);
+                return;
+            }
+        };
+
+        // Race the handshake against PROBE_TIMEOUT. Use the wider
+        // PROBE_HARD_CEILING for the await itself so a slow-but-eventual
+        // success still settles cleanly (we close it on success, see
+        // below), then narrow down to PROBE_TIMEOUT for the
+        // report-as-reachable decision. This keeps the connection-driver
+        // leak bounded by PROBE_HARD_CEILING rather than the full QUIC
+        // handshake timeout (~30s).
+        //
+        // KNOWN LIMITATION: when the handshake takes longer than
+        // PROBE_HARD_CEILING the underlying `ConnectionDriver` keeps
+        // polling QUIC retransmits until the QUIC idle timer reaps it.
+        // This is bounded per probe but uncapped fleet-wide; the
+        // companion bounded-queue + in-flight-dedup guard
+        // (`pending_address_probes`) caps the steady-state cost. A
+        // future refactor to expose a probe-only `Endpoint::probe_addr`
+        // that uses raw UDP would eliminate the residual leak entirely.
+        let probe_started = std::time::Instant::now();
+        let probe_result = tokio::time::timeout(PROBE_HARD_CEILING, connecting).await;
+        let elapsed = probe_started.elapsed();
+        let reachable = match probe_result {
+            Ok(Ok(connection)) => {
+                connection.close(0u32.into(), b"address-probe-complete");
+                elapsed <= PROBE_TIMEOUT
+            }
+            Ok(Err(e)) => {
+                debug!(
+                    "address probe: handshake failed for {} (advertiser_conn={}): {}",
+                    candidate, probe.peer_addr, e
+                );
+                false
+            }
+            Err(_elapsed) => {
+                debug!(
+                    "address probe: handshake exceeded hard ceiling {:?} for {} (advertiser_conn={})",
+                    PROBE_HARD_CEILING, candidate, probe.peer_addr
+                );
+                false
+            }
+        };
+
+        if reachable {
+            info!(
+                "address probe: {} responded within {:?} (advertiser_conn={})",
+                candidate, PROBE_TIMEOUT, probe.peer_addr
+            );
+        } else {
+            info!(
+                "address probe: {} did NOT respond within {:?} (advertiser_conn={}) — dropping candidate",
+                candidate, PROBE_TIMEOUT, probe.peer_addr
+            );
+        }
+
+        endpoint.deliver_address_probe_result(source, candidate, reachable);
     }
 
     /// Attempt a QUIC connection to a peer address for hole-punching.

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -3971,6 +3971,10 @@ impl P2pEndpoint {
                 // outgoing connections (not fire-and-forget).
                 inner.process_pending_hole_punches().await;
 
+                // Dispatch ADD_ADDRESS reachability probes (no-op when the
+                // probe gate is disabled — the queue stays empty).
+                inner.process_pending_address_probes().await;
+
                 // Forward peer address updates as P2pEvents so the upper layer
                 // (saorsa-core) can update its DHT routing table.
                 {

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -28,6 +28,16 @@ pub(crate) enum ConnectionEventInner {
     QueueAddAddress(crate::frame::AddAddress),
     /// Queue a PUNCH_ME_NOW frame for transmission
     QueuePunchMeNow(crate::frame::PunchMeNow),
+    /// Result of an out-of-band reachability probe issued in response to
+    /// `EndpointEventInner::ProbeAdvertisedAddress`. When `reachable` is
+    /// `true` the connection promotes the matching `Probing` candidate to
+    /// `New`; when `false` the candidate is removed.
+    AdvertisedAddressProbeResult {
+        /// The candidate address that was probed.
+        candidate_addr: SocketAddr,
+        /// Whether the probe succeeded within the timeout window.
+        reachable: bool,
+    },
 }
 
 /// Variant of [`ConnectionEventInner`].
@@ -96,6 +106,25 @@ pub(crate) enum EndpointEventInner {
         peer_addr: SocketAddr,
         /// The new address the peer is advertising
         advertised_addr: SocketAddr,
+    },
+    /// Request the high-level endpoint to issue an out-of-band reachability
+    /// probe (a single QUIC Initial with a short timeout) to a candidate
+    /// learned via `ADD_ADDRESS`, before allowing it to consume validation
+    /// budget. The result is delivered back as
+    /// `ConnectionEventInner::AdvertisedAddressProbeResult` to the
+    /// originating connection.
+    ///
+    /// Emitted only when the connection has `probe_advertised_addresses`
+    /// enabled. Loopback and same-IP-as-advertiser candidates are
+    /// short-circuited at the connection layer and never produce this event.
+    ProbeAdvertisedAddress {
+        /// The connected peer that advertised the address (for diagnostics).
+        peer_addr: SocketAddr,
+        /// The candidate to probe.
+        candidate_addr: SocketAddr,
+        /// Local-only PeerId fingerprint of the advertiser. Carried so a
+        /// future PR can wire failed probes into reputation/trust events.
+        advertiser: [u8; 32],
     },
     /// Request to attempt connection to a target address (NAT callback mechanism)
     TryConnectTo {

--- a/src/unified_config.rs
+++ b/src/unified_config.rs
@@ -174,6 +174,14 @@ pub struct NatConfig {
     /// under-used, while handling lossy paths and shared bottlenecks
     /// more gracefully than BBRv1.
     pub congestion_algorithm: crate::nat_traversal_api::CongestionAlgorithm,
+
+    /// Gate `ADD_ADDRESS`-derived candidates on a sub-second QUIC Initial
+    /// reachability probe before allowing them to consume `PATH_CHALLENGE`
+    /// validation budget. Mirrors
+    /// [`crate::nat_traversal_api::NatTraversalConfig::probe_advertised_addresses`].
+    ///
+    /// Default: `false`.
+    pub probe_advertised_addresses: bool,
 }
 
 impl Default for NatConfig {
@@ -190,6 +198,7 @@ impl Default for NatConfig {
             upnp: crate::upnp::UpnpConfig::default(),
             advertise_external_addresses: true,
             congestion_algorithm: crate::nat_traversal_api::CongestionAlgorithm::default(),
+            probe_advertised_addresses: false,
         }
     }
 }
@@ -346,6 +355,7 @@ impl P2pConfig {
             upnp: self.nat.upnp.clone(),
             advertise_external_addresses: self.nat.advertise_external_addresses,
             congestion_algorithm: self.nat.congestion_algorithm,
+            probe_advertised_addresses: self.nat.probe_advertised_addresses,
         }
     }
 

--- a/tests/relay_queue_tests.rs
+++ b/tests/relay_queue_tests.rs
@@ -58,6 +58,7 @@ mod nat_traversal_api_tests {
             upnp: Default::default(),
             advertise_external_addresses: true,
             congestion_algorithm: Default::default(),
+            probe_advertised_addresses: false,
         };
 
         assert_eq!(config.known_peers.len(), 1);
@@ -197,6 +198,7 @@ mod functional_tests {
             upnp: Default::default(),
             advertise_external_addresses: true,
             congestion_algorithm: Default::default(),
+            probe_advertised_addresses: false,
         };
 
         // May fail due to zero values or other validation
@@ -226,6 +228,7 @@ mod functional_tests {
             upnp: Default::default(),
             advertise_external_addresses: true,
             congestion_algorithm: Default::default(),
+            probe_advertised_addresses: false,
         };
 
         let result = NatTraversalEndpoint::new(valid_config, None, None).await;
@@ -421,6 +424,7 @@ mod performance_tests {
                 upnp: Default::default(),
                 advertise_external_addresses: true,
                 congestion_algorithm: Default::default(),
+                probe_advertised_addresses: false,
             };
 
             // Use the config to prevent optimization
@@ -494,6 +498,7 @@ mod relay_functionality_tests {
             upnp: Default::default(),
             advertise_external_addresses: true,
             congestion_algorithm: Default::default(),
+            probe_advertised_addresses: false,
         };
 
         // This might be accepted or rejected depending on implementation

--- a/tests/security_regression_tests.rs
+++ b/tests/security_regression_tests.rs
@@ -40,6 +40,7 @@ fn test_peer_config() -> NatTraversalConfig {
         upnp: Default::default(),
         advertise_external_addresses: true,
         congestion_algorithm: Default::default(),
+        probe_advertised_addresses: false,
     }
 }
 
@@ -67,6 +68,7 @@ fn test_server_config() -> NatTraversalConfig {
         upnp: Default::default(),
         advertise_external_addresses: true,
         congestion_algorithm: Default::default(),
+        probe_advertised_addresses: false,
     }
 }
 
@@ -117,6 +119,7 @@ async fn test_error_handling_no_panic() {
         upnp: Default::default(),
         advertise_external_addresses: true,
         congestion_algorithm: Default::default(),
+        probe_advertised_addresses: false,
     };
 
     let result1 = NatTraversalEndpoint::new(config1, None, None).await;
@@ -148,6 +151,7 @@ async fn test_error_handling_no_panic() {
         upnp: Default::default(),
         advertise_external_addresses: true,
         congestion_algorithm: Default::default(),
+        probe_advertised_addresses: false,
     };
 
     let result2 = NatTraversalEndpoint::new(config2, None, None).await;
@@ -242,6 +246,7 @@ async fn test_malformed_config_handling() {
         upnp: Default::default(),
         advertise_external_addresses: true,
         congestion_algorithm: Default::default(),
+        probe_advertised_addresses: false,
     };
 
     let result = NatTraversalEndpoint::new(no_peers_config, None, None).await;
@@ -274,6 +279,7 @@ async fn test_malformed_config_handling() {
         upnp: Default::default(),
         advertise_external_addresses: true,
         congestion_algorithm: Default::default(),
+        probe_advertised_addresses: false,
     };
 
     let result2 = NatTraversalEndpoint::new(extreme_config, None, None).await;
@@ -313,6 +319,7 @@ async fn test_input_sanitization() {
         upnp: Default::default(),
         advertise_external_addresses: true,
         congestion_algorithm: Default::default(),
+        probe_advertised_addresses: false,
     };
 
     // This should either work or fail gracefully, not exhaust memory or panic
@@ -387,6 +394,7 @@ mod specific_regression_tests {
             upnp: Default::default(),
             advertise_external_addresses: true,
             congestion_algorithm: Default::default(),
+            probe_advertised_addresses: false,
         };
 
         // Should not panic and should handle random port selection
@@ -441,6 +449,7 @@ mod specific_regression_tests {
             upnp: Default::default(),
             advertise_external_addresses: true,
             congestion_algorithm: Default::default(),
+            probe_advertised_addresses: false,
         };
 
         // Should not panic, even if configuration is inconsistent


### PR DESCRIPTION
## Why

Production fleet measurement (24 ant-node v0.11.3 hosts, 3h47m window 2026-05-14 23:15 → 2026-05-15 03:02 UTC) shows peer `5.250.190.226` advertising the BLAKE3-binding attacker IP `75.48.86.24` to other peers via NAT-traversal `ADD_ADDRESS` frames. Receivers admit it into their candidate pool with **NO reachability check**, then dial it **35,592 times** across the fleet (top-1 per-IP timeout target — 12.6% of all `direct connect timed out` warnings).

Live evidence from `do-lon1-node-3` on 2026-05-15:
```
INFO connection: handle_add_address: RECEIVED ADD_ADDRESS from peer addr=75.48.86.24:40196 (normalized=75.48.86.24:40196) seq=7 priority=2130706431
INFO connection: Added remote candidate: 75.48.86.24:40196 (seq=7, priority=2130706431)
INFO endpoint: Peer [::ffff:5.250.190.226]:56543 advertised new address 75.48.86.24:40196
```

This PR lands the **opt-in infrastructure** to close that vector. The probe gate is **default off** — with the default, this PR is a no-op for behaviour. The only on-by-default change is that local-only state (an `Option<[u8; 32]>` advertiser fingerprint) becomes available for a future trust-events PR to attribute failures back to the source.

## What

- **`AddressCandidate.advertiser: Option<[u8; 32]>`** — local state only, never on the wire. Currently dead-code but unblocks trust-event attribution in a follow-up.

- **New `CandidateState::Probing`** keeps `ADD_ADDRESS`-derived candidates invisible to PATH_CHALLENGE selection and pair generation until an out-of-band probe completes.

- **Two new config knobs** (default `false` in every layer):
  - `NatTraversalConfig::probe_advertised_addresses` (the active knob)
  - `TransportConfig` / `NatConfig::probe_advertised_addresses` (plumbing)

- **Probe path** (only fires when gate is on AND target is non-loopback): `handle_add_address` tags the candidate with the advertiser, places it in `Probing`, emits `ProbeAdvertisedAddress`. The high-level `Endpoint` drains pending probes via mpsc to `NatTraversalEndpoint::run_single_address_probe`, which spawns a single `endpoint.connect()` with `PROBE_TIMEOUT = 1250ms` for the report-as-reachable decision and `PROBE_HARD_CEILING = 5s` for the await itself. Result feeds back via `AdvertisedAddressProbeResult`; the originating connection promotes (success → `New` + trigger validation) or drops (failure → `Removed`). Failed probes do NOT touch trust/security counters yet — that's the follow-up trust-events PR.

- **Loopback short-circuit**: addresses on `127.0.0.1` / `::1` skip the probe entirely (devnet correctness).

- **Probe queue cap**: 256 in-flight + per-address dedup so a peer flooding `ADD_ADDRESS` cannot grow the queue without bound.

- **Port predictor isolation**: no longer fed for `Probing` candidates. Closes a bypass — an attacker advertising garbage IPs would otherwise pollute the predictor with predictions that bypass the gate. The predictor IS fed in `promote_probed_candidate` after a successful probe.

## Adversarial review applied

A hostile reviewer pass before push found 5 P0-class issues. All addressed:

- **P0-3: Default-off was not byte-identical.** `derive_peer_id_from_connection()` ran unconditionally on every `ADD_ADDRESS` (including with the gate off) — a heap allocation per frame for no benefit. The INFO log also gained a `, probing=` suffix that broke any log-scraper regex. Fixed: advertiser is computed only when the gate is on, and the existing log format is preserved when `probing=false`. The `port_predictor.record_observation` + `generate_predicted_candidates` pollution bypass is now also gated.

- **P0-4: 250ms probe timeout was hostile to cross-region peers.** lon1 → syd1 ≈ 280ms one-way; multi-packet PQC handshake (ML-KEM-768 pubkey + ML-DSA-65 cert) easily blows out 250ms. Bumped `PROBE_TIMEOUT` to **1250ms** matching saorsa-core's existing `DIRECT_CONNECT_TIMEOUT` precedent. Added `PROBE_HARD_CEILING = 5s` to bound the underlying `ConnectionDriver` lifetime.

- **P0-2: Unbounded probe queue + no in-flight dedup.** Capped at 256 in-flight and added per-address dedup so retries cost O(1) per unique candidate.

- **P2-14: Dropped the dead `StrategyConfig::probe_advertised_addresses` field.** It was wired through the public API but did nothing. The active knob is `NatTraversalConfig::probe_advertised_addresses`.

## Known limitation (acknowledged)

The probe goes through `endpoint.connect()` which spawns a real `ConnectionDriver`. On `PROBE_HARD_CEILING` expiry the driver keeps polling QUIC retransmits until the QUIC idle timer reaps it (tens of seconds). `PROBE_HARD_CEILING` bounds the worst case per probe; in-flight cap + dedup bound steady-state cost. A future refactor to expose `Endpoint::probe_addr` using raw UDP would eliminate the residual leak entirely. Not worth blocking this PR — the gate is **opt-in** and provides observable infrastructure for the bigger trust-events follow-up.

## Tests

- 5 new unit tests covering source-tracking, gate-on/off behaviour, promote/drop helpers, idempotence under races
- All **1524 lib tests pass** (3 ignored are pre-existing on `main`)
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean

**Not included**: an end-to-end integration test driving the full chain `handle_add_address → endpoint_events → drain → mpsc → run_single_address_probe → real connect → result feedback → promote`. Constructing two `NatTraversalEndpoint`s in-process to exercise this is non-trivial. The unit tests cover each link in isolation. Adding the e2e test is a low-risk follow-up before flipping the gate on by default in any prod deployment.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an opt-in reachability gate for `ADD_ADDRESS`-derived NAT candidates, addressing a measured amplification attack where one peer advertising an unreachable IP caused 35,592 dial timeouts across a 24-node fleet. The gate is default-off so existing behaviour is byte-identical unless `probe_advertised_addresses` is explicitly enabled.

- Introduces `CandidateState::Probing` which hides candidates from `PATH_CHALLENGE` selection and pair generation until a short-timeout QUIC Initial probe (1250 ms) confirms reachability; successful probes promote the candidate to `New`, failed probes mark it `Removed`.
- Adds plumbing through all three config layers (`TransportConfig`, `NatConfig`, `NatTraversalConfig`) and an async dispatch loop (`process_pending_address_probes`) in `NatTraversalEndpoint`; the in-flight probe queue is capped at 256 with per-address dedup to bound amplification from flooding peers.
- Ports the port-predictor feed behind the gate so attacker-advertised addresses cannot pollute predicted candidates even when the gate is off.

<h3>Confidence Score: 3/5</h3>

Safe to merge as infrastructure since the gate is default-off, but enabling the probe gate will leave some connections with permanently stuck Probing candidates.

The per-address dedup in `pending_address_probes` keys only on `candidate_addr`, not on the originating connection handle. In a network where two concurrent connections both receive an ADD_ADDRESS advertising the same external address, the second connection's Probing candidate receives no probe result and stays Probing indefinitely, silently blocking that path. This is a present defect on the enabled-gate code path.

src/endpoint.rs — the dedup/dispatch logic in the `ProbeAdvertisedAddress` arm needs to deliver a result (or fan out) to all connections that have a Probing candidate for the same address, not just the first one queued.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/endpoint.rs | Adds `pending_address_probes` queue with 256-cap and per-address dedup; dedup logic only keys on `candidate_addr`, leaving a second connection's Probing candidate permanently stuck when two connections observe the same advertised address. |
| src/connection/nat_traversal.rs | Adds `CandidateState::Probing`, `advertiser` field, `promote_probed_candidate`, and `drop_unreachable_candidate`; port-predictor gating on probe state is correct; pair generation and validation candidate filtering correctly exclude Probing candidates. |
| src/nat_traversal_api.rs | Adds `process_pending_address_probes` and `run_single_address_probe`; two doc-comment occurrences still reference the old 250 ms timeout instead of the actual 1250 ms `PROBE_TIMEOUT`. |
| src/connection/mod.rs | Adds `handle_advertised_address_probe_result` dispatching promote/drop on Probing candidates; byte-identical gate-off path preserved; loopback short-circuit correct. |
| src/high_level/endpoint.rs | Wires `address_probe_tx` channel and `deliver_address_probe_result` correctly; driver wake-up on result delivery is correct. |
| src/shared.rs | Adds `AdvertisedAddressProbeResult` connection event and `ProbeAdvertisedAddress` endpoint event; shape and documentation are clean. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Peer as Remote Peer
    participant Conn as Connection (low-level)
    participant EP as Endpoint (low-level)
    participant HEP as high_level::Endpoint
    participant NTE as NatTraversalEndpoint

    Peer->>Conn: ADD_ADDRESS frame
    Conn->>Conn: handle_add_address()
    alt probe gate ON and non-loopback
        Conn->>Conn: "add_remote_candidate(probing=true) -> Probing"
        Conn->>EP: EndpointEvent::ProbeAdvertisedAddress
        EP->>EP: dedup + cap check, push to pending_address_probes
        NTE->>HEP: process_pending_address_probes()
        HEP->>NTE: drain_address_probes()
        NTE->>NTE: tokio::spawn run_single_address_probe()
        NTE->>Peer: endpoint.connect() QUIC Initial
        alt handshake within 1250ms
            Peer-->>NTE: handshake OK
            NTE->>HEP: "deliver_address_probe_result(reachable=true)"
            HEP->>EP: deliver_advertised_address_probe_result
            EP->>Conn: ConnectionEvent::AdvertisedAddressProbeResult
            Conn->>Conn: "promote_probed_candidate() -> New"
            Conn->>Conn: trigger_candidate_validation()
        else timeout or error
            NTE->>HEP: "deliver_address_probe_result(reachable=false)"
            HEP->>EP: deliver_advertised_address_probe_result
            EP->>Conn: ConnectionEvent::AdvertisedAddressProbeResult
            Conn->>Conn: "drop_unreachable_candidate() -> Removed"
        end
    else probe gate OFF or loopback
        Conn->>Conn: "add_remote_candidate(probing=false) -> New"
        Conn->>Conn: trigger_candidate_validation()
    end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/endpoint.rs`, line 1111-1115 ([link](https://github.com/saorsa-labs/saorsa-transport/blob/ddda8a3a1b441b6642f739e8cefee657a93ab59a/src/endpoint.rs#L1111-L1115)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Per-address dedup leaves second connection's candidate stuck in `Probing` forever**

   The `already_queued` check deduplicates by `candidate_addr` only, ignoring the `source` (`ConnectionHandle`). When two concurrent connections each receive an `ADD_ADDRESS` frame advertising the same IP (e.g. peers A and B both advertise `1.2.3.4:9000` to us), the second `ProbeAdvertisedAddress` event is silently dropped. Because no `AdvertisedAddressProbeResult` event is ever delivered to that second connection, its candidate remains in `CandidateState::Probing` indefinitely — invisible to `PATH_CHALLENGE` and pair generation — permanently blocking that path even if the probe for the first connection succeeded and promoted its own candidate.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/endpoint.rs
   Line: 1111-1115

   Comment:
   **Per-address dedup leaves second connection's candidate stuck in `Probing` forever**

   The `already_queued` check deduplicates by `candidate_addr` only, ignoring the `source` (`ConnectionHandle`). When two concurrent connections each receive an `ADD_ADDRESS` frame advertising the same IP (e.g. peers A and B both advertise `1.2.3.4:9000` to us), the second `ProbeAdvertisedAddress` event is silently dropped. Because no `AdvertisedAddressProbeResult` event is ever delivered to that second connection, its candidate remains in `CandidateState::Probing` indefinitely — invisible to `PATH_CHALLENGE` and pair generation — permanently blocking that path even if the probe for the first connection succeeded and promoted its own candidate.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/endpoint.rs:1111-1115
**Per-address dedup leaves second connection's candidate stuck in `Probing` forever**

The `already_queued` check deduplicates by `candidate_addr` only, ignoring the `source` (`ConnectionHandle`). When two concurrent connections each receive an `ADD_ADDRESS` frame advertising the same IP (e.g. peers A and B both advertise `1.2.3.4:9000` to us), the second `ProbeAdvertisedAddress` event is silently dropped. Because no `AdvertisedAddressProbeResult` event is ever delivered to that second connection, its candidate remains in `CandidateState::Probing` indefinitely — invisible to `PATH_CHALLENGE` and pair generation — permanently blocking that path even if the probe for the first connection succeeded and promoted its own candidate.

### Issue 2 of 3
src/nat_traversal_api.rs:6976-6979
Stale doc comment says "250 ms timeout" but `PROBE_TIMEOUT` was bumped to 1250 ms (PR description, P0-4). Both the `process_pending_address_probes` and `run_single_address_probe` doc blocks still reference 250 ms.

```suggestion
    /// Called from the same poll cadence as
    /// [`Self::process_pending_peer_address_updates`]. The dispatch loop
    /// itself does not block on probe results — each probe runs on its own
    /// `tokio::spawn` future with a 1250 ms reachability timeout (bounded
    /// by a 5 s hard ceiling).
```

### Issue 3 of 3
src/nat_traversal_api.rs:6996-6997
Same stale "250 ms" in the `run_single_address_probe` function-level doc.

```suggestion
    /// Sends one QUIC Initial via `endpoint.connect()` and waits up to
    /// `PROBE_TIMEOUT` (1250 ms) for the handshake to complete. The result is delivered
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(nat): opt-in reachability gate for ..."](https://github.com/saorsa-labs/saorsa-transport/commit/ddda8a3a1b441b6642f739e8cefee657a93ab59a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32282094)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->