### PR TITLE
ci: add ADR governance compliance

### DIFF
--- a/.adr-kit.yaml
+++ b/.adr-kit.yaml
@@ -1,0 +1,18 @@
+# ADR kit configuration for repository-level decision governance.
+adr_directory: docs/adr
+filename_pattern: "ADR-[0-9]{4}-[a-z0-9-]+\.md"
+statuses:
+  - Proposed
+  - Accepted
+  - Superseded
+  - Deprecated
+  - Rejected
+immutable_statuses:
+  - Accepted
+required_sections:
+  - Context
+  - Decision
+  - Consequences
+  - Validation
+human_acceptance_required: true
+ai_may_accept: false

--- a/.github/workflows/adr-governance.yml
+++ b/.github/workflows/adr-governance.yml
@@ -1,0 +1,29 @@
+name: ADR Governance
+
+on:
+  pull_request:
+    paths:
+      - 'docs/adr/**'
+      - '.adr-kit.yaml'
+      - 'scripts/adr-governance.py'
+      - '.github/workflows/adr-governance.yml'
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - 'docs/adr/**'
+      - '.adr-kit.yaml'
+      - 'scripts/adr-governance.py'
+      - '.github/workflows/adr-governance.yml'
+
+jobs:
+  adr-governance:
+    name: Validate ADRs and immutable Accepted status
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run ADR governance checks
+        run: python3 scripts/adr-governance.py

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -1,0 +1,51 @@
+# ADR-NNNN: <Decision Title>
+
+- **Status:** Proposed
+- **Date:** YYYY-MM-DD
+- **Decision owners:** <names/handles>
+- **Reviewers:** <names/handles>
+- **Supersedes:** <ADR-NNNN or none>
+- **Superseded by:** <ADR-NNNN or none>
+- **Related:** <issues/PRs/specs>
+
+## Context
+
+What problem, constraint, or architectural tension forced this decision?
+
+## Decision Drivers
+
+- <driver 1>
+- <driver 2>
+- <driver 3>
+
+## Considered Options
+
+1. <option A>
+2. <option B>
+3. <option C>
+
+## Decision
+
+We will <state the chosen option clearly>.
+
+## Consequences
+
+### Positive
+
+- <benefit>
+
+### Negative / Trade-offs
+
+- <cost or risk>
+
+### Neutral / Operational
+
+- <ongoing implication>
+
+## Validation
+
+How will we know this decision remains correct? Include tests, metrics, audit checks, or review triggers.
+
+## Notes for AI-assisted work
+
+AI tools may help draft this ADR, but **must not mark it Accepted without human review**. Accepted ADRs are immutable: create a new superseding ADR rather than editing an Accepted ADR.

--- a/docs/adr/TOOLING.md
+++ b/docs/adr/TOOLING.md
@@ -1,0 +1,50 @@
+# ADR Tooling and AI Harness Setup
+
+We use ADRs as engineering memory, not paperwork. They capture *why* a decision was made, what alternatives were rejected, and what consequences we accept.
+
+## Install `adrs`
+
+`adrs` is the preferred local CLI for creating, searching, and checking ADRs.
+
+```bash
+cargo install adrs
+# or, if the repo has a Rust toolchain wrapper, use that wrapper's cargo equivalent.
+```
+
+Useful commands:
+
+```bash
+adrs list
+adrs search "post-quantum"
+adrs doctor
+```
+
+## Install `adr-kit`
+
+`adr-kit` is used for agent-aware ADR analysis and policy/lint generation where available.
+
+Recommended isolated install:
+
+```bash
+uv tool install adr-kit
+# fallback
+uvx adr-kit --help
+```
+
+If the published package name differs on your machine, install from the project source used by the team and keep it isolated with `uv tool` or `pipx` rather than a global Python environment.
+
+## AI harness guidance: pi, Codex, Claude Code, OpenCode
+
+Add this project instruction to every AI coding harness profile (`AGENTS.md`, `CLAUDE.md`, Codex/OpenCode project rules, pi harness prompts, etc.):
+
+```text
+Before changing architecture, protocols, storage formats, crypto, network behaviour, public APIs, data models, or operational invariants, inspect docs/adr/.
+If the change creates or changes an architectural decision, draft or update a Proposed ADR using docs/adr/TEMPLATE.md.
+Never edit an Accepted ADR. Create a superseding ADR instead.
+Never mark an ADR Accepted autonomously; that requires human engineering review and debate.
+During review, check ADR correctness, rejected alternatives, evidence, consequences, and immutable-Accepted compliance.
+```
+
+## Review standard
+
+Do **not** "vibe code" ADRs. A useful ADR must show clear thinking: context, options, trade-offs, consequences, and validation. AI can help prepare a draft, but humans must debate and own the decision.

--- a/scripts/adr-governance.py
+++ b/scripts/adr-governance.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Repository-local ADR governance checks.
+
+Enforces:
+- ADR files live under docs/adr/ and use ADR-NNNN-short-title.md.
+- Required sections exist.
+- Status is present and from the allowed lifecycle.
+- Accepted ADRs are immutable after acceptance. If a decision changes, create a
+  new ADR and supersede by reference rather than editing the Accepted ADR.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ADR_DIR = Path("docs/adr")
+ALLOWED_STATUSES = {"Proposed", "Accepted", "Superseded", "Deprecated", "Rejected"}
+REQUIRED_SECTIONS = ["Context", "Decision", "Consequences", "Validation"]
+FILENAME_RE = re.compile(r"^ADR-\d{4}-[a-z0-9][a-z0-9-]*\.md$")
+STATUS_RE = re.compile(r"(?im)^\s*(?:[-*]\s*)?.*?Status.*?:\s*(.+?)\s*$")
+
+
+def run(cmd: list[str]) -> str:
+    return subprocess.check_output(cmd, text=True, stderr=subprocess.DEVNULL).strip()
+
+
+def status_of(text: str) -> str | None:
+    m = STATUS_RE.search(text)
+    return m.group(1).strip().strip("*").strip() if m else None
+
+
+def base_ref() -> str | None:
+    ref = os.environ.get("GITHUB_BASE_REF")
+    if ref:
+        return f"origin/{ref}"
+    # On push, compare against first parent where available.
+    try:
+        return run(["git", "rev-parse", "HEAD^@"])
+    except Exception:
+        return None
+
+
+def changed_files_against_base(base: str) -> list[str]:
+    try:
+        return run(["git", "diff", "--name-only", f"{base}...HEAD"]).splitlines()
+    except Exception:
+        try:
+            return run(["git", "diff", "--name-only", f"{base}", "HEAD"]).splitlines()
+        except Exception:
+            return []
+
+
+def file_at(ref: str, path: str) -> str | None:
+    try:
+        return run(["git", "show", f"{ref}:{path}"])
+    except Exception:
+        return None
+
+
+def main() -> int:
+    errors: list[str] = []
+    if not ADR_DIR.exists():
+        print("No docs/adr directory; nothing to validate.")
+        return 0
+
+    adr_files = sorted(p for p in ADR_DIR.glob("ADR-*.md") if p.is_file())
+    base = base_ref()
+    changed = changed_files_against_base(base) if base else []
+    changed_adr_paths = {Path(name) for name in changed if name.startswith("docs/adr/ADR-") and name.endswith(".md")}
+
+    # Grandfather legacy ADRs when first installing governance. Enforce full
+    # structure on ADRs touched by this PR, while still checking duplicate
+    # numbers across the full directory.
+    files_to_validate = sorted((Path(p) for p in changed_adr_paths if Path(p).exists()), key=str) if base else adr_files
+
+    seen_numbers: dict[str, Path] = {}
+    for path in adr_files:
+        number = path.name.split("-", 2)[1] if "-" in path.name else path.name
+        if number in seen_numbers:
+            errors.append(f"{path}: duplicate ADR number also used by {seen_numbers[number]}")
+        seen_numbers[number] = path
+
+    for path in files_to_validate:
+        if not FILENAME_RE.match(path.name):
+            errors.append(f"{path}: filename must match ADR-NNNN-short-title.md")
+        text = path.read_text(encoding="utf-8")
+        st = status_of(text)
+        if not st:
+            errors.append(f"{path}: missing Status")
+        elif st not in ALLOWED_STATUSES:
+            errors.append(f"{path}: invalid Status '{st}' (allowed: {', '.join(sorted(ALLOWED_STATUSES))})")
+        for section in REQUIRED_SECTIONS:
+            if not re.search(rf"(?im)^##\s+{re.escape(section)}\b", text):
+                errors.append(f"{path}: missing required section '## {section}'")
+
+    if base:
+        for name in changed:
+            if not (name.startswith("docs/adr/ADR-") and name.endswith(".md")):
+                continue
+            old = file_at(base, name)
+            if old is None:
+                continue
+            old_status = status_of(old)
+            if old_status == "Accepted":
+                errors.append(
+                    f"{name}: Accepted ADRs are immutable. Create a new superseding ADR instead of editing this file."
+                )
+
+    if errors:
+        print("ADR governance failed:")
+        for e in errors:
+            print(f"- {e}")
+        return 1
+    print(f"ADR governance passed ({len(adr_files)} ADR file(s) checked).")
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/adr-governance.py
+++ b/scripts/adr-governance.py
@@ -38,7 +38,7 @@ def base_ref() -> str | None:
         return f"origin/{ref}"
     # On push, compare against first parent where available.
     try:
-        return run(["git", "rev-parse", "HEAD^@"])
+        return run(["git", "rev-parse", "HEAD^1"])
     except Exception:
         return None
 


### PR DESCRIPTION
## Summary

Adds repository-local ADR governance and team-standard ADR tooling:

- `docs/adr/TEMPLATE.md` with a structured ADR format
- `docs/adr/TOOLING.md` with `adrs`, `adr-kit`, Codex/Claude Code/OpenCode/pi harness guidance
- `.adr-kit.yaml` policy config
- `scripts/adr-governance.py` validation for ADR format, required sections, status values, duplicate numbers, and immutable `Accepted` ADRs
- `.github/workflows/adr-governance.yml` CI gate

For repos without existing ADRs, this also bootstraps `ADR-0001: Adopt Architecture Decision Records`.

## Why

ADRs are part of our engineering safety system, especially now we use AI coding assistance. They preserve the reasoning, rejected alternatives, consequences, and validation behind architectural decisions. `Accepted` ADRs must not be rewritten; if a decision changes, we create a superseding ADR so the audit trail remains intact.

## Review focus

- Check the ADR template is suitable for this repository.
- Check the immutable `Accepted` enforcement is strict enough.
- Check the harness guidance matches how contributors use Codex, Claude Code, OpenCode, and other agents.

## Test plan

- [x] Ran `python3 scripts/adr-governance.py` locally on the branch.
