### PR TITLE
fix: tolerate icmp-driven udp recv errors in endpoint driver

### DIFF
--- a/src/high_level/endpoint.rs
+++ b/src/high_level/endpoint.rs
@@ -1184,6 +1184,37 @@ struct RecvState {
     recv_limiter: WorkLimiter,
 }
 
+/// Returns `true` for UDP receive errors that pertain to a single prior
+/// transmit — typically surfaced from an ICMP error report — rather than to the
+/// shared endpoint socket itself. Such errors must NOT terminate the endpoint
+/// driver: the endpoint multiplexes every peer connection over one socket, so
+/// tearing it down on a per-peer ICMP report drops all connections at once and,
+/// because the driver is never respawned, wedges the node permanently.
+///
+/// On Windows these are delivered inline from `recvfrom` unless the
+/// `SIO_UDP_CONNRESET` / `SIO_UDP_NETRESET` ioctls are cleared (which this
+/// socket path does not do). The damaging one observed in the field is
+/// `WSAENETRESET` (os error 10052), reported for an ICMP "TTL expired in
+/// transit" on an earlier outbound datagram; it has no stable `io::ErrorKind`,
+/// so it is matched by raw code. The numeric WinSock codes do not collide with
+/// Unix `errno` values, so the raw-code check is harmless on every platform.
+fn is_transient_recv_error(e: &io::Error) -> bool {
+    use io::ErrorKind::{ConnectionRefused, ConnectionReset, HostUnreachable, NetworkUnreachable};
+    if matches!(
+        e.kind(),
+        ConnectionReset | ConnectionRefused | HostUnreachable | NetworkUnreachable
+    ) {
+        return true;
+    }
+    // WinSock codes for per-datagram ICMP conditions, several of which lack a
+    // portable `ErrorKind`: NETUNREACH(10051), NETRESET(10052), CONNRESET(10054),
+    // CONNREFUSED(10061), HOSTUNREACH(10065).
+    matches!(
+        e.raw_os_error(),
+        Some(10051 | 10052 | 10054 | 10061 | 10065)
+    )
+}
+
 impl RecvState {
     fn new(
         sender: mpsc::UnboundedSender<(ConnectionHandle, EndpointEvent)>,
@@ -1292,9 +1323,15 @@ impl RecvState {
                         keep_going: false,
                     });
                 }
-                // Ignore ECONNRESET as it's undefined in QUIC and may be injected by an
-                // attacker
-                Poll::Ready(Err(ref e)) if e.kind() == io::ErrorKind::ConnectionReset => {
+                // Tolerate per-datagram receive errors instead of killing the
+                // endpoint driver. ECONNRESET is undefined in QUIC and may be
+                // injected by an attacker; the ICMP-driven family (e.g. Windows
+                // WSAENETRESET / os error 10052) refers to a single prior transmit
+                // to one peer. Tearing down the shared socket for any of these
+                // drops every multiplexed connection permanently. See
+                // `is_transient_recv_error`.
+                Poll::Ready(Err(ref e)) if is_transient_recv_error(e) => {
+                    trace!(error = %e, "ignoring transient UDP recv error");
                     continue;
                 }
                 Poll::Ready(Err(e)) => {
@@ -1328,4 +1365,59 @@ struct PollProgress {
     received_connection_packet: bool,
     /// Whether datagram handling was interrupted early by the work limiter for fairness
     keep_going: bool,
+}
+
+#[cfg(test)]
+mod transient_recv_error_tests {
+    use super::is_transient_recv_error;
+    use std::io;
+
+    #[test]
+    fn wsaenetreset_10052_is_transient() {
+        // The exact error that wedged Windows nodes in the field: an ICMP
+        // "TTL expired in transit" surfaced as WSAENETRESET. It has no portable
+        // ErrorKind, so it must be recognised by its raw WinSock code.
+        assert!(is_transient_recv_error(&io::Error::from_raw_os_error(
+            10052
+        )));
+    }
+
+    #[test]
+    fn icmp_family_winsock_codes_are_transient() {
+        // NETUNREACH, CONNRESET, CONNREFUSED, HOSTUNREACH.
+        for code in [10051, 10054, 10061, 10065] {
+            assert!(
+                is_transient_recv_error(&io::Error::from_raw_os_error(code)),
+                "WinSock {code} should be tolerated"
+            );
+        }
+    }
+
+    #[test]
+    fn portable_error_kinds_are_transient() {
+        for kind in [
+            io::ErrorKind::ConnectionReset,
+            io::ErrorKind::ConnectionRefused,
+            io::ErrorKind::HostUnreachable,
+            io::ErrorKind::NetworkUnreachable,
+        ] {
+            assert!(
+                is_transient_recv_error(&io::Error::from(kind)),
+                "{kind:?} should be tolerated"
+            );
+        }
+    }
+
+    #[test]
+    fn genuinely_fatal_errors_still_propagate() {
+        // A dead/closed socket must still kill the driver, not be swallowed.
+        assert!(!is_transient_recv_error(&io::Error::from(
+            io::ErrorKind::NotConnected
+        )));
+        // WSAENETDOWN (10050) is deliberately excluded: a downed adapter is not a
+        // per-datagram condition and tolerating it could busy-loop the driver.
+        assert!(!is_transient_recv_error(&io::Error::from_raw_os_error(
+            10050
+        )));
+    }
 }


### PR DESCRIPTION
## Summary

The endpoint driver's receive loop treated every UDP recv error except `ECONNRESET` as fatal. A single error propagated out of `RecvState::poll_socket`, ended the `EndpointDriver` future, set `driver_lost = true`, and dropped every multiplexed connection. The driver is never respawned, so the node was wedged permanently afterwards — no dials, no accepts, near-zero network I/O (the reported "stall").

On Windows the shared UDP socket is a bare tokio socket that does not clear `SIO_UDP_CONNRESET` / `SIO_UDP_NETRESET`, so ICMP error reports surface inline from `recvfrom`. Field logs from a stalled Windows node pin the exact trigger: **`WSAENETRESET` (os error 10052)**, reported for an ICMP "TTL expired in transit" on a prior outbound datagram. It killed both of the node's endpoints within ~1.3 ms and tore down 1854 connections at once, after which every `connect()` returned `EndpointStopping`. The Linux production fleet never hits this (**0 occurrences across 30 nodes over 3 days**), confirming it is environmental to Windows rather than a network-wide fault.

## Change

`RecvState::poll_socket` now tolerates the ICMP-driven, per-datagram error family and `continue`s instead of tearing down the shared endpoint (new `is_transient_recv_error` helper):

- `ECONNRESET` (as before) plus net/host-unreachable and conn-refused, matched by `io::ErrorKind`
- `WSAENETRESET` and the rest matched by raw WinSock code, since 10052 has no portable `ErrorKind`
- Each tolerated error is logged at `trace`
- `WSAENETDOWN` (10050) is deliberately left fatal to avoid busy-looping on a genuinely downed adapter

Minimal, low-risk change scoped to the recv error path; the happy path is untouched. A more complete follow-up would be to configure the socket via `quinn_udp::UdpSocketState` (which clears the Windows ioctls and restores GSO/GRO), and to supervise/recreate the endpoint driver rather than leaving a dead one.

## Test plan

- [x] `cargo test` — 4 new unit tests for `is_transient_recv_error` (incl. the exact `10052` case and a fatal-error negative): **4 passed, 0 failed**
- [x] `cargo clippy --lib --tests -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] Staging testnet — confirm no regression on the normal recv/connect path (the `10052` path itself only reproduces on Windows under an ICMP event)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
