### PR TITLE
chore(release): promote rc-2026.6.3

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -5,14 +5,14 @@ name: Benchmarks
 
 on:
   push:
-    branches: [master, main]
+    branches: [master, main, "rc-*"]
     paths:
       - "src/**"
       - "Cargo.toml"
       - "Cargo.lock"
       - "benches/**"
   pull_request:
-    branches: [master, main]
+    branches: [master, main, "rc-*"]
     paths:
       - "src/**"
       - "Cargo.toml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ name: CI
 
 on:
   push:
-    branches: [master, main]
+    branches: [master, main, "rc-*"]
   pull_request:
-    branches: [master, main]
+    branches: [master, main, "rc-*"]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,9 +5,9 @@ name: Coverage
 
 on:
   push:
-    branches: [master, main]
+    branches: [master, main, "rc-*"]
   pull_request:
-    branches: [master, main]
+    branches: [master, main, "rc-*"]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -22,13 +22,13 @@ on:
           - minimal
           - full
   push:
-    branches: [master, main]
+    branches: [master, main, "rc-*"]
     paths:
       - '**.rs'
       - '**/Cargo.toml'
       - '**/Cargo.lock'
   pull_request:
-    branches: [master, main]
+    branches: [master, main, "rc-*"]
   schedule:
     # Run weekly
     - cron: '0 2 * * 1'

--- a/.github/workflows/quick-checks.yml
+++ b/.github/workflows/quick-checks.yml
@@ -2,9 +2,9 @@ name: Quick Checks
 
 on:
   push:
-    branches: [master, main]
+    branches: [master, main, "rc-*"]
   pull_request:
-    branches: [master, main]
+    branches: [master, main, "rc-*"]
   workflow_call:
     outputs:
       passed:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,14 +12,14 @@ on:
         value: ${{ jobs.security-report.result == 'success' }}
   workflow_dispatch:
   push:
-    branches: [master, main]
+    branches: [master, main, "rc-*"]
     paths:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
       - '.github/workflows/security.yml'
       - 'deny.toml'
   pull_request:
-    branches: [master, main]
+    branches: [master, main, "rc-*"]
     paths:
       - '**/Cargo.toml'
       - '**/Cargo.lock'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,13 +31,13 @@ on:
         type: boolean
         default: false
   push:
-    branches: [master, main]
+    branches: [master, main, "rc-*"]
     paths:
       - '**.rs'
       - '**/Cargo.toml'
       - '**/Cargo.lock'
   pull_request:
-    branches: [master, main]
+    branches: [master, main, "rc-*"]
   schedule:
     # Extended tests weekly on Mondays at 4 AM UTC
     - cron: '0 4 * * 1'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2525,9 +2525,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3062,7 +3062,7 @@ dependencies = [
 
 [[package]]
 name = "saorsa-transport"
-version = "0.35.0"
+version = "0.35.1-rc.1"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3062,7 +3062,7 @@ dependencies = [
 
 [[package]]
 name = "saorsa-transport"
-version = "0.35.1-rc.1"
+version = "0.35.1"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "saorsa-transport"
-version = "0.35.1-rc.1"
+version = "0.35.1"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "saorsa-transport"
-version = "0.35.0"
+version = "0.35.1-rc.1"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/docs/adr/ADR-011-stable-relay-port-reservations.md
+++ b/docs/adr/ADR-011-stable-relay-port-reservations.md
@@ -1,0 +1,237 @@
+# ADR-011: Stable Relay Port Reservations (Authenticated, Leased)
+
+## Status
+
+Proposed (2026-06-24)
+
+## Context
+
+### The problem: relay reconnects mint permanent dead addresses
+
+Each MASQUE relay session binds a fresh OS-assigned UDP port. In
+`src/masque/relay_server.rs` the relay binds `SocketAddr::new(UNSPECIFIED, 0)`,
+reads back the kernel-assigned port via `local_addr().port()`, and advertises
+`SocketAddr::new(public_ip, bound_port)` to the relayed peer, which then
+publishes it into the DHT.
+
+Sessions are tracked only by session id and **client socket address**
+(`client_to_session: HashMap<SocketAddr, u64>`). There is no peer-identity map
+and no reservation concept. When a session ends, `close_session` removes the
+maps and **drops the `Arc<UdpSocket>`**, freeing the port forever.
+
+Production analysis of file uploads showed relayed peers' sessions die and
+re-establish constantly — one peer produced **13 sessions (13 distinct ports)
+in a single day to the same relay**. Because each reconnect gets a brand-new
+address, every previously-advertised `relay_ip:port` is orphaned the instant the
+session drops and never becomes valid again. The owner only heals the DHT when
+it eventually re-advertises and that propagates (tens of minutes to hours).
+Churny peers therefore leave a growing trail of permanently-dead addresses in
+FIND_NODE — a major contributor to the observed **~25% dead-record fraction**
+and **~53% relay-dial-failure rate**.
+
+### Why a stable port helps at the source
+
+If a reconnecting peer is handed **the same `relay_ip:port`** it had before,
+every DHT entry already pointing at that peer self-heals the moment it
+reconnects — no re-advertise, no propagation wait, no orphan. This attacks the
+dead-record problem at the source (stops minting orphans) rather than mopping up
+after it client-side. We operate roughly **half of the network's relays**, so it
+can be deployed on our own nodes unilaterally and measured.
+
+### Why it is not a simple port-allocator tweak
+
+A naive "reuse the last port for this peer" allocator is unsafe. Adversarial
+review requires that identity binding, handover, replay, DoS, lease, and privacy
+semantics all be specified first. The relay did not even have the relayed peer's
+authenticated identity in scope at allocation time: the QUIC connection is
+PQC-authenticated (ML-KEM-768 + ML-DSA-65) and the peer's public key is
+extractable via `connection.peer_identity()`, but that identity was dropped
+before `handle_connect_request` ran — which received only `client_addr`. Any
+peer id in `ConnectUdpRequest` payload would be untrusted and spoofable.
+
+## Decision
+
+Introduce an **authenticated, leased, identity-keyed relay-port reservation**,
+applied unconditionally for authenticated relayed peers, with structured INFO
+logs as a metrics substitute (the node has no metrics system, and only INFO/WARN
+reach the log pipeline). `reservation_ttl` and `max_reservations` are plain
+tuning numbers on the relay config (like `max_sessions`), not feature toggles.
+
+### 1. Authenticated identity source
+
+The relayed peer's authenticated identity is derived once per connection as the
+canonical `AUTONOMI_PEER_ID_V2` fingerprint — BLAKE3 over the ML-DSA-65 public
+key from `connection.peer_identity()` (`authenticated_peer_fingerprint`). It is
+threaded into `handle_connect_request` and stored on `RelaySession`. A peer id
+supplied in request payload is **never** used.
+
+### 2. Leased reservation, retained socket (Option A)
+
+`MasqueRelayServer` holds `reservations: RwLock<HashMap<RelayPeerId, Reservation>>`
+where `Reservation { port, udp_socket: Arc<UdpSocket>, upnp, released_at }`.
+
+When an authenticated peer's session ends, instead of dropping the socket we
+**move the bound `UdpSocket` (and its UPnP mapping) into the reservation**
+(`released_at = now`). Because we keep the socket bound for the lease, the port
+**cannot be reassigned to anyone else** — reuse is conflict-free. The
+reservation is bounded by:
+
+- `reservation_ttl` (default 10 min) — lease lifetime after session loss;
+- `max_reservations` (default 1024) — an LRU cap; the least-recently-released
+  reservation is evicted (and its port freed) when the cap is reached.
+
+Expiry is **lazy + LRU-bounded** (no background sweeper): a reconnecting peer
+discards its own over-TTL reservation on reclaim, vanished peers are reclaimed by
+the LRU cap, and `cleanup_expired_reservations()` is exposed for a future
+maintenance tick or tests. This matches the existing dial-failure-cache pattern
+and avoids new startup wiring (the relay server has no periodic task today).
+
+### 3. Safe reconnect / handover
+
+On an incoming CONNECT from authenticated peer `P` (`reclaim_reservation`):
+
+- If `P` still has a **live session** (duplicate / stale half-open), it is
+  retired first — `close_session` leases that session's port into
+  `reservations`, which the step below then reclaims. This is the deterministic
+  handover: the port is reused only after ownership is unambiguous.
+- The reservation is taken only if it is **fresh** (within `reservation_ttl`) and
+  its socket matches the client's **IP family**; otherwise it is discarded and a
+  fresh port is bound.
+
+Concurrent CONNECTs from the same identity are serialized by the reservation
+lock so only one adopts the port.
+
+### 4. Fallback path
+
+Any miss — no authenticated identity, no/stale/mismatched reservation, feature
+disabled — falls through to the original random `UNSPECIFIED:0` bind. Relay
+acquisition is never wedged on "must have the previous port". Because Option A
+holds the socket for the lease, a bind **conflict** cannot arise on the reuse
+path (it is the failure mode of the rejected Option B, where only the port
+number is remembered and re-bound).
+
+### 5. DHT freshness preserved
+
+No change to the publish path. The owner's `PublishAddressSet` remains
+authoritative and sequence-ordered (monotonic `seq`, `last_publish_seqs`
+newer-wins, FIND_NODE "newest seq beats XOR-closer stale report"). Relay-loss
+still triggers direct-only/updated republish, and relayer-eligibility / K-closest
+checks still apply. Stable ports simply make the already-published address valid
+again on reconnect.
+
+### 6. Companion client failure-cache adjustment (saorsa-core)
+
+The client `DialFailureCache` is keyed by socket address with a 30-minute TTL and
+clears only on a successful dial. With random ports a recovered peer dodges the
+cache (new port = new key); with **stable** ports the recovered `relay_ip:port`
+is the *same* key and would stay suppressed for up to 30 minutes — blunting the
+self-heal. Therefore, when a **higher-`seq`** `PublishAddressSet` is *applied*
+for a peer, saorsa-core clears the dial-failure entries for that peer's
+newly-published socket addresses (`clear_dial_failures_for_published`), so a
+self-healed address is re-admitted immediately. Shipped as a separate saorsa-core
+commit; it runs in both the node and the `ant` client.
+
+### 7. Logs as metrics
+
+All reservation lines share a stable `component = "relay_reservation"` with an
+`event` field and carry the peer fingerprint (short hex) and port. They are
+tiered by level to keep **production** log volume low while leaving full detail
+for a **testnet** run, because the node forwards only INFO/WARN to the log
+pipeline (Elasticsearch) and the per-event lines fire once per relay-session
+lifecycle:
+
+- **DEBUG (per-event detail, testnet):** `reclaim_hit`, `reclaim_miss`,
+  `reservation_created`, `reservation_expired`. Enabled on a testnet via
+  `RUST_LOG=saorsa_transport::masque=debug`; off production ES entirely.
+- **INFO (production signal):**
+  - `event = "summary"` — a rate-limited "gauge" line
+    (`RELAY_RESERVATION_SUMMARY_INTERVAL_MS`, default 5 min) carrying cumulative
+    `hits / misses / created / expired / evicted` and the current
+    `active_reservations`. Emitted opportunistically from the CONNECT path (no
+    background task), so a busy relay reports ~once per interval and an idle one
+    not at all. This is enough to confirm on production that reuse is happening
+    (hits climbing) and to watch the pool size.
+  - `reservation_evicted` — kept at INFO because it is rare and signals that
+    `max_reservations` is being hit (the cap may be too low).
+
+There is no `bind_conflict` event — Option A makes reuse conflict-free (see §4).
+
+## Consequences
+
+### Benefits
+- Existing DHT records pointing at a reconnecting peer self-heal immediately — no
+  re-advertise, no propagation wait, no orphan trail. Targets the dead-record /
+  dial-failure rate at source.
+- Deployable unilaterally on the relays we operate (~50%). Validation is a
+  binary A/B — the current release (no reservations) as baseline vs the new
+  build as treatment — since the behaviour is unconditional rather than toggled.
+- Fewer distinct relay addresses per peer over time collapses the "13 ports/day"
+  pattern toward one, which also makes the client IP-tier suppressor (V2-463)
+  less likely to mis-trip.
+
+### Costs / trade-offs
+- Each idle reservation holds an open UDP socket + fd until TTL/eviction —
+  bounded by `max_reservations` (LRU) and `reservation_ttl`. Expiry is lazy, so
+  in the worst case up to `max_reservations` idle sockets are held until the cap
+  forces eviction.
+- Added state and lock discipline on the relay connect/close paths; the handover
+  logic must be correct (covered by unit tests).
+- **Privacy:** a stable port links "this port ⇄ this peer" at the relay across
+  reconnects for the lease window. The peer↔relay-address mapping is already
+  public in the DHT, so the added linkability is bounded to the lease window; the
+  TTL caps it. Accepted, documented.
+- A first rollout needs both the relay binary (nodes) and, for the cache-clear
+  benefit, the saorsa-core change in the client binary.
+
+### Security semantics (adversarial review)
+- **Identity binding:** reservation key is the authenticated ML-DSA fingerprint
+  from the QUIC connection; payload identity is never trusted.
+- **Handover:** authenticated same-identity reconnect retires the old session and
+  reuses the port under lock; a different identity can never reuse another peer's
+  port (different key).
+- **Replay:** a replayed CONNECT cannot authenticate as `P` without `P`'s ML-DSA
+  key (the QUIC handshake binds it); the port is only ever handed to a live
+  authenticated connection.
+- **DoS:** one reservation per identity (reconnects reuse, they do not multiply);
+  total bounded by `max_reservations` LRU + TTL; idle reservations evicted under
+  pressure; fd/memory bounded. An attacker minting many identities is capped by
+  the LRU and gains nothing per-port.
+- **Lease:** bounded TTL after session loss; no permanent reservation; in-memory
+  only, **not** persisted across relay restart (a restart yields fresh random
+  ports and the seq mechanism heals the DHT normally).
+- **Privacy:** as above — bounded by the lease window, accepted.
+
+## Alternatives Considered
+
+- **Naive "reuse last port" allocator.** Rejected: no identity binding →
+  spoofable; no lease/DoS bounds; review-blocked.
+- **Option B — remember only the port number, rebind on reconnect.** Simpler
+  state (no idle socket held) but the port can be reassigned between sessions,
+  producing bind conflicts and reclaim misses. Documented as the fallback shape
+  but not implemented; Option A (hold the socket) is conflict-free.
+- **Client-side eviction only (drop dead relay records faster).** Mops up after
+  the fact rather than stopping orphan creation; complementary, not a substitute.
+  The companion cache-clear (§6) is a minimal, targeted version of this.
+- **Persisting reservations across relay restart.** Rejected: violates "no
+  permanent reservation," adds replay/ownership complexity; the seq mechanism
+  already heals post-restart.
+- **A background maintenance sweeper for prompt expiry + a periodic gauge.**
+  Deferred: the relay server has no maintenance tick today (session cleanup is
+  likewise unscheduled). Lazy + LRU expiry is sufficient and self-contained; a
+  sweeper can be added later at the `RelayManager` keepalive tick.
+- **Building a real metrics subsystem.** Out of scope; structured INFO logs are
+  sufficient for validation given the log pipeline.
+
+## References
+
+- Implementation (branch `feat-consistent_relay_port`): `src/masque/relay_server.rs`
+  (`authenticated_peer_fingerprint` via `nat_traversal_api.rs`, `Reservation`,
+  `lease_reservation`, `reclaim_reservation`, `cleanup_expired_reservations`),
+  `src/masque/relay_session.rs` (`RelayPeerId`, `peer_id`).
+- Identity: `src/nat_traversal_api.rs` (`authenticated_peer_fingerprint`,
+  `extract_public_key_from_connection`), `src/crypto/raw_public_keys/pqc.rs`
+  (`fingerprint_public_key`, `extract_public_key_from_spki`).
+- Companion: saorsa-core `src/dht_network_manager.rs`
+  (`clear_dial_failures_for_published`, `PublishAddressSet` handler,
+  `DialFailureCache`); prior work V2-463 (relay-IP tier).
+- Related ADRs: ADR-006 (MASQUE relay fallback), ADR-009 (relay data plane).

--- a/docs/adr/ADR-011-stable-relay-port-reservations.md
+++ b/docs/adr/ADR-011-stable-relay-port-reservations.md
@@ -88,18 +88,25 @@ and avoids new startup wiring (the relay server has no periodic task today).
 
 ### 3. Safe reconnect / handover
 
-On an incoming CONNECT from authenticated peer `P` (`reclaim_reservation`):
+On an incoming CONNECT from authenticated peer `P`, `handle_connect_request`:
 
-- If `P` still has a **live session** (duplicate / stale half-open), it is
-  retired first — `close_session` leases that session's port into
-  `reservations`, which the step below then reclaims. This is the deterministic
-  handover: the port is reused only after ownership is unambiguous.
-- The reservation is taken only if it is **fresh** (within `reservation_ttl`) and
-  its socket matches the client's **IP family**; otherwise it is discarded and a
-  fresh port is bound.
+- Acquires a **per-identity mutex stripe** (bounded; indexed by the fingerprint)
+  and holds it across the handover, the capacity/duplicate checks, the reclaim,
+  and the session insert — so concurrent CONNECTs from the same identity are
+  serialized and never leave two live sessions for one identity.
+- **Retires any live session `P` already holds, before the capacity/duplicate
+  checks**, so an authenticated reconnect is not rejected with `503`/`409`. A
+  session whose stream-forwarding loop is still live is *not* leased (its
+  reader/writer tasks still hold the socket); that handover therefore takes a
+  **fresh** port. The common path — `P` disconnected, its loop ended and leased
+  the port, then `P` reconnects — reclaims the **same** port.
+- Takes the reservation only if it is **fresh** (within `reservation_ttl`) and
+  its socket matches the client's **IP family**; otherwise discards it and binds
+  a fresh port.
 
-Concurrent CONNECTs from the same identity are serialized by the reservation
-lock so only one adopts the port.
+Socket exclusivity is enforced by aborting and awaiting a session's forwarding
+tasks before its socket can be leased/reclaimed, so old and new sessions never
+share a socket (see §"Consequences").
 
 ### 4. Fallback path
 

--- a/docs/adr/ADR-011-stable-relay-port-reservations.md
+++ b/docs/adr/ADR-011-stable-relay-port-reservations.md
@@ -95,18 +95,23 @@ On an incoming CONNECT from authenticated peer `P`, `handle_connect_request`:
   and the session insert — so concurrent CONNECTs from the same identity are
   serialized and never leave two live sessions for one identity.
 - **Retires any live session `P` already holds, before the capacity/duplicate
-  checks**, so an authenticated reconnect is not rejected with `503`/`409`. A
-  session whose stream-forwarding loop is still live is *not* leased (its
-  reader/writer tasks still hold the socket); that handover therefore takes a
-  **fresh** port. The common path — `P` disconnected, its loop ended and leased
-  the port, then `P` reconnects — reclaims the **same** port.
+  checks**, so an authenticated reconnect is not rejected with `503`/`409`.
+  `close_session` **cancels and awaits** that session's stream-forwarding loop —
+  the loop aborts its reader/writer tasks and releases the socket before the
+  call returns — so no orphaned data plane survives the handover and the port can
+  be leased and immediately reclaimed by the reconnect (**same** port). The
+  common path (`P` disconnected, its loop ended and leased the port, then `P`
+  reconnects) reclaims the same port the same way.
 - Takes the reservation only if it is **fresh** (within `reservation_ttl`) and
   its socket matches the client's **IP family**; otherwise discards it and binds
   a fresh port.
 
-Socket exclusivity is enforced by aborting and awaiting a session's forwarding
-tasks before its socket can be leased/reclaimed, so old and new sessions never
-share a socket (see §"Consequences").
+Socket exclusivity is enforced two ways: the loop aborts and awaits its forwarding
+tasks on its own exit, and `close_session` cancels and awaits a still-live loop
+before the socket can be leased/reclaimed — so old and new sessions never share a
+socket. The connection handler also forwards the **exact** session id returned by
+`handle_connect_request` (not a later client-address lookup), and a loop claims its
+session id, so one session never gets two forwarding loops.
 
 ### 4. Fallback path
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,6 +20,7 @@ ADRs document significant architectural decisions made in the project. Each reco
 | [ADR-008](ADR-008-universal-connectivity-architecture.md) | Universal Connectivity Architecture | Accepted | 2025-12-26 |
 | [ADR-009](ADR-009-masque-relay-data-plane.md) | MASQUE Relay Data Plane Implementation | Accepted | 2026-03-29 |
 | [ADR-010](ADR-010-repository-ownership.md) | Repository Ownership under WithAutonomi | Accepted | 2026-05-29 |
+| [ADR-011](ADR-011-stable-relay-port-reservations.md) | Stable Relay Port Reservations (Authenticated, Leased) | Proposed | 2026-06-24 |
 
 ## ADR Template
 

--- a/src/high_level/endpoint.rs
+++ b/src/high_level/endpoint.rs
@@ -1184,6 +1184,37 @@ struct RecvState {
     recv_limiter: WorkLimiter,
 }
 
+/// Returns `true` for UDP receive errors that pertain to a single prior
+/// transmit — typically surfaced from an ICMP error report — rather than to the
+/// shared endpoint socket itself. Such errors must NOT terminate the endpoint
+/// driver: the endpoint multiplexes every peer connection over one socket, so
+/// tearing it down on a per-peer ICMP report drops all connections at once and,
+/// because the driver is never respawned, wedges the node permanently.
+///
+/// On Windows these are delivered inline from `recvfrom` unless the
+/// `SIO_UDP_CONNRESET` / `SIO_UDP_NETRESET` ioctls are cleared (which this
+/// socket path does not do). The damaging one observed in the field is
+/// `WSAENETRESET` (os error 10052), reported for an ICMP "TTL expired in
+/// transit" on an earlier outbound datagram; it has no stable `io::ErrorKind`,
+/// so it is matched by raw code. The numeric WinSock codes do not collide with
+/// Unix `errno` values, so the raw-code check is harmless on every platform.
+fn is_transient_recv_error(e: &io::Error) -> bool {
+    use io::ErrorKind::{ConnectionRefused, ConnectionReset, HostUnreachable, NetworkUnreachable};
+    if matches!(
+        e.kind(),
+        ConnectionReset | ConnectionRefused | HostUnreachable | NetworkUnreachable
+    ) {
+        return true;
+    }
+    // WinSock codes for per-datagram ICMP conditions, several of which lack a
+    // portable `ErrorKind`: NETUNREACH(10051), NETRESET(10052), CONNRESET(10054),
+    // CONNREFUSED(10061), HOSTUNREACH(10065).
+    matches!(
+        e.raw_os_error(),
+        Some(10051 | 10052 | 10054 | 10061 | 10065)
+    )
+}
+
 impl RecvState {
     fn new(
         sender: mpsc::UnboundedSender<(ConnectionHandle, EndpointEvent)>,
@@ -1292,9 +1323,15 @@ impl RecvState {
                         keep_going: false,
                     });
                 }
-                // Ignore ECONNRESET as it's undefined in QUIC and may be injected by an
-                // attacker
-                Poll::Ready(Err(ref e)) if e.kind() == io::ErrorKind::ConnectionReset => {
+                // Tolerate per-datagram receive errors instead of killing the
+                // endpoint driver. ECONNRESET is undefined in QUIC and may be
+                // injected by an attacker; the ICMP-driven family (e.g. Windows
+                // WSAENETRESET / os error 10052) refers to a single prior transmit
+                // to one peer. Tearing down the shared socket for any of these
+                // drops every multiplexed connection permanently. See
+                // `is_transient_recv_error`.
+                Poll::Ready(Err(ref e)) if is_transient_recv_error(e) => {
+                    trace!(error = %e, "ignoring transient UDP recv error");
                     continue;
                 }
                 Poll::Ready(Err(e)) => {
@@ -1328,4 +1365,59 @@ struct PollProgress {
     received_connection_packet: bool,
     /// Whether datagram handling was interrupted early by the work limiter for fairness
     keep_going: bool,
+}
+
+#[cfg(test)]
+mod transient_recv_error_tests {
+    use super::is_transient_recv_error;
+    use std::io;
+
+    #[test]
+    fn wsaenetreset_10052_is_transient() {
+        // The exact error that wedged Windows nodes in the field: an ICMP
+        // "TTL expired in transit" surfaced as WSAENETRESET. It has no portable
+        // ErrorKind, so it must be recognised by its raw WinSock code.
+        assert!(is_transient_recv_error(&io::Error::from_raw_os_error(
+            10052
+        )));
+    }
+
+    #[test]
+    fn icmp_family_winsock_codes_are_transient() {
+        // NETUNREACH, CONNRESET, CONNREFUSED, HOSTUNREACH.
+        for code in [10051, 10054, 10061, 10065] {
+            assert!(
+                is_transient_recv_error(&io::Error::from_raw_os_error(code)),
+                "WinSock {code} should be tolerated"
+            );
+        }
+    }
+
+    #[test]
+    fn portable_error_kinds_are_transient() {
+        for kind in [
+            io::ErrorKind::ConnectionReset,
+            io::ErrorKind::ConnectionRefused,
+            io::ErrorKind::HostUnreachable,
+            io::ErrorKind::NetworkUnreachable,
+        ] {
+            assert!(
+                is_transient_recv_error(&io::Error::from(kind)),
+                "{kind:?} should be tolerated"
+            );
+        }
+    }
+
+    #[test]
+    fn genuinely_fatal_errors_still_propagate() {
+        // A dead/closed socket must still kill the driver, not be swallowed.
+        assert!(!is_transient_recv_error(&io::Error::from(
+            io::ErrorKind::NotConnected
+        )));
+        // WSAENETDOWN (10050) is deliberately excluded: a downed adapter is not a
+        // per-datagram condition and tolerating it could busy-loop the driver.
+        assert!(!is_transient_recv_error(&io::Error::from_raw_os_error(
+            10050
+        )));
+    }
 }

--- a/src/masque/connect.rs
+++ b/src/masque/connect.rs
@@ -275,6 +275,11 @@ pub struct ConnectUdpResponse {
     pub proxy_public_address: Option<SocketAddr>,
     /// Human-readable reason phrase
     pub reason: Option<String>,
+    /// Relay-internal: the session id created for a successful CONNECT. NOT part
+    /// of the wire format (it is not encoded/decoded); the relay sets it so the
+    /// connection handler can start forwarding the *exact* session it created,
+    /// rather than re-looking-up by client address (which races on reconnect).
+    pub session_id: Option<u64>,
 }
 
 impl ConnectUdpResponse {
@@ -295,6 +300,7 @@ impl ConnectUdpResponse {
             status: Self::STATUS_OK,
             proxy_public_address: public_addr,
             reason: None,
+            session_id: None,
         }
     }
 
@@ -304,6 +310,7 @@ impl ConnectUdpResponse {
             status,
             proxy_public_address: None,
             reason: Some(reason.into()),
+            session_id: None,
         }
     }
 
@@ -454,6 +461,9 @@ impl ConnectUdpResponse {
             status,
             proxy_public_address,
             reason,
+            // Not part of the wire format; only set by the relay on the response
+            // object it returns locally.
+            session_id: None,
         })
     }
 }

--- a/src/masque/mod.rs
+++ b/src/masque/mod.rs
@@ -124,5 +124,7 @@ pub use relay_server::{
     DatagramResult, MasqueRelayConfig, MasqueRelayServer, MasqueRelayStats, OutboundDatagram,
     SessionInfo,
 };
-pub use relay_session::{RelaySession, RelaySessionConfig, RelaySessionState, RelaySessionStats};
+pub use relay_session::{
+    RelayPeerId, RelaySession, RelaySessionConfig, RelaySessionState, RelaySessionStats,
+};
 pub use relay_socket::{MasqueRelaySocket, RawRelayStreams};

--- a/src/masque/relay_server.rs
+++ b/src/masque/relay_server.rs
@@ -33,13 +33,14 @@
 
 use bytes::Bytes;
 use parking_lot::RwLock as ParkingRwLock;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 use tokio::net::UdpSocket;
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::{Mutex, Notify, RwLock};
+use tokio_util::sync::CancellationToken;
 
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))]
 use std::os::unix::io::AsRawFd;
@@ -376,6 +377,19 @@ fn short_peer_hex(id: &RelayPeerId) -> String {
     s
 }
 
+/// Per-session control handle for the stream-forwarding loop (ADR-011).
+///
+/// `cancel` lets `close_session` stop a still-live forwarding loop — e.g. a
+/// same-identity handover — rather than leaving an untracked data plane running
+/// after the session is removed. `done` is signalled by the loop once it has
+/// aborted its reader/writer tasks and released the socket, so a handover waits
+/// until the old loop has fully quiesced before the port is reused.
+#[derive(Clone)]
+struct ForwardingControl {
+    cancel: CancellationToken,
+    done: Arc<Notify>,
+}
+
 /// A retained stable relay-port reservation (ADR-011).
 ///
 /// Created when a relayed peer's session ends: instead of dropping the bound
@@ -441,14 +455,14 @@ pub struct MasqueRelayServer {
     reservations_evicted: AtomicU64,
     /// Epoch-millis of the last reservation summary emit (rate-limit gate).
     last_reservation_summary_ms: AtomicU64,
-    /// Session IDs whose stream-forwarding loop is currently live. While a
-    /// session is in this set its reader/writer tasks still hold the bound UDP
-    /// socket, so `close_session` must NOT lease that socket into a reservation
-    /// (a still-live handover): leasing+reclaiming a live socket would let the
-    /// old and new sessions race on the same port. The natural session-end path
-    /// removes the id only after aborting its forwarding tasks, so the socket is
-    /// exclusively owned before it can be leased.
-    active_forwarding: RwLock<HashSet<u64>>,
+    /// Control handles for currently-live stream-forwarding loops, keyed by
+    /// session id. Lets `close_session` cancel and await a live loop (so a
+    /// same-identity handover stops the old data plane before reusing the port)
+    /// and serves as a claim so a session never gets two concurrent loops. A
+    /// loop registers here before touching its socket and deregisters only after
+    /// aborting its reader/writer tasks, so the socket is exclusively owned by the
+    /// time it can be leased.
+    forwarding: RwLock<HashMap<u64, ForwardingControl>>,
     /// Mutex stripes serializing concurrent CONNECTs from the same authenticated
     /// identity (ADR-011), indexed by the first fingerprint byte. Length is
     /// `RELAY_PEER_LOCK_STRIPES`.
@@ -511,7 +525,7 @@ impl MasqueRelayServer {
             last_reservation_summary_ms: AtomicU64::new(0),
             upnp_mappings: RwLock::new(HashMap::new()),
             reservations: RwLock::new(HashMap::new()),
-            active_forwarding: RwLock::new(HashSet::new()),
+            forwarding: RwLock::new(HashMap::new()),
             peer_locks: (0..RELAY_PEER_LOCK_STRIPES)
                 .map(|_| Mutex::new(()))
                 .collect(),
@@ -583,7 +597,7 @@ impl MasqueRelayServer {
             last_reservation_summary_ms: AtomicU64::new(0),
             upnp_mappings: RwLock::new(HashMap::new()),
             reservations: RwLock::new(HashMap::new()),
-            active_forwarding: RwLock::new(HashSet::new()),
+            forwarding: RwLock::new(HashMap::new()),
             peer_locks: (0..RELAY_PEER_LOCK_STRIPES)
                 .map(|_| Mutex::new(()))
                 .collect(),
@@ -773,10 +787,9 @@ impl MasqueRelayServer {
         // any live session this identity already holds, so an authenticated
         // reconnect is never rejected by the capacity (503) or duplicate-address
         // (409) checks below, and we never leave two live sessions for one
-        // identity. close_session will not lease a still-forwarding session's
-        // socket (see `active_forwarding`), so a live handover takes a fresh port;
-        // the common disconnect→reconnect path instead reclaims the reservation
-        // left when the previous session's forwarding loop ended.
+        // identity. close_session cancels and awaits the old session's forwarding
+        // loop before leasing its socket, so the old data plane is fully stopped
+        // and the reclaim below hands this reconnect back the same port.
         if let Some(pid) = peer_id {
             let old = {
                 let sessions = self.sessions.read().await;
@@ -989,7 +1002,12 @@ impl MasqueRelayServer {
             "MASQUE relay session created with bound UDP socket"
         );
 
-        Ok(ConnectUdpResponse::success(Some(advertised_address)))
+        // Expose the exact session id so the connection handler forwards *this*
+        // session rather than re-looking-up by client address (which races with a
+        // same-address reconnect). Not part of the wire format.
+        let mut response = ConnectUdpResponse::success(Some(advertised_address));
+        response.session_id = Some(session_id);
+        Ok(response)
     }
 
     /// Get session for a specific client address
@@ -1382,11 +1400,34 @@ impl MasqueRelayServer {
         mut send_stream: crate::high_level::SendStream,
         mut recv_stream: crate::high_level::RecvStream,
     ) {
-        // Mark this session's forwarding as live BEFORE touching the socket, so a
-        // concurrent handover close_session sees it active and will not lease the
-        // socket out from under us (Blocker 1). Removed on every exit path below.
-        self.active_forwarding.write().await.insert(session_id);
+        // Claim this session's forwarding slot BEFORE touching the socket. The
+        // registration (a) lets a concurrent handover close_session cancel this
+        // loop and wait until it has released the socket, and (b) guards against a
+        // second loop ever running for the same session id (e.g. a racing
+        // duplicate from the connection handler). If one is already registered,
+        // do not start another.
+        let cancel = CancellationToken::new();
+        let done = Arc::new(Notify::new());
+        let claimed = match self.forwarding.write().await.entry(session_id) {
+            std::collections::hash_map::Entry::Occupied(_) => false,
+            std::collections::hash_map::Entry::Vacant(slot) => {
+                slot.insert(ForwardingControl {
+                    cancel: cancel.clone(),
+                    done: done.clone(),
+                });
+                true
+            }
+        };
+        if !claimed {
+            tracing::debug!(
+                session_id,
+                "stream forwarding already active for session; not starting a second loop"
+            );
+            return;
+        }
 
+        // From here every exit path must call `finish_forwarding` so a handover
+        // close_session waiting on `done` is released.
         let udp_socket = {
             let sessions = self.sessions.read().await;
             match sessions.get(&session_id) {
@@ -1396,7 +1437,7 @@ impl MasqueRelayServer {
                         session_id,
                         "Cannot start stream forwarding: session not found"
                     );
-                    self.active_forwarding.write().await.remove(&session_id);
+                    self.finish_forwarding(session_id, &done).await;
                     return;
                 }
             }
@@ -1406,7 +1447,7 @@ impl MasqueRelayServer {
             Some(s) => s,
             None => {
                 tracing::warn!(session_id, "Cannot start stream forwarding: no UDP socket");
-                self.active_forwarding.write().await.remove(&session_id);
+                self.finish_forwarding(session_id, &done).await;
                 return;
             }
         };
@@ -1539,6 +1580,9 @@ impl MasqueRelayServer {
         // we retain ownership and explicitly abort + await both afterwards so no
         // detached task can keep using the socket (Blocker 1).
         let close_reason = tokio::select! {
+            // A handover (or any external close_session) cancels the loop so it
+            // stops relaying before its socket is reused.
+            _ = cancel.cancelled() => "handover_cancelled",
             result = &mut reader_handle => {
                 match result {
                     Ok(reason) => reason,
@@ -1679,14 +1723,28 @@ impl MasqueRelayServer {
         writer_handle.abort();
         let _ = reader_handle.await;
         let _ = writer_handle.await;
-        // Forwarding is finished; clear the live flag BEFORE close_session so the
-        // natural session-end close is allowed to lease the now exclusively-owned
-        // socket (a still-live handover close would instead skip the lease).
-        self.active_forwarding.write().await.remove(&session_id);
 
-        if let Err(e) = self.close_session(session_id).await {
-            tracing::debug!(session_id, error = %e, "Error closing session");
+        // Deregister and release any handover waiter now that the tasks are gone
+        // and the socket is exclusively owned again. Done BEFORE close_session so
+        // the natural-end close sees no live loop and may lease the socket.
+        self.finish_forwarding(session_id, &done).await;
+
+        // Natural end: close the session here (which leases the freed socket). On
+        // a handover the cancelling close_session owns the close and the lease, so
+        // we must not double-close.
+        if !cancel.is_cancelled() {
+            if let Err(e) = self.close_session(session_id).await {
+                tracing::debug!(session_id, error = %e, "Error closing session");
+            }
         }
+    }
+
+    /// Deregister a session's forwarding control and release any `close_session`
+    /// waiting (via `done`) for the loop to fully exit. `notify_one` stores a
+    /// permit if no waiter is registered yet, so the signal can't be lost.
+    async fn finish_forwarding(&self, session_id: u64, done: &Arc<Notify>) {
+        self.forwarding.write().await.remove(&session_id);
+        done.notify_one();
     }
 
     /// Close a specific session.
@@ -1707,6 +1765,21 @@ impl MasqueRelayServer {
                     kind: SessionErrorKind::NotFound,
                 })?
         };
+
+        // If a forwarding loop is still live for this session, cancel it and wait
+        // until it has aborted its tasks and released the socket — so an old
+        // session stops relaying before we remove/lease it (no untracked data
+        // plane left behind after a handover), and the socket is exclusively
+        // owned before it can be reused. Removing the session above serialized
+        // concurrent closes, so only one caller reaches this; on a natural end the
+        // loop has already deregistered, making this a no-op.
+        let control = { self.forwarding.read().await.get(&session_id).cloned() };
+        if let Some(control) = control {
+            let exited = control.done.notified();
+            control.cancel.cancel();
+            exited.await;
+        }
+
         session.close();
 
         if let Some(addr) = session.client_address() {
@@ -1717,24 +1790,13 @@ impl MasqueRelayServer {
         let upnp = self.upnp_mappings.write().await.remove(&session_id);
 
         // ADR-011: lease the port for reconnect when the peer's authenticated
-        // identity is known; otherwise drop the socket and shut the UPnP
-        // mapping down (the original behaviour for unauthenticated sessions).
-        //
-        // BUT never lease a socket whose forwarding loop is still live: its
-        // reader/writer tasks still hold the socket, so leasing then reclaiming it
-        // would let the old and new sessions race on the same port. This is the
-        // still-live handover case; drop the socket instead and let the old loop
-        // tear it down when it ends. The natural session-end path has already
-        // removed the id from `active_forwarding` (after aborting its tasks), so
-        // there the socket is free and the lease proceeds.
-        let forwarding_active = self.active_forwarding.read().await.contains(&session_id);
-        let lease = if forwarding_active {
-            None
-        } else {
-            match (session.peer_id(), session.udp_socket().cloned()) {
-                (Some(peer_id), Some(socket)) => Some((peer_id, socket)),
-                _ => None,
-            }
+        // identity is known; otherwise drop the socket and shut the UPnP mapping
+        // down (the original behaviour for unauthenticated sessions). The socket
+        // is now exclusively owned — any forwarding loop has been cancelled and
+        // awaited above — so leasing it is race-free.
+        let lease = match (session.peer_id(), session.udp_socket().cloned()) {
+            (Some(peer_id), Some(socket)) => Some((peer_id, socket)),
+            _ => None,
         };
         match lease {
             Some((peer_id, socket)) => {
@@ -2321,48 +2383,63 @@ mod tests {
         );
     }
 
-    /// Review blocker 1: while a session's forwarding loop is live, `close_session`
-    /// must NOT lease its socket — leasing then reclaiming a socket still held by
-    /// the old reader/writer tasks would let old and new sessions race on the port.
+    /// Review (round 2) blocker: `close_session` must actively cancel a still-live
+    /// forwarding loop and wait for it to exit before returning — so a same-identity
+    /// handover stops the old data plane (no untracked loop survives) and only then
+    /// leases the socket for reuse.
     #[tokio::test]
-    async fn stable_ports_no_lease_while_forwarding_active() {
-        let server = MasqueRelayServer::new(MasqueRelayConfig::default(), test_addr(9000));
+    async fn stable_ports_close_cancels_live_forwarding_loop() {
+        let server = Arc::new(MasqueRelayServer::new(
+            MasqueRelayConfig::default(),
+            test_addr(9000),
+        ));
         let peer = peer_fp(7);
-        let request = ConnectUdpRequest::bind_any();
 
-        server
-            .handle_connect_request(&request, client_addr(1), Some(peer))
+        let resp = server
+            .handle_connect_request(&ConnectUdpRequest::bind_any(), client_addr(1), Some(peer))
             .await
             .unwrap();
-        let sid = server
-            .get_session_for_client(client_addr(1))
-            .await
-            .unwrap()
-            .session_id;
+        let sid = resp
+            .session_id
+            .expect("success response carries the created session id");
 
-        // Simulate a still-live forwarding loop holding the socket.
-        server.active_forwarding.write().await.insert(sid);
-        server.close_session(sid).await.unwrap();
-        assert_eq!(
-            server.reservations.read().await.len(),
-            0,
-            "must not lease a socket whose forwarding loop is still live"
+        // Register a control and spawn a stand-in forwarding loop that runs until
+        // close_session cancels it, then deregisters + signals done — exactly what
+        // run_stream_forwarding_loop does on cancellation.
+        let cancel = CancellationToken::new();
+        let done = Arc::new(Notify::new());
+        server.forwarding.write().await.insert(
+            sid,
+            ForwardingControl {
+                cancel: cancel.clone(),
+                done: done.clone(),
+            },
         );
-        server.active_forwarding.write().await.remove(&sid);
+        let exited = Arc::new(AtomicBool::new(false));
+        let task = {
+            let server = server.clone();
+            let exited = exited.clone();
+            tokio::spawn(async move {
+                cancel.cancelled().await;
+                exited.store(true, Ordering::SeqCst);
+                server.finish_forwarding(sid, &done).await;
+            })
+        };
 
-        // With forwarding no longer active, the same flow leases normally.
-        server
-            .handle_connect_request(&request, client_addr(2), Some(peer))
-            .await
-            .unwrap();
-        server
-            .close_session_by_client(client_addr(2))
-            .await
-            .unwrap();
+        // Must cancel the stand-in loop and block until it has fully exited.
+        server.close_session(sid).await.unwrap();
+        assert!(
+            exited.load(Ordering::SeqCst),
+            "close_session must cancel and await the live forwarding loop"
+        );
+        let _ = task.await;
+
+        // The socket was leased only after the loop quiesced, so the port is
+        // retained for the peer to reclaim on reconnect.
         assert_eq!(
             server.reservations.read().await.len(),
             1,
-            "leases once forwarding is no longer active"
+            "port leased once the loop stopped"
         );
     }
 

--- a/src/masque/relay_server.rs
+++ b/src/masque/relay_server.rs
@@ -49,8 +49,8 @@ use crate::high_level::Connection as QuicConnection;
 use crate::masque::ip_policy::IpPolicy;
 use crate::masque::tunnel_control::{CONTROL_FRAME_MARKER, TunnelControlFrame};
 use crate::masque::{
-    Capsule, ConnectUdpRequest, ConnectUdpResponse, Datagram, RelaySession, RelaySessionConfig,
-    RelaySessionState, UncompressedDatagram,
+    Capsule, ConnectUdpRequest, ConnectUdpResponse, Datagram, RelayPeerId, RelaySession,
+    RelaySessionConfig, RelaySessionState, UncompressedDatagram,
 };
 use crate::relay::error::{RelayError, RelayResult, SessionErrorKind};
 use crate::upnp::{UpnpConfig, UpnpMappingService};
@@ -70,6 +70,12 @@ const RELAY_STREAM_BATCH_MAX_BYTES: usize = 64 * 1024;
 /// userspace buffer that replaces the tiny kernel UDP receive buffer
 /// (208 KB default on Linux, which holds only ~170 packets).
 const RELAY_FORWARD_CHANNEL_CAPACITY: usize = 8192;
+
+/// Minimum interval between relay-reservation INFO summary lines (ADR-011).
+/// Per-event reservation detail is logged at DEBUG to keep production log
+/// volume low; one summary per relay per interval is enough to confirm the
+/// feature is working (reclaim hits climbing, reservation pool size).
+const RELAY_RESERVATION_SUMMARY_INTERVAL_MS: u64 = 5 * 60 * 1000; // 5 minutes
 
 /// Suggested PMTU sent to the relay-client when the egress UDP send
 /// fails with `EMSGSIZE`.  Picked to be QUIC's mandatory minimum
@@ -232,6 +238,15 @@ pub struct MasqueRelayConfig {
     pub global_bandwidth_limit: u64,
     /// Enable authentication requirement
     pub require_authentication: bool,
+    /// How long a stable-port reservation (ADR-011) is retained after the
+    /// session using it ends, waiting for the same authenticated peer to
+    /// reconnect and reclaim its previously-advertised port. Bounds how long an
+    /// idle port is held.
+    pub reservation_ttl: Duration,
+    /// Maximum number of idle stable-port reservations held at once. When the
+    /// cap is reached the least-recently-released reservation is evicted (its
+    /// port freed) to bound socket/fd/memory use under churn.
+    pub max_reservations: usize,
 }
 
 impl Default for MasqueRelayConfig {
@@ -242,6 +257,8 @@ impl Default for MasqueRelayConfig {
             cleanup_interval: Duration::from_secs(60),
             global_bandwidth_limit: 100 * 1024 * 1024, // 100 MB/s
             require_authentication: true,
+            reservation_ttl: Duration::from_secs(600), // 10 minutes
+            max_reservations: 1024,
         }
     }
 }
@@ -338,6 +355,38 @@ pub enum DatagramResult {
     Error(RelayError),
 }
 
+/// Short hex prefix (first 8 bytes) of a 32-byte peer fingerprint, for
+/// greppable log correlation without dumping the whole identity.
+fn short_peer_hex(id: &RelayPeerId) -> String {
+    use std::fmt::Write as _;
+    let mut s = String::with_capacity(16);
+    for b in &id[..8] {
+        let _ = write!(s, "{b:02x}");
+    }
+    s
+}
+
+/// A retained stable relay-port reservation (ADR-011).
+///
+/// Created when a relayed peer's session ends: instead of dropping the bound
+/// UDP socket (which frees the OS-assigned port), the socket is moved here and
+/// kept alive so the *same* port can be handed back when that peer — identified
+/// by its authenticated ML-DSA fingerprint — reconnects. Holding the socket
+/// makes reuse conflict-free for the lease window. Bounded by TTL and LRU cap.
+struct Reservation {
+    /// The stable public port retained for the peer.
+    port: u16,
+    /// The bound UDP socket, kept alive so the kernel cannot reassign the port
+    /// while the reservation is held.
+    udp_socket: Arc<UdpSocket>,
+    /// UPnP mapping for the retained port, kept alive alongside the socket so
+    /// NAT forwarding survives the lease. Shut down explicitly on release.
+    upnp: Option<UpnpMappingService>,
+    /// When the session using this port was released — the start of the lease,
+    /// used for TTL expiry and least-recently-released eviction.
+    released_at: Instant,
+}
+
 /// MASQUE Relay Server
 ///
 /// Manages multiple relay sessions and coordinates datagram forwarding
@@ -372,6 +421,16 @@ pub struct MasqueRelayServer {
     started_at: Instant,
     /// Bridged connection count (IPv4↔IPv6)
     bridged_connections: AtomicU64,
+    /// ADR-011 reservation activity counters (cumulative), surfaced in a
+    /// rate-limited INFO summary so production gets a low-volume "feature is
+    /// working" signal while per-event detail stays at DEBUG.
+    reservation_hits: AtomicU64,
+    reservation_misses: AtomicU64,
+    reservations_created: AtomicU64,
+    reservations_expired: AtomicU64,
+    reservations_evicted: AtomicU64,
+    /// Epoch-millis of the last reservation summary emit (rate-limit gate).
+    last_reservation_summary_ms: AtomicU64,
     /// Whether this node is willing to serve as a relay for private peers.
     ///
     /// Set to `false` by the ADR-014 reachability classifier when the node
@@ -387,6 +446,11 @@ pub struct MasqueRelayServer {
     /// the local IGD gateway (if any) to forward that port from the public
     /// side so relay-forwarded traffic can reach it through a NAT.
     upnp_mappings: RwLock<HashMap<u64, UpnpMappingService>>,
+    /// Retained stable-port reservations keyed by the relayed peer's
+    /// authenticated ML-DSA fingerprint (ADR-011). Populated on session close
+    /// for authenticated peers; consumed when the same peer reconnects, or
+    /// dropped by TTL/LRU eviction.
+    reservations: RwLock<HashMap<RelayPeerId, Reservation>>,
     /// Optional IP-diversity policy shared with the node's relay-client half.
     /// When set, the server refuses inbound clients whose source IP matches
     /// one of our current upstream relays (see [`IpPolicy`]).
@@ -417,7 +481,14 @@ impl MasqueRelayServer {
             stats: Arc::new(MasqueRelayStats::new()),
             started_at: Instant::now(),
             bridged_connections: AtomicU64::new(0),
+            reservation_hits: AtomicU64::new(0),
+            reservation_misses: AtomicU64::new(0),
+            reservations_created: AtomicU64::new(0),
+            reservations_expired: AtomicU64::new(0),
+            reservations_evicted: AtomicU64::new(0),
+            last_reservation_summary_ms: AtomicU64::new(0),
             upnp_mappings: RwLock::new(HashMap::new()),
+            reservations: RwLock::new(HashMap::new()),
             ip_policy: None,
         }
     }
@@ -478,7 +549,14 @@ impl MasqueRelayServer {
             stats: Arc::new(MasqueRelayStats::new()),
             started_at: Instant::now(),
             bridged_connections: AtomicU64::new(0),
+            reservation_hits: AtomicU64::new(0),
+            reservation_misses: AtomicU64::new(0),
+            reservations_created: AtomicU64::new(0),
+            reservations_expired: AtomicU64::new(0),
+            reservations_evicted: AtomicU64::new(0),
+            last_reservation_summary_ms: AtomicU64::new(0),
             upnp_mappings: RwLock::new(HashMap::new()),
+            reservations: RwLock::new(HashMap::new()),
             ip_policy: None,
         }
     }
@@ -620,7 +698,13 @@ impl MasqueRelayServer {
         &self,
         request: &ConnectUdpRequest,
         client_addr: SocketAddr,
+        peer_id: Option<RelayPeerId>,
     ) -> RelayResult<ConnectUdpResponse> {
+        // ADR-011: opportunistic, rate-limited INFO summary of reservation
+        // activity (per-event lines are DEBUG). Driven from the CONNECT path so
+        // no background task is needed.
+        self.maybe_log_reservation_summary().await;
+
         // ADR-014: private nodes must not serve as relays because they
         // cannot forward traffic from the public internet. The classifier
         // toggles this flag after determining the node's reachability.
@@ -709,55 +793,91 @@ impl MasqueRelayServer {
             ));
         }
 
-        // Bind a real UDP socket for this session's data plane.
-        // Bind to INADDR_ANY / IN6ADDR_ANY with OS-assigned port, then advertise
-        // our public IP with the bound port.
-        let bind_addr: SocketAddr = if client_addr.is_ipv4() {
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0)
-        } else {
-            SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0)
+        // ADR-011: try to hand a reconnecting authenticated peer back its
+        // previously retained stable port before binding a fresh random one.
+        let reclaimed = match peer_id {
+            Some(pid) => self.reclaim_reservation(pid, client_addr.is_ipv4()).await,
+            None => None,
         };
 
-        let udp_socket =
-            UdpSocket::bind(bind_addr)
-                .await
-                .map_err(|e| RelayError::SessionError {
-                    session_id: None,
-                    kind: SessionErrorKind::InvalidState {
-                        current_state: format!("UDP bind failed: {}", e),
-                        expected_state: "bound".into(),
-                    },
-                })?;
+        // Bind a real UDP socket for this session's data plane (unless reclaimed).
+        // Bind to INADDR_ANY / IN6ADDR_ANY with OS-assigned port, then advertise
+        // our public IP with the bound port.
+        let (udp_socket, bound_port, reused_upnp) = match reclaimed {
+            Some((socket, port, upnp)) => {
+                self.reservation_hits.fetch_add(1, Ordering::Relaxed);
+                tracing::debug!(
+                    component = "relay_reservation",
+                    event = "reclaim_hit",
+                    peer = %peer_id.map(|p| short_peer_hex(&p)).unwrap_or_default(),
+                    port = port,
+                    client = %client_addr,
+                    "reusing stable relay port for reconnecting peer"
+                );
+                (socket, port, upnp)
+            }
+            None => {
+                let bind_addr: SocketAddr = if client_addr.is_ipv4() {
+                    SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0)
+                } else {
+                    SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0)
+                };
 
-        // Force DF=1 on the bound socket so oversized egress send_to
-        // fails with EMSGSIZE rather than getting silently fragmented.
-        // The error then drives a PmtuUpdate control frame back to the
-        // relay-client (see [`run_stream_forwarding_loop`]).  If the
-        // setsockopt itself fails (very old kernel, exotic platform),
-        // we log and proceed: PMTU control frames will simply never
-        // fire and the relay falls back to the legacy lossy behaviour.
-        if let Err(e) = set_dont_fragment(&udp_socket) {
-            tracing::warn!(
-                error = %e,
-                "Failed to enable IP_DONTFRAG on relay-allocated socket — \
-                 oversized egress will silently fragment instead of \
-                 surfacing PMTU feedback"
-            );
-        }
+                let udp_socket =
+                    UdpSocket::bind(bind_addr)
+                        .await
+                        .map_err(|e| RelayError::SessionError {
+                            session_id: None,
+                            kind: SessionErrorKind::InvalidState {
+                                current_state: format!("UDP bind failed: {}", e),
+                                expected_state: "bound".into(),
+                            },
+                        })?;
 
-        let bound_port = udp_socket
-            .local_addr()
-            .map_err(|e| RelayError::SessionError {
-                session_id: None,
-                kind: SessionErrorKind::InvalidState {
-                    current_state: format!("Failed to get bound address: {}", e),
-                    expected_state: "address available".into(),
-                },
-            })?
-            .port();
+                // Force DF=1 on the bound socket so oversized egress send_to
+                // fails with EMSGSIZE rather than getting silently fragmented.
+                // The error then drives a PmtuUpdate control frame back to the
+                // relay-client (see [`run_stream_forwarding_loop`]).  If the
+                // setsockopt itself fails (very old kernel, exotic platform),
+                // we log and proceed: PMTU control frames will simply never
+                // fire and the relay falls back to the legacy lossy behaviour.
+                if let Err(e) = set_dont_fragment(&udp_socket) {
+                    tracing::warn!(
+                        error = %e,
+                        "Failed to enable IP_DONTFRAG on relay-allocated socket — \
+                         oversized egress will silently fragment instead of \
+                         surfacing PMTU feedback"
+                    );
+                }
+
+                let bound_port = udp_socket
+                    .local_addr()
+                    .map_err(|e| RelayError::SessionError {
+                        session_id: None,
+                        kind: SessionErrorKind::InvalidState {
+                            current_state: format!("Failed to get bound address: {}", e),
+                            expected_state: "address available".into(),
+                        },
+                    })?
+                    .port();
+
+                if peer_id.is_some() {
+                    self.reservation_misses.fetch_add(1, Ordering::Relaxed);
+                    tracing::debug!(
+                        component = "relay_reservation",
+                        event = "reclaim_miss",
+                        peer = %peer_id.map(|p| short_peer_hex(&p)).unwrap_or_default(),
+                        port = bound_port,
+                        client = %client_addr,
+                        "no reusable reservation; bound a fresh relay port"
+                    );
+                }
+
+                (Arc::new(udp_socket), bound_port, None)
+            }
+        };
 
         let advertised_address = SocketAddr::new(public_ip, bound_port);
-        let udp_socket = Arc::new(udp_socket);
 
         // Create new session with the bound socket
         let session_id = self.next_session_id.fetch_add(1, Ordering::SeqCst);
@@ -767,6 +887,7 @@ impl MasqueRelayServer {
             advertised_address,
         );
         session.set_client_address(client_addr);
+        session.set_peer_id(peer_id);
         session.set_udp_socket(udp_socket);
         if requires_bridging {
             session.set_bridging(true);
@@ -788,10 +909,11 @@ impl MasqueRelayServer {
             self.record_bridged_connection();
         }
 
-        // Best-effort UPnP: ask the local gateway (if any) to forward
-        // the relay port so traffic can reach it through a home NAT.
-        // The service is non-blocking and tolerates missing gateways.
-        let upnp_svc = UpnpMappingService::start(bound_port, UpnpConfig::default());
+        // Best-effort UPnP: reuse the reservation's existing mapping on a
+        // reclaim, otherwise ask the local gateway (if any) to forward the
+        // freshly-bound relay port. The service tolerates missing gateways.
+        let upnp_svc = reused_upnp
+            .unwrap_or_else(|| UpnpMappingService::start(bound_port, UpnpConfig::default()));
         self.upnp_mappings
             .write()
             .await
@@ -1483,42 +1605,277 @@ impl MasqueRelayServer {
         }
     }
 
-    /// Close a specific session
+    /// Close a specific session.
+    ///
+    /// When stable ports (ADR-011) are enabled and the session's relayed peer
+    /// was authenticated, the bound UDP socket and its UPnP mapping are retained
+    /// as a leased reservation — so the same peer can reclaim the port on
+    /// reconnect — instead of being dropped.
     pub async fn close_session(&self, session_id: u64) -> RelayResult<()> {
-        let client_addr = {
+        // Remove the session up-front so we can inspect its identity and socket
+        // for a possible stable-port lease before it is dropped.
+        let mut session = {
             let mut sessions = self.sessions.write().await;
-            let session = sessions
-                .get_mut(&session_id)
-                .ok_or(RelayError::SessionError {
-                    session_id: Some(session_id as u32),
-                    kind: SessionErrorKind::NotFound,
-                })?;
-
-            let addr = session.client_address();
-            session.close();
-            addr
+            sessions.remove(&session_id).ok_or(RelayError::SessionError {
+                session_id: Some(session_id as u32),
+                kind: SessionErrorKind::NotFound,
+            })?
         };
+        session.close();
 
-        // Remove from maps
-        {
-            let mut sessions = self.sessions.write().await;
-            sessions.remove(&session_id);
-        }
-        if let Some(addr) = client_addr {
+        if let Some(addr) = session.client_address() {
             let mut client_map = self.client_to_session.write().await;
             client_map.remove(&addr);
         }
 
-        // Release the UPnP port mapping (if one was created for this session).
-        if let Some(svc) = self.upnp_mappings.write().await.remove(&session_id) {
-            svc.shutdown().await;
+        let upnp = self.upnp_mappings.write().await.remove(&session_id);
+
+        // ADR-011: lease the port for reconnect when the peer's authenticated
+        // identity is known; otherwise drop the socket and shut the UPnP
+        // mapping down (the original behaviour for unauthenticated sessions).
+        let lease = match (session.peer_id(), session.udp_socket().cloned()) {
+            (Some(peer_id), Some(socket)) => Some((peer_id, socket)),
+            _ => None,
+        };
+        match lease {
+            Some((peer_id, socket)) => {
+                let port = session.public_address().port();
+                self.lease_reservation(peer_id, port, socket, upnp).await;
+            }
+            None => {
+                if let Some(svc) = upnp {
+                    svc.shutdown().await;
+                }
+            }
         }
 
         self.stats.record_session_terminated();
-
         tracing::info!(session_id = session_id, "MASQUE relay session closed");
-
         Ok(())
+    }
+
+    /// ADR-011: retain a closed session's bound socket as a leased stable-port
+    /// reservation keyed by the peer's authenticated fingerprint, so the same
+    /// peer can reclaim the port on reconnect. Enforces the `max_reservations`
+    /// LRU cap, evicting the least-recently-released reservation when full.
+    async fn lease_reservation(
+        &self,
+        peer_id: RelayPeerId,
+        port: u16,
+        udp_socket: Arc<UdpSocket>,
+        upnp: Option<UpnpMappingService>,
+    ) {
+        let now = Instant::now();
+        let (evicted, previous) = {
+            let mut reservations = self.reservations.write().await;
+            // Enforce the LRU cap, but only when inserting a genuinely new key
+            // (replacing an existing key does not grow the map).
+            let evicted = if reservations.len() >= self.config.max_reservations
+                && !reservations.contains_key(&peer_id)
+            {
+                let lru = reservations
+                    .iter()
+                    .min_by_key(|(_, r)| r.released_at)
+                    .map(|(k, _)| *k);
+                lru.and_then(|k| reservations.remove(&k).map(|r| (k, r)))
+            } else {
+                None
+            };
+            let previous = reservations.insert(
+                peer_id,
+                Reservation {
+                    port,
+                    udp_socket,
+                    upnp,
+                    released_at: now,
+                },
+            );
+            (evicted, previous)
+        };
+
+        // Free evicted / replaced resources outside the lock (shutdown is async).
+        if let Some((evicted_key, old)) = evicted {
+            self.reservations_evicted.fetch_add(1, Ordering::Relaxed);
+            if let Some(svc) = old.upnp {
+                svc.shutdown().await;
+            }
+            // Kept at INFO: rare, and a signal that `max_reservations` is being
+            // hit (the cap may be too low).
+            tracing::info!(
+                component = "relay_reservation",
+                event = "reservation_evicted",
+                peer = %short_peer_hex(&evicted_key),
+                port = old.port,
+                "evicted least-recently-used relay-port reservation (cap reached)"
+            );
+        }
+        if let Some(old) = previous {
+            if let Some(svc) = old.upnp {
+                svc.shutdown().await;
+            }
+        }
+
+        self.reservations_created.fetch_add(1, Ordering::Relaxed);
+        tracing::debug!(
+            component = "relay_reservation",
+            event = "reservation_created",
+            peer = %short_peer_hex(&peer_id),
+            port = port,
+            "retained relay port as a leased reservation"
+        );
+    }
+
+    /// ADR-011: drop stable-port reservations whose lease has exceeded
+    /// `reservation_ttl`, freeing the retained ports. Reservations are also
+    /// expired lazily on reclaim and bounded by `max_reservations`; this method
+    /// lets a caller (or test) sweep idle reservations proactively. Returns the
+    /// number expired.
+    pub async fn cleanup_expired_reservations(&self) -> usize {
+        let ttl = self.config.reservation_ttl;
+        let expired: Vec<(RelayPeerId, Reservation)> = {
+            let mut reservations = self.reservations.write().await;
+            let stale: Vec<RelayPeerId> = reservations
+                .iter()
+                .filter(|(_, r)| r.released_at.elapsed() >= ttl)
+                .map(|(k, _)| *k)
+                .collect();
+            stale
+                .into_iter()
+                .filter_map(|k| reservations.remove(&k).map(|r| (k, r)))
+                .collect()
+        };
+
+        let count = expired.len();
+        for (peer_id, res) in expired {
+            self.reservations_expired.fetch_add(1, Ordering::Relaxed);
+            if let Some(svc) = res.upnp {
+                svc.shutdown().await;
+            }
+            // res.udp_socket drops here → the OS frees the retained port.
+            tracing::debug!(
+                component = "relay_reservation",
+                event = "reservation_expired",
+                peer = %short_peer_hex(&peer_id),
+                port = res.port,
+                "released expired relay-port reservation"
+            );
+        }
+        if count > 0 {
+            tracing::debug!(count, "Cleaned up expired MASQUE relay-port reservations");
+        }
+        count
+    }
+
+    /// ADR-011: attempt to hand a reconnecting authenticated peer back its
+    /// previously retained stable port.
+    ///
+    /// Retires any still-live session for the same identity first (deterministic
+    /// handover: `close_session` leases that session's port into `reservations`,
+    /// which the take below then reclaims), then returns a reservation that is
+    /// both fresh (within `reservation_ttl`) and bound to the client's IP family.
+    /// Returns `None` to fall back to a fresh random bind. This never fails — the
+    /// caller always has the random-bind fallback, so a reservation problem can
+    /// never wedge relay acquisition.
+    async fn reclaim_reservation(
+        &self,
+        peer_id: RelayPeerId,
+        want_ipv4: bool,
+    ) -> Option<(Arc<UdpSocket>, u16, Option<UpnpMappingService>)> {
+        // Deterministic handover: if this identity still has a live session
+        // (duplicate / stale half-open), retire it first so its port is leased
+        // and can be reclaimed below.
+        let live = {
+            let sessions = self.sessions.read().await;
+            sessions
+                .iter()
+                .find(|(_, s)| s.peer_id() == Some(peer_id))
+                .map(|(id, _)| *id)
+        };
+        if let Some(session_id) = live {
+            let _ = self.close_session(session_id).await;
+        }
+
+        // Take the reservation if present, fresh, and IP-family-compatible.
+        let ttl = self.config.reservation_ttl;
+        let mut stale_drop: Option<Reservation> = None;
+        let reclaimed = {
+            let mut reservations = self.reservations.write().await;
+            match reservations.remove(&peer_id) {
+                Some(res) => {
+                    let fresh = res.released_at.elapsed() < ttl;
+                    let family_ok = res
+                        .udp_socket
+                        .local_addr()
+                        .map(|a| a.is_ipv4() == want_ipv4)
+                        .unwrap_or(false);
+                    if fresh && family_ok {
+                        Some(res)
+                    } else {
+                        stale_drop = Some(res);
+                        None
+                    }
+                }
+                None => None,
+            }
+        };
+
+        // Free a stale / mismatched reservation outside the lock.
+        if let Some(res) = stale_drop {
+            self.reservations_expired.fetch_add(1, Ordering::Relaxed);
+            if let Some(svc) = res.upnp {
+                svc.shutdown().await;
+            }
+            tracing::debug!(
+                component = "relay_reservation",
+                event = "reservation_expired",
+                peer = %short_peer_hex(&peer_id),
+                port = res.port,
+                "discarded stale/mismatched relay-port reservation on reclaim"
+            );
+        }
+
+        reclaimed.map(|res| (res.udp_socket, res.port, res.upnp))
+    }
+
+    /// ADR-011: emit a rate-limited INFO summary of reservation activity.
+    ///
+    /// Per-event reservation lines (`reclaim_hit`/`reclaim_miss`/
+    /// `reservation_created`/`reservation_expired`) are logged at DEBUG to keep
+    /// production log volume low. This instead emits a single INFO "gauge" line
+    /// at most once per [`RELAY_RESERVATION_SUMMARY_INTERVAL_MS`] — enough to
+    /// confirm on production that reuse is happening (hits climbing) and to see
+    /// the reservation pool size — without a per-session firehose. Driven from
+    /// the CONNECT path, so it needs no background task; an idle relay simply
+    /// has nothing to report.
+    async fn maybe_log_reservation_summary(&self) {
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+        let last = self.last_reservation_summary_ms.load(Ordering::Relaxed);
+        if now_ms.saturating_sub(last) < RELAY_RESERVATION_SUMMARY_INTERVAL_MS {
+            return;
+        }
+        // Claim the interval so only one concurrent CONNECT emits the summary.
+        if self
+            .last_reservation_summary_ms
+            .compare_exchange(last, now_ms, Ordering::Relaxed, Ordering::Relaxed)
+            .is_err()
+        {
+            return;
+        }
+        let active_reservations = self.reservations.read().await.len();
+        tracing::info!(
+            component = "relay_reservation",
+            event = "summary",
+            hits = self.reservation_hits.load(Ordering::Relaxed),
+            misses = self.reservation_misses.load(Ordering::Relaxed),
+            created = self.reservations_created.load(Ordering::Relaxed),
+            expired = self.reservations_expired.load(Ordering::Relaxed),
+            evicted = self.reservations_evicted.load(Ordering::Relaxed),
+            active_reservations = active_reservations,
+            "relay-reservation activity summary (cumulative counts)"
+        );
     }
 
     /// Close session by client address
@@ -1632,6 +1989,163 @@ mod tests {
         SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, id)), 12345)
     }
 
+    // ── ADR-011: stable relay-port reservation tests ──────────────────────
+
+    fn peer_fp(b: u8) -> RelayPeerId {
+        [b; 32]
+    }
+
+    /// A reconnecting authenticated peer is handed back the same public port.
+    #[tokio::test]
+    async fn stable_ports_reclaim_reuses_port_on_reconnect() {
+        let server = MasqueRelayServer::new(MasqueRelayConfig::default(), test_addr(9000));
+        let peer = peer_fp(7);
+        let request = ConnectUdpRequest::bind_any();
+
+        let r1 = server
+            .handle_connect_request(&request, client_addr(1), Some(peer))
+            .await
+            .unwrap();
+        assert_eq!(r1.status, 200);
+        let port1 = r1.proxy_public_address.unwrap().port();
+
+        // Session drops → the port is leased as a reservation.
+        server.close_session_by_client(client_addr(1)).await.unwrap();
+        assert_eq!(server.session_count().await, 0);
+        assert_eq!(server.reservations.read().await.len(), 1);
+
+        // Same identity reconnects from a different client address.
+        let r2 = server
+            .handle_connect_request(&request, client_addr(2), Some(peer))
+            .await
+            .unwrap();
+        assert_eq!(r2.status, 200);
+        let port2 = r2.proxy_public_address.unwrap().port();
+
+        assert_eq!(port1, port2, "reconnecting peer should reclaim its stable port");
+        // Reservation consumed by the reclaim.
+        assert_eq!(server.reservations.read().await.len(), 0);
+    }
+
+    /// A different identity does not reclaim another peer's retained port.
+    #[tokio::test]
+    async fn stable_ports_other_identity_does_not_reclaim() {
+        let server = MasqueRelayServer::new(MasqueRelayConfig::default(), test_addr(9000));
+        let request = ConnectUdpRequest::bind_any();
+
+        let r1 = server
+            .handle_connect_request(&request, client_addr(1), Some(peer_fp(1)))
+            .await
+            .unwrap();
+        let port1 = r1.proxy_public_address.unwrap().port();
+        server.close_session_by_client(client_addr(1)).await.unwrap();
+
+        // peer_1's reservation still holds port1's socket, so peer_2 cannot get it.
+        let r2 = server
+            .handle_connect_request(&request, client_addr(2), Some(peer_fp(2)))
+            .await
+            .unwrap();
+        let port2 = r2.proxy_public_address.unwrap().port();
+        assert_ne!(port1, port2, "a different identity must not reuse the port");
+    }
+
+    /// Without an authenticated identity, no reservation is created.
+    #[tokio::test]
+    async fn stable_ports_no_identity_creates_no_reservation() {
+        let server = MasqueRelayServer::new(MasqueRelayConfig::default(), test_addr(9000));
+        let request = ConnectUdpRequest::bind_any();
+
+        server
+            .handle_connect_request(&request, client_addr(1), None)
+            .await
+            .unwrap();
+        server.close_session_by_client(client_addr(1)).await.unwrap();
+
+        assert_eq!(server.reservations.read().await.len(), 0);
+    }
+
+    /// Reservations past their TTL are swept and their ports freed.
+    #[tokio::test]
+    async fn stable_ports_reservation_expires_after_ttl() {
+        let config = MasqueRelayConfig {
+            reservation_ttl: Duration::from_millis(50),
+            ..Default::default()
+        };
+        let server = MasqueRelayServer::new(config, test_addr(9000));
+        let request = ConnectUdpRequest::bind_any();
+
+        server
+            .handle_connect_request(&request, client_addr(1), Some(peer_fp(7)))
+            .await
+            .unwrap();
+        server.close_session_by_client(client_addr(1)).await.unwrap();
+        assert_eq!(server.reservations.read().await.len(), 1);
+
+        tokio::time::sleep(Duration::from_millis(90)).await;
+        let expired = server.cleanup_expired_reservations().await;
+        assert_eq!(expired, 1);
+        assert_eq!(server.reservations.read().await.len(), 0);
+    }
+
+    /// The reservation map is bounded by `max_reservations` via LRU eviction.
+    #[tokio::test]
+    async fn stable_ports_lru_eviction_bounds_reservations() {
+        let config = MasqueRelayConfig {
+            max_reservations: 2,
+            ..Default::default()
+        };
+        let server = MasqueRelayServer::new(config, test_addr(9000));
+        let request = ConnectUdpRequest::bind_any();
+
+        for i in 1..=3u8 {
+            server
+                .handle_connect_request(&request, client_addr(i), Some(peer_fp(i)))
+                .await
+                .unwrap();
+            server.close_session_by_client(client_addr(i)).await.unwrap();
+            // Distinct release timestamps so LRU order is unambiguous.
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+
+        let reservations = server.reservations.read().await;
+        assert_eq!(reservations.len(), 2, "cap must bound the reservation map");
+        assert!(
+            !reservations.contains_key(&peer_fp(1)),
+            "least-recently-released reservation should be evicted"
+        );
+        assert!(reservations.contains_key(&peer_fp(2)));
+        assert!(reservations.contains_key(&peer_fp(3)));
+    }
+
+    /// A duplicate/stale live session for the same identity is retired and its
+    /// port handed to the new session (deterministic handover).
+    #[tokio::test]
+    async fn stable_ports_handover_retires_live_session() {
+        let server = MasqueRelayServer::new(MasqueRelayConfig::default(), test_addr(9000));
+        let peer = peer_fp(7);
+        let request = ConnectUdpRequest::bind_any();
+
+        let r1 = server
+            .handle_connect_request(&request, client_addr(1), Some(peer))
+            .await
+            .unwrap();
+        let port1 = r1.proxy_public_address.unwrap().port();
+        assert_eq!(server.session_count().await, 1);
+
+        // Same identity reconnects from a new address while the old session is
+        // still live — handover retires the old and reuses the port.
+        let r2 = server
+            .handle_connect_request(&request, client_addr(2), Some(peer))
+            .await
+            .unwrap();
+        let port2 = r2.proxy_public_address.unwrap().port();
+
+        assert_eq!(port1, port2, "handover should reuse the port");
+        assert_eq!(server.session_count().await, 1, "old session retired");
+        assert!(server.get_session_for_client(client_addr(2)).await.is_some());
+        assert!(server.get_session_for_client(client_addr(1)).await.is_none());
+    }
+
     #[tokio::test]
     async fn test_server_creation() {
         let config = MasqueRelayConfig::default();
@@ -1649,7 +2163,7 @@ mod tests {
 
         let request = ConnectUdpRequest::bind_any();
         let response = server
-            .handle_connect_request(&request, client_addr(1))
+            .handle_connect_request(&request, client_addr(1), None)
             .await
             .unwrap();
 
@@ -1668,14 +2182,14 @@ mod tests {
 
         // First request succeeds
         let response1 = server
-            .handle_connect_request(&request, client)
+            .handle_connect_request(&request, client, None)
             .await
             .unwrap();
         assert_eq!(response1.status, 200);
 
         // Second request from same client fails
         let response2 = server
-            .handle_connect_request(&request, client)
+            .handle_connect_request(&request, client, None)
             .await
             .unwrap();
         assert_eq!(response2.status, 409);
@@ -1694,7 +2208,7 @@ mod tests {
         let offending_client = SocketAddr::new(upstream_ip, 55555);
         let request = ConnectUdpRequest::bind_any();
         let response = server
-            .handle_connect_request(&request, offending_client)
+            .handle_connect_request(&request, offending_client, None)
             .await
             .unwrap();
         assert_eq!(response.status, 403);
@@ -1702,7 +2216,7 @@ mod tests {
 
         // Client on any other IP is still accepted.
         let response = server
-            .handle_connect_request(&request, client_addr(1))
+            .handle_connect_request(&request, client_addr(1), None)
             .await
             .unwrap();
         assert_eq!(response.status, 200);
@@ -1720,7 +2234,7 @@ mod tests {
 
         let request = ConnectUdpRequest::bind_any();
         let response = server
-            .handle_connect_request(&request, SocketAddr::new(upstream_ip, 55555))
+            .handle_connect_request(&request, SocketAddr::new(upstream_ip, 55555), None)
             .await
             .unwrap();
         assert_eq!(response.status, 200);
@@ -1739,7 +2253,7 @@ mod tests {
         // Create 2 sessions
         for i in 1..=2 {
             let response = server
-                .handle_connect_request(&request, client_addr(i))
+                .handle_connect_request(&request, client_addr(i), None)
                 .await
                 .unwrap();
             assert_eq!(response.status, 200);
@@ -1747,7 +2261,7 @@ mod tests {
 
         // Third session should be rejected
         let response = server
-            .handle_connect_request(&request, client_addr(3))
+            .handle_connect_request(&request, client_addr(3), None)
             .await
             .unwrap();
         assert_eq!(response.status, 503);
@@ -1761,7 +2275,7 @@ mod tests {
         // Target request (regular CONNECT-UDP) - now supported for bridging
         let request = ConnectUdpRequest::target(test_addr(8080));
         let response = server
-            .handle_connect_request(&request, client_addr(1))
+            .handle_connect_request(&request, client_addr(1), None)
             .await
             .unwrap();
 
@@ -1776,7 +2290,7 @@ mod tests {
 
         let request = ConnectUdpRequest::bind_any();
         let response = server
-            .handle_connect_request(&request, client_addr(1))
+            .handle_connect_request(&request, client_addr(1), None)
             .await
             .unwrap();
         assert_eq!(response.status, 200);
@@ -1799,7 +2313,7 @@ mod tests {
 
         let request = ConnectUdpRequest::bind_any();
         server
-            .handle_connect_request(&request, client)
+            .handle_connect_request(&request, client, None)
             .await
             .unwrap();
         assert_eq!(server.session_count().await, 1);
@@ -1818,7 +2332,7 @@ mod tests {
 
         let request = ConnectUdpRequest::bind_any();
         server
-            .handle_connect_request(&request, client_addr(1))
+            .handle_connect_request(&request, client_addr(1), None)
             .await
             .unwrap();
 
@@ -1834,7 +2348,7 @@ mod tests {
 
         let request = ConnectUdpRequest::bind_any();
         server
-            .handle_connect_request(&request, client)
+            .handle_connect_request(&request, client, None)
             .await
             .unwrap();
 
@@ -1947,7 +2461,7 @@ mod tests {
         // IPv4 client trying to reach IPv6 target on single-stack server
         let request = ConnectUdpRequest::target(ipv6_addr(8080));
         let response = server
-            .handle_connect_request(&request, ipv4_client(1))
+            .handle_connect_request(&request, ipv4_client(1), None)
             .await
             .unwrap();
 
@@ -1964,7 +2478,7 @@ mod tests {
 
         let request = ConnectUdpRequest::bind_any();
         let response = server
-            .handle_connect_request(&request, ipv4_client(1))
+            .handle_connect_request(&request, ipv4_client(1), None)
             .await
             .unwrap();
 
@@ -1983,7 +2497,7 @@ mod tests {
 
         let request = ConnectUdpRequest::bind_any();
         let response = server
-            .handle_connect_request(&request, ipv6_client(1))
+            .handle_connect_request(&request, ipv6_client(1), None)
             .await
             .unwrap();
 
@@ -2005,7 +2519,7 @@ mod tests {
         // Regular same-version session (no bridging)
         let request = ConnectUdpRequest::bind_any();
         server
-            .handle_connect_request(&request, ipv4_client(1))
+            .handle_connect_request(&request, ipv4_client(1), None)
             .await
             .unwrap();
 
@@ -2022,7 +2536,7 @@ mod tests {
 
         let request = ConnectUdpRequest::bind_any();
         server
-            .handle_connect_request(&request, ipv4_client(1))
+            .handle_connect_request(&request, ipv4_client(1), None)
             .await
             .unwrap();
 

--- a/src/masque/relay_server.rs
+++ b/src/masque/relay_server.rs
@@ -33,13 +33,13 @@
 
 use bytes::Bytes;
 use parking_lot::RwLock as ParkingRwLock;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 use tokio::net::UdpSocket;
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))]
 use std::os::unix::io::AsRawFd;
@@ -76,6 +76,12 @@ const RELAY_FORWARD_CHANNEL_CAPACITY: usize = 8192;
 /// volume low; one summary per relay per interval is enough to confirm the
 /// feature is working (reclaim hits climbing, reservation pool size).
 const RELAY_RESERVATION_SUMMARY_INTERVAL_MS: u64 = 5 * 60 * 1000; // 5 minutes
+
+/// Number of mutex stripes used to serialize concurrent CONNECTs from the same
+/// authenticated identity (ADR-011). A peer maps to a stripe by the first byte
+/// of its fingerprint, so same-identity CONNECTs always take the same lock while
+/// memory stays bounded (no per-peer map that grows without limit).
+const RELAY_PEER_LOCK_STRIPES: usize = 256;
 
 /// Suggested PMTU sent to the relay-client when the egress UDP send
 /// fails with `EMSGSIZE`.  Picked to be QUIC's mandatory minimum
@@ -238,10 +244,14 @@ pub struct MasqueRelayConfig {
     pub global_bandwidth_limit: u64,
     /// Enable authentication requirement
     pub require_authentication: bool,
-    /// How long a stable-port reservation (ADR-011) is retained after the
-    /// session using it ends, waiting for the same authenticated peer to
-    /// reconnect and reclaim its previously-advertised port. Bounds how long an
-    /// idle port is held.
+    /// Freshness window for a stable-port reservation (ADR-011): after the
+    /// session using it ends, a reconnecting authenticated peer reclaims the port
+    /// only if it returns within this window. Expiry is **lazy** — the TTL is
+    /// checked when the peer reconnects (a stale reservation is discarded and a
+    /// fresh port bound), not by a background sweeper. Idle reservations from
+    /// peers that never return are bounded instead by `max_reservations` (LRU
+    /// eviction); `cleanup_expired_reservations()` can be called to sweep them
+    /// proactively but is not wired to a timer.
     pub reservation_ttl: Duration,
     /// Maximum number of idle stable-port reservations held at once. When the
     /// cap is reached the least-recently-released reservation is evicted (its
@@ -431,6 +441,18 @@ pub struct MasqueRelayServer {
     reservations_evicted: AtomicU64,
     /// Epoch-millis of the last reservation summary emit (rate-limit gate).
     last_reservation_summary_ms: AtomicU64,
+    /// Session IDs whose stream-forwarding loop is currently live. While a
+    /// session is in this set its reader/writer tasks still hold the bound UDP
+    /// socket, so `close_session` must NOT lease that socket into a reservation
+    /// (a still-live handover): leasing+reclaiming a live socket would let the
+    /// old and new sessions race on the same port. The natural session-end path
+    /// removes the id only after aborting its forwarding tasks, so the socket is
+    /// exclusively owned before it can be leased.
+    active_forwarding: RwLock<HashSet<u64>>,
+    /// Mutex stripes serializing concurrent CONNECTs from the same authenticated
+    /// identity (ADR-011), indexed by the first fingerprint byte. Length is
+    /// `RELAY_PEER_LOCK_STRIPES`.
+    peer_locks: Vec<Mutex<()>>,
     /// Whether this node is willing to serve as a relay for private peers.
     ///
     /// Set to `false` by the ADR-014 reachability classifier when the node
@@ -489,6 +511,10 @@ impl MasqueRelayServer {
             last_reservation_summary_ms: AtomicU64::new(0),
             upnp_mappings: RwLock::new(HashMap::new()),
             reservations: RwLock::new(HashMap::new()),
+            active_forwarding: RwLock::new(HashSet::new()),
+            peer_locks: (0..RELAY_PEER_LOCK_STRIPES)
+                .map(|_| Mutex::new(()))
+                .collect(),
             ip_policy: None,
         }
     }
@@ -557,6 +583,10 @@ impl MasqueRelayServer {
             last_reservation_summary_ms: AtomicU64::new(0),
             upnp_mappings: RwLock::new(HashMap::new()),
             reservations: RwLock::new(HashMap::new()),
+            active_forwarding: RwLock::new(HashSet::new()),
+            peer_locks: (0..RELAY_PEER_LOCK_STRIPES)
+                .map(|_| Mutex::new(()))
+                .collect(),
             ip_policy: None,
         }
     }
@@ -727,6 +757,36 @@ impl MasqueRelayServer {
                     "Rejecting relay CONNECT (IP policy: client on upstream relay IP)",
                 );
                 return Ok(ConnectUdpResponse::error(403, denial.to_string()));
+            }
+        }
+
+        // ADR-011 [W1]: serialize concurrent CONNECTs from the same authenticated
+        // identity via a bounded mutex stripe, so the handover below plus the
+        // capacity / duplicate-address checks plus the reclaim-or-bind and session
+        // insert form a single critical section per identity. Held to function end.
+        let _peer_guard = match peer_id {
+            Some(pid) => Some(self.peer_lock(&pid).lock().await),
+            None => None,
+        };
+
+        // ADR-011 [handover, ordered BEFORE the capacity/duplicate checks]: retire
+        // any live session this identity already holds, so an authenticated
+        // reconnect is never rejected by the capacity (503) or duplicate-address
+        // (409) checks below, and we never leave two live sessions for one
+        // identity. close_session will not lease a still-forwarding session's
+        // socket (see `active_forwarding`), so a live handover takes a fresh port;
+        // the common disconnect→reconnect path instead reclaims the reservation
+        // left when the previous session's forwarding loop ended.
+        if let Some(pid) = peer_id {
+            let old = {
+                let sessions = self.sessions.read().await;
+                sessions
+                    .iter()
+                    .find(|(_, s)| s.peer_id() == Some(pid))
+                    .map(|(id, _)| *id)
+            };
+            if let Some(old_sid) = old {
+                let _ = self.close_session(old_sid).await;
             }
         }
 
@@ -1322,6 +1382,11 @@ impl MasqueRelayServer {
         mut send_stream: crate::high_level::SendStream,
         mut recv_stream: crate::high_level::RecvStream,
     ) {
+        // Mark this session's forwarding as live BEFORE touching the socket, so a
+        // concurrent handover close_session sees it active and will not lease the
+        // socket out from under us (Blocker 1). Removed on every exit path below.
+        self.active_forwarding.write().await.insert(session_id);
+
         let udp_socket = {
             let sessions = self.sessions.read().await;
             match sessions.get(&session_id) {
@@ -1331,6 +1396,7 @@ impl MasqueRelayServer {
                         session_id,
                         "Cannot start stream forwarding: session not found"
                     );
+                    self.active_forwarding.write().await.remove(&session_id);
                     return;
                 }
             }
@@ -1340,6 +1406,7 @@ impl MasqueRelayServer {
             Some(s) => s,
             None => {
                 tracing::warn!(session_id, "Cannot start stream forwarding: no UDP socket");
+                self.active_forwarding.write().await.remove(&session_id);
                 return;
             }
         };
@@ -1375,7 +1442,7 @@ impl MasqueRelayServer {
         let ctrl_tx = fwd_tx.clone();
 
         // Reader: UDP socket → channel (never blocked by stream writes)
-        let reader_handle = tokio::spawn(async move {
+        let mut reader_handle = tokio::spawn(async move {
             let mut buf = vec![0u8; 65536];
             loop {
                 match socket.recv_from(&mut buf).await {
@@ -1403,7 +1470,7 @@ impl MasqueRelayServer {
         });
 
         // Writer: channel → QUIC stream (paced by stream flow control)
-        let writer_handle = tokio::spawn(async move {
+        let mut writer_handle = tokio::spawn(async move {
             let mut keepalive = tokio::time::interval(RELAY_KEEPALIVE_INTERVAL);
             keepalive.tick().await; // skip immediate first tick
 
@@ -1468,8 +1535,11 @@ impl MasqueRelayServer {
             }
         });
 
+        // Borrow the task handles (`&mut`) so the select! does not consume them;
+        // we retain ownership and explicitly abort + await both afterwards so no
+        // detached task can keep using the socket (Blocker 1).
         let close_reason = tokio::select! {
-            result = reader_handle => {
+            result = &mut reader_handle => {
                 match result {
                     Ok(reason) => reason,
                     Err(e) => {
@@ -1478,7 +1548,7 @@ impl MasqueRelayServer {
                     }
                 }
             },
-            result = writer_handle => {
+            result = &mut writer_handle => {
                 match result {
                     Ok(reason) => reason,
                     Err(e) => {
@@ -1600,6 +1670,20 @@ impl MasqueRelayServer {
             close_reason,
             "Stream-based relay forwarding loop ended"
         );
+
+        // Blocker 1: stop the forwarding tasks so neither still holds the UDP
+        // socket once it can be leased/reclaimed. The select! polled the handles
+        // by &mut, so we still own them; abort + await guarantees both tasks have
+        // dropped their socket clones before we close (and possibly lease) it.
+        reader_handle.abort();
+        writer_handle.abort();
+        let _ = reader_handle.await;
+        let _ = writer_handle.await;
+        // Forwarding is finished; clear the live flag BEFORE close_session so the
+        // natural session-end close is allowed to lease the now exclusively-owned
+        // socket (a still-live handover close would instead skip the lease).
+        self.active_forwarding.write().await.remove(&session_id);
+
         if let Err(e) = self.close_session(session_id).await {
             tracing::debug!(session_id, error = %e, "Error closing session");
         }
@@ -1616,10 +1700,12 @@ impl MasqueRelayServer {
         // for a possible stable-port lease before it is dropped.
         let mut session = {
             let mut sessions = self.sessions.write().await;
-            sessions.remove(&session_id).ok_or(RelayError::SessionError {
-                session_id: Some(session_id as u32),
-                kind: SessionErrorKind::NotFound,
-            })?
+            sessions
+                .remove(&session_id)
+                .ok_or(RelayError::SessionError {
+                    session_id: Some(session_id as u32),
+                    kind: SessionErrorKind::NotFound,
+                })?
         };
         session.close();
 
@@ -1633,9 +1719,22 @@ impl MasqueRelayServer {
         // ADR-011: lease the port for reconnect when the peer's authenticated
         // identity is known; otherwise drop the socket and shut the UPnP
         // mapping down (the original behaviour for unauthenticated sessions).
-        let lease = match (session.peer_id(), session.udp_socket().cloned()) {
-            (Some(peer_id), Some(socket)) => Some((peer_id, socket)),
-            _ => None,
+        //
+        // BUT never lease a socket whose forwarding loop is still live: its
+        // reader/writer tasks still hold the socket, so leasing then reclaiming it
+        // would let the old and new sessions race on the same port. This is the
+        // still-live handover case; drop the socket instead and let the old loop
+        // tear it down when it ends. The natural session-end path has already
+        // removed the id from `active_forwarding` (after aborting its tasks), so
+        // there the socket is free and the lease proceeds.
+        let forwarding_active = self.active_forwarding.read().await.contains(&session_id);
+        let lease = if forwarding_active {
+            None
+        } else {
+            match (session.peer_id(), session.udp_socket().cloned()) {
+                (Some(peer_id), Some(socket)) => Some((peer_id, socket)),
+                _ => None,
+            }
         };
         match lease {
             Some((peer_id, socket)) => {
@@ -1781,19 +1880,10 @@ impl MasqueRelayServer {
         peer_id: RelayPeerId,
         want_ipv4: bool,
     ) -> Option<(Arc<UdpSocket>, u16, Option<UpnpMappingService>)> {
-        // Deterministic handover: if this identity still has a live session
-        // (duplicate / stale half-open), retire it first so its port is leased
-        // and can be reclaimed below.
-        let live = {
-            let sessions = self.sessions.read().await;
-            sessions
-                .iter()
-                .find(|(_, s)| s.peer_id() == Some(peer_id))
-                .map(|(id, _)| *id)
-        };
-        if let Some(session_id) = live {
-            let _ = self.close_session(session_id).await;
-        }
+        // Deterministic handover (retiring any live session for this identity) is
+        // performed up-front in `handle_connect_request`, under the per-identity
+        // lock and before the capacity/duplicate checks — so by here there is at
+        // most a leased reservation to take, never a live session to close.
 
         // Take the reservation if present, fresh, and IP-family-compatible.
         let ttl = self.config.reservation_ttl;
@@ -1876,6 +1966,12 @@ impl MasqueRelayServer {
             active_reservations = active_reservations,
             "relay-reservation activity summary (cumulative counts)"
         );
+    }
+
+    /// The mutex stripe that serializes concurrent CONNECTs for a given
+    /// authenticated identity (ADR-011). Same fingerprint → same stripe.
+    fn peer_lock(&self, peer_id: &RelayPeerId) -> &Mutex<()> {
+        &self.peer_locks[peer_id[0] as usize % RELAY_PEER_LOCK_STRIPES]
     }
 
     /// Close session by client address
@@ -2010,7 +2106,10 @@ mod tests {
         let port1 = r1.proxy_public_address.unwrap().port();
 
         // Session drops → the port is leased as a reservation.
-        server.close_session_by_client(client_addr(1)).await.unwrap();
+        server
+            .close_session_by_client(client_addr(1))
+            .await
+            .unwrap();
         assert_eq!(server.session_count().await, 0);
         assert_eq!(server.reservations.read().await.len(), 1);
 
@@ -2022,7 +2121,10 @@ mod tests {
         assert_eq!(r2.status, 200);
         let port2 = r2.proxy_public_address.unwrap().port();
 
-        assert_eq!(port1, port2, "reconnecting peer should reclaim its stable port");
+        assert_eq!(
+            port1, port2,
+            "reconnecting peer should reclaim its stable port"
+        );
         // Reservation consumed by the reclaim.
         assert_eq!(server.reservations.read().await.len(), 0);
     }
@@ -2038,7 +2140,10 @@ mod tests {
             .await
             .unwrap();
         let port1 = r1.proxy_public_address.unwrap().port();
-        server.close_session_by_client(client_addr(1)).await.unwrap();
+        server
+            .close_session_by_client(client_addr(1))
+            .await
+            .unwrap();
 
         // peer_1's reservation still holds port1's socket, so peer_2 cannot get it.
         let r2 = server
@@ -2059,7 +2164,10 @@ mod tests {
             .handle_connect_request(&request, client_addr(1), None)
             .await
             .unwrap();
-        server.close_session_by_client(client_addr(1)).await.unwrap();
+        server
+            .close_session_by_client(client_addr(1))
+            .await
+            .unwrap();
 
         assert_eq!(server.reservations.read().await.len(), 0);
     }
@@ -2078,7 +2186,10 @@ mod tests {
             .handle_connect_request(&request, client_addr(1), Some(peer_fp(7)))
             .await
             .unwrap();
-        server.close_session_by_client(client_addr(1)).await.unwrap();
+        server
+            .close_session_by_client(client_addr(1))
+            .await
+            .unwrap();
         assert_eq!(server.reservations.read().await.len(), 1);
 
         tokio::time::sleep(Duration::from_millis(90)).await;
@@ -2102,7 +2213,10 @@ mod tests {
                 .handle_connect_request(&request, client_addr(i), Some(peer_fp(i)))
                 .await
                 .unwrap();
-            server.close_session_by_client(client_addr(i)).await.unwrap();
+            server
+                .close_session_by_client(client_addr(i))
+                .await
+                .unwrap();
             // Distinct release timestamps so LRU order is unambiguous.
             tokio::time::sleep(Duration::from_millis(5)).await;
         }
@@ -2142,8 +2256,114 @@ mod tests {
 
         assert_eq!(port1, port2, "handover should reuse the port");
         assert_eq!(server.session_count().await, 1, "old session retired");
-        assert!(server.get_session_for_client(client_addr(2)).await.is_some());
-        assert!(server.get_session_for_client(client_addr(1)).await.is_none());
+        assert!(
+            server
+                .get_session_for_client(client_addr(2))
+                .await
+                .is_some()
+        );
+        assert!(
+            server
+                .get_session_for_client(client_addr(1))
+                .await
+                .is_none()
+        );
+    }
+
+    /// Review blocker 2: an authenticated reconnect must retire the peer's
+    /// existing session BEFORE the capacity check, so a full relay
+    /// (`max_sessions = 1`) still admits the reconnect rather than returning 503.
+    #[tokio::test]
+    async fn stable_ports_handover_precedes_capacity_check() {
+        let config = MasqueRelayConfig {
+            max_sessions: 1,
+            ..Default::default()
+        };
+        let server = MasqueRelayServer::new(config, test_addr(9000));
+        let peer = peer_fp(7);
+        let request = ConnectUdpRequest::bind_any();
+
+        let r1 = server
+            .handle_connect_request(&request, client_addr(1), Some(peer))
+            .await
+            .unwrap();
+        assert_eq!(r1.status, 200);
+        let port1 = r1.proxy_public_address.unwrap().port();
+        assert_eq!(server.session_count().await, 1);
+
+        // Relay is at capacity. The same identity reconnecting from a new address
+        // must hand over (retire the old session first), not be rejected with 503.
+        let r2 = server
+            .handle_connect_request(&request, client_addr(2), Some(peer))
+            .await
+            .unwrap();
+        assert_eq!(
+            r2.status, 200,
+            "reconnect at capacity must hand over, not 503"
+        );
+        assert_eq!(server.session_count().await, 1, "old session retired");
+        assert_eq!(
+            r2.proxy_public_address.unwrap().port(),
+            port1,
+            "reconnect reclaims the same port"
+        );
+        assert!(
+            server
+                .get_session_for_client(client_addr(2))
+                .await
+                .is_some()
+        );
+        assert!(
+            server
+                .get_session_for_client(client_addr(1))
+                .await
+                .is_none()
+        );
+    }
+
+    /// Review blocker 1: while a session's forwarding loop is live, `close_session`
+    /// must NOT lease its socket — leasing then reclaiming a socket still held by
+    /// the old reader/writer tasks would let old and new sessions race on the port.
+    #[tokio::test]
+    async fn stable_ports_no_lease_while_forwarding_active() {
+        let server = MasqueRelayServer::new(MasqueRelayConfig::default(), test_addr(9000));
+        let peer = peer_fp(7);
+        let request = ConnectUdpRequest::bind_any();
+
+        server
+            .handle_connect_request(&request, client_addr(1), Some(peer))
+            .await
+            .unwrap();
+        let sid = server
+            .get_session_for_client(client_addr(1))
+            .await
+            .unwrap()
+            .session_id;
+
+        // Simulate a still-live forwarding loop holding the socket.
+        server.active_forwarding.write().await.insert(sid);
+        server.close_session(sid).await.unwrap();
+        assert_eq!(
+            server.reservations.read().await.len(),
+            0,
+            "must not lease a socket whose forwarding loop is still live"
+        );
+        server.active_forwarding.write().await.remove(&sid);
+
+        // With forwarding no longer active, the same flow leases normally.
+        server
+            .handle_connect_request(&request, client_addr(2), Some(peer))
+            .await
+            .unwrap();
+        server
+            .close_session_by_client(client_addr(2))
+            .await
+            .unwrap();
+        assert_eq!(
+            server.reservations.read().await.len(),
+            1,
+            "leases once forwarding is no longer active"
+        );
     }
 
     #[tokio::test]

--- a/src/masque/relay_session.rs
+++ b/src/masque/relay_session.rs
@@ -147,6 +147,13 @@ impl RelaySessionStats {
 
 /// A MASQUE relay session
 ///
+/// 32-byte BLAKE3 fingerprint of a relayed peer's authenticated ML-DSA-65
+/// identity (the canonical `AUTONOMI_PEER_ID_V2` peer id). Relay-port
+/// reservations are keyed by this so a reconnecting peer can reclaim the
+/// public port it previously advertised. It is always derived from the
+/// authenticated QUIC/TLS identity — never from untrusted request payload.
+pub type RelayPeerId = [u8; 32];
+
 /// Manages the lifecycle of a single relay connection, including context
 /// registration, datagram forwarding, and session cleanup.
 #[derive(Debug)]
@@ -161,6 +168,10 @@ pub struct RelaySession {
     public_address: SocketAddr,
     /// Client's address
     client_address: Option<SocketAddr>,
+    /// Authenticated peer fingerprint (`AUTONOMI_PEER_ID_V2`) of the relayed
+    /// peer, when the QUIC connection is PQC-authenticated. Keys stable-port
+    /// reservations; `None` when the identity is unavailable.
+    peer_id: Option<RelayPeerId>,
     /// Context manager for this session (server role - odd context IDs)
     context_manager: ContextManager,
     /// Reverse mapping: target address → context ID
@@ -191,6 +202,7 @@ impl RelaySession {
             state: RelaySessionState::Pending,
             public_address,
             client_address: None,
+            peer_id: None,
             context_manager: ContextManager::new(false), // Server role (odd IDs)
             target_to_context: HashMap::new(),
             created_at: now,
@@ -226,6 +238,17 @@ impl RelaySession {
     /// Get client address if known
     pub fn client_address(&self) -> Option<SocketAddr> {
         self.client_address
+    }
+
+    /// Set the authenticated peer fingerprint for this session.
+    pub fn set_peer_id(&mut self, peer_id: Option<RelayPeerId>) {
+        self.peer_id = peer_id;
+    }
+
+    /// Get the authenticated peer fingerprint if the connection was
+    /// PQC-authenticated.
+    pub fn peer_id(&self) -> Option<RelayPeerId> {
+        self.peer_id
     }
 
     /// Get session statistics

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -3446,7 +3446,12 @@ impl NatTraversalEndpoint {
                                             .await
                                         {
                                             Ok(response) => {
-                                                let is_success = response.is_success();
+                                                // Capture the exact session id the
+                                                // relay created for THIS request, so
+                                                // forwarding can't bind to a different
+                                                // session via a later client-address
+                                                // lookup (which races on reconnect).
+                                                let created_session = response.session_id;
                                                 debug!(
                                                     "Sending CONNECT-UDP response to {}: {:?}",
                                                     addr, response
@@ -3476,22 +3481,20 @@ impl NatTraversalEndpoint {
                                                 // Do NOT call finish() — stream stays open for forwarding
 
                                                 // Start stream-based forwarding loop
-                                                if is_success {
-                                                    if let Some(session_info) =
-                                                        server.get_session_for_client(addr).await
-                                                    {
-                                                        info!(
-                                                            "Starting stream-based relay forwarding for session {} (client: {})",
-                                                            session_info.session_id, addr
-                                                        );
-                                                        server
-                                                            .run_stream_forwarding_loop(
-                                                                session_info.session_id,
-                                                                send_stream,
-                                                                recv_stream,
-                                                            )
-                                                            .await;
-                                                    }
+                                                // for exactly the session that was
+                                                // created (if the request succeeded).
+                                                if let Some(session_id) = created_session {
+                                                    info!(
+                                                        "Starting stream-based relay forwarding for session {} (client: {})",
+                                                        session_id, addr
+                                                    );
+                                                    server
+                                                        .run_stream_forwarding_loop(
+                                                            session_id,
+                                                            send_stream,
+                                                            recv_stream,
+                                                        )
+                                                        .await;
                                                 }
                                             }
                                             Err(e) => {

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -3390,9 +3390,15 @@ impl NatTraversalEndpoint {
         };
 
         let client_addr = connection.remote_address();
+        // Resolve the relayed peer's authenticated identity once for the
+        // connection's lifetime; it keys stable-port reservations. `Copy`, so
+        // it threads into each per-stream task for free.
+        let peer_fingerprint = Self::authenticated_peer_fingerprint(&connection);
         debug!(
-            "Started relay request handler for peer at {} (stable_id={})",
-            client_addr, stable_id
+            "Started relay request handler for peer at {} (stable_id={}, authenticated={})",
+            client_addr,
+            stable_id,
+            peer_fingerprint.is_some()
         );
 
         loop {
@@ -3401,6 +3407,7 @@ impl NatTraversalEndpoint {
                 Ok((mut send_stream, mut recv_stream)) => {
                     let server = Arc::clone(&relay_server);
                     let addr = client_addr;
+                    let peer_id = peer_fingerprint;
                     let _conn_for_relay = connection.clone();
 
                     tokio::spawn(async move {
@@ -3434,7 +3441,10 @@ impl NatTraversalEndpoint {
                                         );
 
                                         // Handle the request via relay server
-                                        match server.handle_connect_request(&request, addr).await {
+                                        match server
+                                            .handle_connect_request(&request, addr, peer_id)
+                                            .await
+                                        {
                                             Ok(response) => {
                                                 let is_success = response.is_success();
                                                 debug!(
@@ -5554,6 +5564,22 @@ impl NatTraversalEndpoint {
         }
 
         None
+    }
+
+    /// Derive the canonical 32-byte peer fingerprint (`AUTONOMI_PEER_ID_V2`)
+    /// from a connection's authenticated ML-DSA-65 identity, or `None` if the
+    /// peer is not PQC-authenticated.
+    ///
+    /// This keys relay-port reservations to a cryptographic identity rather
+    /// than an ephemeral socket address. The identity comes solely from the
+    /// authenticated QUIC/TLS handshake — never from untrusted request payload.
+    fn authenticated_peer_fingerprint(connection: &InnerConnection) -> Option<[u8; 32]> {
+        let spki = Self::extract_public_key_from_connection(connection)?;
+        let public_key =
+            crate::crypto::raw_public_keys::pqc::extract_public_key_from_spki(&spki).ok()?;
+        Some(crate::crypto::raw_public_keys::pqc::fingerprint_public_key(
+            &public_key,
+        ))
     }
 
     /// Extract the raw SPKI bytes from a connection's TLS identity.

--- a/tests/ipv4_ipv6_bridging_tests.rs
+++ b/tests/ipv4_ipv6_bridging_tests.rs
@@ -97,7 +97,7 @@ async fn test_ipv4_to_ipv4_relay() {
 
     // Request to relay traffic to IPv4 target
     let request = ConnectUdpRequest::target(target_addr);
-    let response = relay.handle_connect_request(&request, client_addr).await;
+    let response = relay.handle_connect_request(&request, client_addr, None).await;
 
     assert!(response.is_ok(), "IPv4→IPv4 should succeed");
     assert!(response.unwrap().is_success());
@@ -115,7 +115,7 @@ async fn test_ipv4_to_ipv6_bridging() {
 
     // Request to relay traffic to IPv6 target from IPv4 client
     let request = ConnectUdpRequest::target(target_addr);
-    let response = relay.handle_connect_request(&request, client_addr).await;
+    let response = relay.handle_connect_request(&request, client_addr, None).await;
 
     assert!(
         response.is_ok(),
@@ -144,7 +144,7 @@ async fn test_ipv6_to_ipv4_bridging() {
 
     // Request to relay traffic to IPv4 target from IPv6 client
     let request = ConnectUdpRequest::target(target_addr);
-    let response = relay.handle_connect_request(&request, client_addr).await;
+    let response = relay.handle_connect_request(&request, client_addr, None).await;
 
     assert!(
         response.is_ok(),
@@ -163,7 +163,7 @@ async fn test_ipv6_to_ipv6_relay() {
     let target_addr = ipv6_addr(10008);
 
     let request = ConnectUdpRequest::target(target_addr);
-    let response = relay.handle_connect_request(&request, client_addr).await;
+    let response = relay.handle_connect_request(&request, client_addr, None).await;
 
     assert!(response.is_ok(), "IPv6→IPv6 should succeed");
     assert!(response.unwrap().is_success());
@@ -183,7 +183,7 @@ async fn test_no_dual_stack_relay_fails_cross_version() {
     let target_addr = ipv6_addr(10010);
 
     let request = ConnectUdpRequest::target(target_addr);
-    let response = relay.handle_connect_request(&request, client_addr).await;
+    let response = relay.handle_connect_request(&request, client_addr, None).await;
 
     // Should fail with clear error
     assert!(response.is_err() || !response.unwrap().is_success());
@@ -198,7 +198,7 @@ async fn test_relay_session_timeout() {
 
     let client_addr = ipv4_addr(10011);
     let request = ConnectUdpRequest::bind_any();
-    let _ = relay.handle_connect_request(&request, client_addr).await;
+    let _ = relay.handle_connect_request(&request, client_addr, None).await;
 
     // Verify session exists
     assert!(relay.get_session_for_client(client_addr).await.is_some());
@@ -228,7 +228,7 @@ async fn test_relay_rate_limit_rejection() {
     let client_addr = ipv4_addr(10012);
     let request = ConnectUdpRequest::bind_any();
     let _ = relay
-        .handle_connect_request(&request, client_addr)
+        .handle_connect_request(&request, client_addr, None)
         .await
         .unwrap();
 
@@ -305,7 +305,7 @@ async fn test_sustained_bridging_load_30s() {
 
         for (client, target) in scenarios.iter() {
             let request = ConnectUdpRequest::target(*target);
-            match relay.handle_connect_request(&request, *client).await {
+            match relay.handle_connect_request(&request, *client, None).await {
                 Ok(resp) if resp.is_success() => success_count += 1,
                 _ => failure_count += 1,
             }

--- a/tests/ipv4_ipv6_bridging_tests.rs
+++ b/tests/ipv4_ipv6_bridging_tests.rs
@@ -97,7 +97,9 @@ async fn test_ipv4_to_ipv4_relay() {
 
     // Request to relay traffic to IPv4 target
     let request = ConnectUdpRequest::target(target_addr);
-    let response = relay.handle_connect_request(&request, client_addr, None).await;
+    let response = relay
+        .handle_connect_request(&request, client_addr, None)
+        .await;
 
     assert!(response.is_ok(), "IPv4→IPv4 should succeed");
     assert!(response.unwrap().is_success());
@@ -115,7 +117,9 @@ async fn test_ipv4_to_ipv6_bridging() {
 
     // Request to relay traffic to IPv6 target from IPv4 client
     let request = ConnectUdpRequest::target(target_addr);
-    let response = relay.handle_connect_request(&request, client_addr, None).await;
+    let response = relay
+        .handle_connect_request(&request, client_addr, None)
+        .await;
 
     assert!(
         response.is_ok(),
@@ -144,7 +148,9 @@ async fn test_ipv6_to_ipv4_bridging() {
 
     // Request to relay traffic to IPv4 target from IPv6 client
     let request = ConnectUdpRequest::target(target_addr);
-    let response = relay.handle_connect_request(&request, client_addr, None).await;
+    let response = relay
+        .handle_connect_request(&request, client_addr, None)
+        .await;
 
     assert!(
         response.is_ok(),
@@ -163,7 +169,9 @@ async fn test_ipv6_to_ipv6_relay() {
     let target_addr = ipv6_addr(10008);
 
     let request = ConnectUdpRequest::target(target_addr);
-    let response = relay.handle_connect_request(&request, client_addr, None).await;
+    let response = relay
+        .handle_connect_request(&request, client_addr, None)
+        .await;
 
     assert!(response.is_ok(), "IPv6→IPv6 should succeed");
     assert!(response.unwrap().is_success());
@@ -183,7 +191,9 @@ async fn test_no_dual_stack_relay_fails_cross_version() {
     let target_addr = ipv6_addr(10010);
 
     let request = ConnectUdpRequest::target(target_addr);
-    let response = relay.handle_connect_request(&request, client_addr, None).await;
+    let response = relay
+        .handle_connect_request(&request, client_addr, None)
+        .await;
 
     // Should fail with clear error
     assert!(response.is_err() || !response.unwrap().is_success());
@@ -198,7 +208,9 @@ async fn test_relay_session_timeout() {
 
     let client_addr = ipv4_addr(10011);
     let request = ConnectUdpRequest::bind_any();
-    let _ = relay.handle_connect_request(&request, client_addr, None).await;
+    let _ = relay
+        .handle_connect_request(&request, client_addr, None)
+        .await;
 
     // Verify session exists
     assert!(relay.get_session_for_client(client_addr).await.is_some());

--- a/tests/masque_integration_tests.rs
+++ b/tests/masque_integration_tests.rs
@@ -71,7 +71,7 @@ async fn test_relay_server_handles_connect_request() {
     let request = ConnectUdpRequest::bind_any();
 
     let response = server
-        .handle_connect_request(&request, client_addr)
+        .handle_connect_request(&request, client_addr, None)
         .await
         .unwrap();
 
@@ -92,7 +92,7 @@ async fn test_relay_server_session_limit() {
         let client = test_addr(12345 + i);
         let request = ConnectUdpRequest::bind_any();
         let response = server
-            .handle_connect_request(&request, client)
+            .handle_connect_request(&request, client, None)
             .await
             .unwrap();
         assert!(response.is_success());
@@ -102,7 +102,7 @@ async fn test_relay_server_session_limit() {
     let extra_client = test_addr(12347);
     let request = ConnectUdpRequest::bind_any();
     let response = server
-        .handle_connect_request(&request, extra_client)
+        .handle_connect_request(&request, extra_client, None)
         .await
         .unwrap();
     assert!(!response.is_success());
@@ -341,7 +341,7 @@ async fn test_e2e_relay_scenario() {
     // Client connects to relay
     let request = ConnectUdpRequest::bind_any();
     let response = server
-        .handle_connect_request(&request, test_addr(12345))
+        .handle_connect_request(&request, test_addr(12345), None)
         .await
         .unwrap();
 
@@ -387,7 +387,7 @@ async fn test_high_session_count() {
         let client = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, i as u8)), 12345 + i);
         let request = ConnectUdpRequest::bind_any();
         let response = server
-            .handle_connect_request(&request, client)
+            .handle_connect_request(&request, client, None)
             .await
             .unwrap();
         assert!(response.is_success());


### PR DESCRIPTION
Promotes `rc-2026.6.3` to release version(s): 0.35.1.

- strips `-rc.*` from `[package].version`
- rewrites internal git+branch deps to crates.io version pins
- regenerates `Cargo.lock`

Once merged, the release tag will be pushed to fire the publish workflow.