### PR TITLE
fix(deps): upgrade anyhow to >=1.0.103 for RUSTSEC-2026-0190

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"


### PR DESCRIPTION
## Summary

Resolves the daily Security workflow failure caused by **RUSTSEC-2026-0190** — an unsoundness in `anyhow 1.0.102`'s `Error::downcast_mut()`. Releases that combine `Error::context()` followed by `Error::downcast_mut()` can cause undefined behaviour / Stacked Borrows violations (confirmed by Miri).

The flaw was fixed upstream in [dtolnay/anyhow commit `6e8c000`](https://github.com/dtolnay/anyhow/issues/451), released as `anyhow 1.0.103`.

## Change

Pure dependency bump — no source code changes. `Cargo.lock` only:

```diff
-version = "1.0.102"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+version = "1.0.103"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
```

The `anyhow = "1"` requirement in `saorsa-transport` already permits `1.0.103`, so no manifest edit was required — `cargo update -p anyhow --precise 1.0.103` was sufficient. The upgrade propagates through both transitive paths flagged in the failing run:

- `anyhow 1.0.103` → `saorsa-pqc 0.4.2` → `saorsa-transport 0.35.1`
- `anyhow 1.0.103` → `saorsa-transport 0.35.1` (direct, and dev-dependencies)

## Verification

After the bump:

```
$ cargo deny check advisories
advisories ok

$ cargo tree -i anyhow
anyhow v1.0.103
├── saorsa-pqc v0.4.2
│   └── saorsa-transport v0.35.1
└── saorsa-transport v0.35.1

$ cargo check --workspace --all-targets
Finished `dev` profile [unoptimized + debuginfo] target(s) in 56.20s
```

`cargo audit` reports only the two pre-existing unmaintained warnings (`atomic-polyfill`, `rustls-pemfile`); zero unsound/error findings. RUSTSEC-2026-0190 is gone.

## References

- Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0190
- Upstream issue: https://github.com/dtolnay/anyhow/issues/451
- Failing workflow run (now expected to turn green): https://github.com/saorsa-labs/saorsa-transport/actions/runs/28696546489