### PR TITLE
fix(deps): bump quinn-proto to 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2496,9 +2496,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
## Summary

Bump `quinn-proto` `0.11.14 → 0.11.15` in the committed lockfile to clear **RUSTSEC-2026-0185** (remote memory exhaustion via unbounded out-of-order stream reassembly).

## Details

- Reaches this crate transitively: `quinn → quinn-proto`, over a caret range — so 0.11.15 resolves with **no `Cargo.toml` change**, lockfile-only.
- Advisory: affected `< 0.11.15`, patched `>= 0.11.15`.
- Keeps `cargo audit` green for this repo.

Lockfile-only; no code or API impact.