### PR TITLE
chore(release): promote rc-2026.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3023,7 +3023,7 @@ dependencies = [
 
 [[package]]
 name = "saorsa-transport"
-version = "0.36.0-rc.1"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3023,7 +3023,7 @@ dependencies = [
 
 [[package]]
 name = "saorsa-transport"
-version = "0.35.3"
+version = "0.36.0-rc.1"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "saorsa-transport"
-version = "0.35.3"
+version = "0.36.0-rc.1"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "saorsa-transport"
-version = "0.36.0-rc.1"
+version = "0.36.0"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Promotes `rc-2026.8.2` to release version(s): 0.36.0.

- strips `-rc.*` from `[package].version`
- rewrites internal git+branch deps to crates.io version pins
- regenerates `Cargo.lock`

Once merged, the release tag will be pushed to fire the publish workflow.