### PR TITLE
fix(nat): keep-alive on the dialling side only, at 10 s

### DIFF
--- a/docs/adr/ADR-012-keep-alive-dial-accept-split.md
+++ b/docs/adr/ADR-012-keep-alive-dial-accept-split.md
@@ -1,0 +1,162 @@
+# ADR-012: Keep-Alive on the Dialling Side Only
+
+## Status
+
+Proposed
+
+## Context
+
+We wanted to cut wasted egress. A node in this network holds many connections
+that sit idle most of the time, and it was paying far more to keep them open
+than the job requires.
+
+A QUIC keep-alive is a small packet sent on an otherwise silent connection so
+that neither end times it out. Two things were wrong with ours.
+
+**Both ends were configured to send them.** That does not mean two exchanges per
+interval: any traffic resets both timers, so the shorter interval sets the pace
+and the longer one rarely fires. The cost is one exchange per *shorter* interval.
+
+**The accepting end's interval was not its own setting.** It read
+`NatTraversalTimeouts::retry_interval`, the cadence for retrying NAT traversal —
+an unrelated concern that happens to live in the same struct. In production that
+made it 2 s, so the fleet's idle cadence was set by a NAT-retry knob nobody had
+chosen for the purpose, and tuning NAT retries would have silently changed idle
+bandwidth.
+
+Together those cost **29.8 B/s per connection endpoint**, continuously, on an
+idle 25-node testnet.
+
+## Decision
+
+Send keep-alives from the dialling side only, at a fixed 10 s:
+
+```rust
+// dialling side
+transport_config.keep_alive_interval(Some(DIAL_KEEP_ALIVE_INTERVAL)); // 10 s
+// accepting side
+transport_config.keep_alive_interval(None);
+```
+
+`retry_interval` is no longer read by the keep-alive path at all.
+
+**One side is enough.** The accepting end answers every keep-alive, so both idle
+timers reset and each end still puts a packet on the wire once per interval.
+That outgoing packet is also what keeps each end's NAT mapping alive, since
+RFC 4787 mappings are refreshed by outbound traffic.
+
+**Every connection has exactly one dialling end**, so this cannot leave a
+connection with no keep-alive. Outbound `connect()`, hole punching and both
+relay paths dial with the client config; simultaneous open makes two ordinary
+client/server connections and deduplication picks one; migration keeps the
+config the connection already had.
+
+**The interval is the only real lever.** Because the shorter timer always
+dominated, disabling one side saves nothing by itself — the saving comes from
+10 s replacing an effective 2 s.
+
+**Not configurable, deliberately.** A keep-alive interval is a property of the
+network the fleet runs on, not a per-operator preference, and nobody can be
+expected to know what to set it to. The coupling to `retry_interval` is an
+example of what a settable value already cost us. Hard-coding means the value is
+reviewed once, here, with its reasoning attached to it.
+
+**Why 10 s and not longer.** The binding constraint is NAT mapping lifetime, not
+the QUIC idle timeout. RFC 4787 requires mappings to survive two minutes, but
+20–30 s middleboxes are reported in the field, and home routers and
+carrier-grade NAT are where those live. If a mapping lapses, the keep-alive is
+dropped at the peer's NAT *before* it can provoke the ACK that would have
+refreshed it, so the connection cannot recover itself and needs a reconnect.
+10 s is also below RFC 8085 §3.5's 15 s floor for general-Internet keep-alives —
+a deliberate departure for a node whose reachability depends on those mappings.
+
+## Consequences
+
+**Idle egress falls 79.5%**, from 29.8 to 6.1 B/s per connection endpoint.
+Measured two ways with no shared code path — a 25-node testnet (79.51%) and
+in-process connection pairs (79.58%) — agreeing to 0.07 percentage points.
+Figures are wire-equivalent: measured UDP payload plus an assumed 28 B IPv4+UDP
+header per datagram.
+
+**The saving is not linear in rollout.** A patched node dialling an un-upgraded
+node saves *nothing* (measured 0%): the un-upgraded accepter keeps pinging at
+its own 2 s cadence, and the shorter timer wins. The full saving arrives only
+when both ends of a connection are upgraded, so plan the upgrade per connection
+pair rather than expecting a proportional gain.
+
+**No API or wire change.** No public type changes, so no semver break. No frame
+or transport-parameter change either; the cadence is a local choice and never
+negotiated, so patched and un-upgraded nodes interoperate in both directions.
+
+**The accepting side stops taking RTT samples on idle connections.** An RTT
+sample needs an ACK covering a locally-sent ack-eliciting packet, and ACK-only
+responses do not produce one, so its PTO estimate can go stale on an otherwise
+silent connection. Any application traffic restores sampling at once.
+
+**Loss margin shrinks.** A lost keep-alive arms PTO rather than waiting for the
+next one, so survivable consecutive loss depends on the path's PTO — roughly
+seven outbound losses near a 1 s PTO, three near 5 s. Computed estimates; no
+local path exercised loss, and every run recorded `lost_packets = 0`.
+
+**Idle connections are cheaper to pin.** A conforming peer now needs one packet
+before 30 s rather than an answer every ~2 s — roughly 15x fewer
+attacker-originated packets, by packet-rate arithmetic rather than measurement.
+Not a new capability: any authenticated packet already reset the idle timer, so
+a peer willing to ignore the old PINGs could always have done this. Connection
+caps are the mitigation, and `P2pConfig::max_connections` not being enforced at
+the QUIC accept layer is a pre-existing gap this ADR does not address.
+
+**Rollback is a dependency pin and a rolling restart.** There is no
+configuration to change, by design. Existing connections keep the transport
+config they were created with, so a revert takes effect on reconnect. No
+durable wire, crypto or persisted state is involved, and mixed versions
+interoperate, so the rollback need not be atomic.
+
+### Not validated locally
+
+Every measurement is loopback: **no NAT and no packet loss**, which is precisely
+what the interval is chosen against. Two further caveats: the gap between
+keep-alives is the interval **plus one round trip**, because the timer re-arms
+on receive as well as send; and no jitter is applied, which RFC 8085 recommends.
+
+Watch after rollout, comparing consumer and cellular nodes against a datacentre
+control over at least seven days:
+
+| signal | why |
+|---|---|
+| connection lifetime p10/p50, and the fraction closing at 30–45 s | a mode near 30 s is the NAT-timeout signature |
+| reconnect rate and handshake bytes per node-hour | reconnects eat the saving; one costs ~165 s of it |
+| `fail_timeout` audit outcomes | a dead connection reads as an unanswered audit and costs trust score |
+| per-node UDP egress | confirms the saving is real off loopback |
+
+Production does not record the first two today, which is worth fixing before
+this reaches a large share of the fleet. If the lifetime signature appears,
+shorten the interval rather than reverting. 5 s is the obvious step and still
+removes the second timer, though note it is not a return to the old behaviour:
+the previous *effective* cadence was the accepting side's 2 s, so only 2 s
+reproduces it exactly. Any other regression means revert and diagnose.
+
+## Alternatives Considered
+
+**Make the interval configurable.** Rejected. A keep-alive interval is a
+property of the network, not a per-operator preference; nobody can be expected
+to know what to set it to, and the accidental coupling to `retry_interval` shows
+what a settable value already cost. It also adds a knob that has to be
+documented, validated, plumbed through consumers and reasoned about at every
+layer, to express a value that should have exactly one correct setting.
+
+**Dialling side only, but at the existing 2 s.** Saves nothing. The shorter
+timer already dominated, so the effective cadence would be unchanged — it just
+moves which side emits it.
+
+**15 s.** Measured better still (86.5%), but leaves roughly half the headroom
+against a short-timeout middlebox, and the failure does not degrade gracefully.
+Given the network is meant to run on home connections, 10 s is the right side of
+that trade to be wrong on.
+
+**Disable the dialling side instead.** Symmetric in egress, worse operationally:
+the dialling side is the one that knows it wants the connection kept open.
+
+**Raise `max_idle_timeout` to 60 s.** Would restore margin against the idle
+timeout at zero egress cost, but does nothing for NAT mapping lifetime, which is
+the actual constraint — and it doubles how long a silent peer pins resources.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -21,6 +21,7 @@ ADRs document significant architectural decisions made in the project. Each reco
 | [ADR-009](ADR-009-masque-relay-data-plane.md) | MASQUE Relay Data Plane Implementation | Accepted | 2026-03-29 |
 | [ADR-010](ADR-010-repository-ownership.md) | Repository Ownership under WithAutonomi | Accepted | 2026-05-29 |
 | [ADR-011](ADR-011-stable-relay-port-reservations.md) | Stable Relay Port Reservations (Authenticated, Leased) | Proposed | 2026-06-24 |
+| [ADR-012](ADR-012-keep-alive-dial-accept-split.md) | Keep-Alive on the Dialling Side Only | Proposed | 2026-08-14 |
 
 ## ADR Template
 

--- a/src/config/nat_timeouts.rs
+++ b/src/config/nat_timeouts.rs
@@ -35,6 +35,36 @@ pub struct NatTraversalTimeouts {
     pub session_timeout: Duration,
 }
 
+/// QUIC keep-alive interval for connections this node dials.
+///
+/// Only the dialling side sends keep-alives. One side is enough: a keep-alive
+/// is ack-eliciting, so the peer answers it, both idle timers reset, and each
+/// side puts a packet on the wire once per interval — which is also what
+/// refreshes a NAT mapping for that five-tuple.
+///
+/// 10 s rather than the 5 s + 2 s pair it replaces. Because any traffic resets
+/// both timers, the old arrangement ran at whichever interval was shorter, so
+/// the effective cadence was the accepting side's 2 s and the interval is the
+/// only real lever on idle egress. Measured on a 25-node testnet, moving to
+/// 10 s takes idle egress from 29.8 to 6.1 B/s per connection endpoint.
+///
+/// The constraint on going further is NAT mapping lifetime, not the QUIC idle
+/// timeout: RFC 4787 requires two minutes but 20-30 s middleboxes are reported
+/// in the field, and if a mapping lapses the keep-alive is dropped before it
+/// can provoke the ACK that would have refreshed it. 10 s is deliberately below
+/// RFC 8085's 15 s floor for general-Internet keep-alives, for that reason.
+pub(crate) const DIAL_KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(10);
+
+/// `max_idle_timeout` applied to every QUIC connection this crate creates.
+///
+/// Named here so the two endpoint configuration sites cannot drift apart, and
+/// so the keep-alive above has something to be read against.
+///
+/// Crate-private on purpose: these are internal wiring values, not API. The
+/// integration test asserts the literals it expects rather than importing
+/// these, so a wrong constant fails the test instead of moving it.
+pub(crate) const QUIC_MAX_IDLE_TIMEOUT_MS: u32 = 30_000;
+
 impl Default for NatTraversalTimeouts {
     fn default() -> Self {
         Self {

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -3458,9 +3458,16 @@ impl NatTraversalEndpoint {
             // Configure transport parameters for NAT traversal
             let mut transport_config = TransportConfig::default();
             transport_config.enable_address_discovery(true);
-            transport_config
-                .keep_alive_interval(Some(config.timeouts.nat_traversal.retry_interval));
-            transport_config.max_idle_timeout(Some(crate::VarInt::from_u32(30000).into()));
+            // Accepting side: no keep-alive. Only one side of a connection needs
+            // one — a keep-alive is ack-eliciting, so the peer answers it and
+            // both idle timers reset — and the dialling peer supplies it. This
+            // used to be `retry_interval`, which is the NAT *retry* cadence and
+            // an unrelated concern that happens to live in the same struct.
+            transport_config.keep_alive_interval(None);
+            transport_config.max_idle_timeout(Some(
+                crate::VarInt::from_u32(crate::config::nat_timeouts::QUIC_MAX_IDLE_TIMEOUT_MS)
+                    .into(),
+            ));
 
             // Tune QUIC flow-control windows from max_message_size
             let window = varint_from_max_message_size(config.max_message_size);
@@ -3544,8 +3551,17 @@ impl NatTraversalEndpoint {
             // Configure transport parameters for NAT traversal
             let mut transport_config = TransportConfig::default();
             transport_config.enable_address_discovery(true);
-            transport_config.keep_alive_interval(Some(Duration::from_secs(5)));
-            transport_config.max_idle_timeout(Some(crate::VarInt::from_u32(30000).into()));
+            // Dialling side: the only keep-alive on the connection. The peer's
+            // ACK is an outbound packet there too, so both directions put a
+            // packet on the wire roughly once per interval — roughly, because
+            // the timer re-arms on receive as well as send, so each cycle drifts
+            // out by about a round trip.
+            transport_config
+                .keep_alive_interval(Some(crate::config::nat_timeouts::DIAL_KEEP_ALIVE_INTERVAL));
+            transport_config.max_idle_timeout(Some(
+                crate::VarInt::from_u32(crate::config::nat_timeouts::QUIC_MAX_IDLE_TIMEOUT_MS)
+                    .into(),
+            ));
 
             // Tune QUIC flow-control windows from max_message_size
             let window = varint_from_max_message_size(config.max_message_size);
@@ -7371,7 +7387,8 @@ impl NatTraversalEndpoint {
                         // Wake the connection driver immediately so the queued
                         // PUNCH_ME_NOW frame is transmitted without waiting for
                         // the next keep-alive or scheduled poll. Without this,
-                        // idle connections delay transmission by up to 15s.
+                        // idle connections delay transmission by up to one
+                        // keep-alive interval.
                         conn.wake_transmit();
                         info!(
                             "Successfully queued PUNCH_ME_NOW for relay to {}",

--- a/tests/keep_alive_asymmetry.rs
+++ b/tests/keep_alive_asymmetry.rs
@@ -1,0 +1,184 @@
+// Copyright 2024 Saorsa Labs Ltd.
+//
+// This Saorsa Network Software is licensed under the General Public License (GPL), version 3.
+// Please see the file LICENSE-GPL, or visit <http://www.gnu.org/licenses/> for the full text.
+//
+// Full details available at https://saorsalabs.com/licenses
+
+//! Only the dialling side keep-alives, and that is enough to hold a connection.
+//!
+//! Two in-process endpoints are connected and left idle for longer than the
+//! 30 s `max_idle_timeout`. Everything is read from the dialling side's
+//! `ConnectionStats`, which sees both halves of the question: `frame_tx.ping`
+//! is what this node sent and `frame_rx.ping` is what the peer sent, so the
+//! accepting side's silence is observed on the wire rather than inferred.
+//!
+//! `frame_tx.ping` is not a keep-alive counter in general — it also counts
+//! DPLPMTUD probes, PTO probes and path validation. None of those should fire
+//! here after the settle: the MTU search finishes in a few loopback round trips
+//! and does not re-probe for 600 s, PTO needs loss, and path validation needs a
+//! migration. That is an argument rather than a proof, so the test checks the
+//! *spacing* of the PINGs too, which a stray probe would not match.
+//!
+//! This is loopback: no NAT, no loss, one connection. It shows the mechanism
+//! works on an ideal path. It says nothing about NAT mapping expiry, which is
+//! what actually bounds how long the interval can be.
+
+#![allow(clippy::expect_used)]
+
+use saorsa_transport::{NatConfig, P2pConfig, P2pEndpoint, PqcConfig};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::time::Duration;
+
+/// The cadence and idle timeout the transport is expected to use. Written as
+/// literals rather than imported from the crate, so that changing the constant
+/// fails this test instead of silently moving what it asserts.
+const EXPECTED_KEEP_ALIVE: Duration = Duration::from_secs(10);
+const EXPECTED_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Long enough for the handshake, PQC key exchange, address discovery and the
+/// MTU search to finish, so none of them lands inside the window.
+const SETTLE: Duration = Duration::from_secs(8);
+
+/// Idle window: past the idle timeout, so a connection nothing is keeping alive
+/// is guaranteed to be gone by the end of it.
+const IDLE_WINDOW: Duration = Duration::from_secs(40);
+
+const _: () = assert!(
+    IDLE_WINDOW.as_millis() > EXPECTED_IDLE_TIMEOUT.as_millis(),
+    "the window must exceed the idle timeout or this proves nothing"
+);
+
+fn config(known_peers: Vec<SocketAddr>) -> P2pConfig {
+    P2pConfig::builder()
+        .bind_addr(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
+        .known_peers(known_peers)
+        .nat(NatConfig {
+            allow_loopback: true,
+            enable_relay_fallback: false,
+            ..Default::default()
+        })
+        .pqc(PqcConfig::default())
+        .build()
+        .expect("build test config")
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn only_the_dialling_side_keep_alives_and_the_connection_survives() {
+    let accepter = P2pEndpoint::new(config(vec![]))
+        .await
+        .expect("accepter endpoint");
+    let peer = accepter.local_addr().expect("accepter address");
+    let dialer = P2pEndpoint::new(config(vec![peer]))
+        .await
+        .expect("dialer endpoint");
+    tokio::time::timeout(Duration::from_secs(20), dialer.connect(peer))
+        .await
+        .expect("connect did not time out")
+        .expect("connect succeeded");
+
+    // `(pings sent, pings received, acks received)` from the dialler's view.
+    let counters = || async {
+        match dialer.get_quic_connection(&peer).await {
+            Ok(Some(conn)) => {
+                let s = conn.stats();
+                (s.frame_tx.ping, s.frame_rx.ping, s.frame_rx.acks)
+            }
+            other => panic!("no live connection to {peer} ({other:?})"),
+        }
+    };
+
+    tokio::time::sleep(SETTLE).await;
+    let (sent_before, received_before, acks_before) = counters().await;
+
+    // Sample across the window so the PINGs can be timed, not just counted.
+    let started = tokio::time::Instant::now();
+    let mut ping_times = Vec::new();
+    let mut seen = sent_before;
+    while started.elapsed() < IDLE_WINDOW {
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        let (sent_now, _, _) = counters().await;
+        for _ in seen..sent_now {
+            ping_times.push(started.elapsed());
+        }
+        seen = sent_now;
+    }
+    let (sent_after, received_after, acks_after) = counters().await;
+    for _ in seen..sent_after {
+        ping_times.push(started.elapsed());
+    }
+
+    let pings_sent = sent_after - sent_before;
+    let pings_received = received_after - received_before;
+    let acks_received = acks_after - acks_before;
+    let report = format!("sent={pings_sent} received={pings_received} acks={acks_received}");
+
+    assert_eq!(
+        pings_received, 0,
+        "the accepting side must send no keep-alive of its own: {report}"
+    );
+    assert!(
+        acks_received > 0,
+        "the accepting side must answer — its ACKs are the outbound packets that \
+         refresh its NAT mapping in the reverse direction: {report}"
+    );
+
+    // At a 10 s cadence a 40 s window holds three or four, depending on where
+    // the window opens relative to the timer.
+    let expected = IDLE_WINDOW.as_secs() / EXPECTED_KEEP_ALIVE.as_secs();
+    assert!(
+        (expected - 1..=expected + 1).contains(&pings_sent),
+        "expected about {expected} keep-alives over {IDLE_WINDOW:?} at a \
+         {EXPECTED_KEEP_ALIVE:?} cadence: {report}"
+    );
+    assert_eq!(
+        ping_times.len() as u64,
+        pings_sent,
+        "every counted PING must be timed, or the spacing check below skips it"
+    );
+
+    // Counting alone would let an unrelated PING — an MTU or PTO probe — stand
+    // in for a keep-alive that never fired, since those cluster near other
+    // traffic rather than arriving on a cadence. So require the gaps to be at
+    // least half the interval.
+    //
+    // Deliberately one-sided: these timestamps are when the sampler *observed*
+    // a counter change, so a busy machine can only stretch a gap, never shrink
+    // one. An upper bound would flake; a lower bound cannot.
+    let minimum_gap = EXPECTED_KEEP_ALIVE / 2;
+    for pair in ping_times.windows(2) {
+        if let [earlier, later] = pair {
+            let gap = later.saturating_sub(*earlier);
+            assert!(
+                gap >= minimum_gap,
+                "PINGs {gap:?} apart, closer than the {minimum_gap:?} floor for a \
+                 {EXPECTED_KEEP_ALIVE:?} cadence — something other than the keep-alive \
+                 is emitting them: {report}"
+            );
+        }
+    }
+
+    // `close_reason()` would only say the local driver has not processed a close
+    // yet, so instead require the far side to still be answering. This shows the
+    // peer is alive and reachable; it is not proof that this particular payload
+    // was delivered, since ACK counters do not identify what they acknowledge.
+    dialer
+        .send(&peer, b"post-idle liveness probe")
+        .await
+        .expect("an idle-but-alive connection must still accept a send");
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    let acks_at_send = counters().await.2;
+    loop {
+        if counters().await.2 > acks_at_send {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "the peer did not acknowledge data sent after a {IDLE_WINDOW:?} idle window"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    let _ = tokio::time::timeout(Duration::from_secs(3), dialer.shutdown()).await;
+    let _ = tokio::time::timeout(Duration::from_secs(3), accepter.shutdown()).await;
+}


### PR DESCRIPTION
## Linear issue

[V2-974](https://linear.app/autonominetwork/issue/V2-974/decouple-the-quic-keep-alive-from-the-nat-retry-interval-80percent)

## Risk tier

- [ ] T0 — docs / tooling / CI / pure UX-output. Repo CI only.
- [ ] T1 — client-only, no network-facing behavior change. CI + prod compat smoke.
- [x] T2 — node/client logic with behavioral surface, no protocol/format/economics change. Dev testnet + ADR.
- [ ] T3 — protocol / storage format / payments / routing. T2 evidence + adversarial testing.

## Compatibility

- Wire: none
- Storage: none
- API: none

**Wire.** No frame or transport-parameter change. Keep-alive cadence is a local
choice and never negotiated, so patched and un-upgraded nodes interoperate in
both directions.

**API.** No public type or signature changes. The interval is a crate-private
constant, not a config field.

## Semver impact

- [ ] breaking
- [ ] feature
- [x] fix

## Test evidence

`cargo test --lib` — 1494 pass, 0 fail, 3 ignored. `cargo fmt --all --check` and
`cargo clippy --all-targets -- -D warnings` clean; `cargo doc --no-deps` exits 0.

`tests/keep_alive_asymmetry.rs` idles a real connection for 40 s against the
30 s `max_idle_timeout` and asserts, from the dialling side's `ConnectionStats`:
three to five PINGs sent, no two closer than 5 s apart, **zero** received,
reverse ACK traffic observed, and the peer still answering afterwards. The
spacing floor matters because `frame_tx.ping` also counts MTU and PTO probes,
which cluster near other traffic rather than arriving on a cadence — a count
alone would let one stand in for a keep-alive that never fired. It is a floor
rather than a range because the timestamps are when the sampler observed a
counter change, so a busy machine can stretch a gap but never shrink one.

The final check confirms the peer is still answering; it is not proof this
particular payload was delivered, since ACK counters do not identify what they
acknowledge.

**Measured effect.** Idle egress per connection endpoint 29.8 → 6.1 B/s,
**79.5%**, on two instruments with no shared code path — a 25-node ant-node
testnet (79.51%) and in-process pairs (79.58%), agreeing to 0.07 points. Figures
are wire-equivalent, adding an assumed 28 B IPv4+UDP header per datagram to
measured payload.

**Rollout is directional.** A patched node *dialling* an un-upgraded one saves
nothing (29.016 vs a 28.990 baseline) — the un-upgraded accepter keeps pinging
at 2 s and the shorter timer wins. The reverse pairing falls to 11.830 B/s, a
59.2% reduction, because disabling the accepting side removes that 2 s timer.
The full 79.5% needs both ends, so upgrading accepters first captures most of
the benefit early.

**What loopback cannot show.** No NAT and no packet loss, which is exactly what
bounds the interval — see ADR-012 for the reasoning and the signals to watch on
the fleet. Production does not currently record connection lifetimes or
handshake bytes, which are the two that would catch a NAT-mapping regression;
worth adding before this reaches a large share of nodes.

Full write-up and raw logs: `ugly_keepalive/REPORT.md`. Measurement harness:
[`experiment/keepalive-egress-harness`](https://github.com/WithAutonomi/saorsa-transport/tree/experiment/keepalive-egress-harness).

## New dependency

None.

## ADR

[ADR-012](https://github.com/WithAutonomi/saorsa-transport/blob/fix/keepalive-dial-accept-split/docs/adr/ADR-012-keep-alive-dial-accept-split.md)
(added here; after merge it lives at `docs/adr/` on `main`).

## Mitigation / rollback

Pin saorsa-transport to 0.36.0 and roll-restart. There is no configuration to
change, by design. Existing connections keep the transport config they were
created with, so a revert takes effect on reconnect; mixed versions interoperate,
so it need not be atomic.

If connection lifetimes show a mode near 30 s — the NAT-timeout signature —
shortening the interval is the lighter response. Note that 5 s dial-only is not
a return to the old behaviour: the previous effective cadence was the accepting
side's 2 s, so only reverting reproduces it exactly.
