### PR TITLE
fix(nat): give the accepting side a keep-alive backstop at 25 s

### DIFF
--- a/docs/adr/ADR-014-accept-side-keep-alive-backstop.md
+++ b/docs/adr/ADR-014-accept-side-keep-alive-backstop.md
@@ -1,0 +1,203 @@
+# ADR-014: Accept-Side Keep-Alive Backstop
+
+## Status
+
+Proposed
+
+Amends [ADR-012](ADR-012-keep-alive-dial-accept-split.md), which is otherwise
+unchanged: the dialling side still drives the cadence at 10 s and still supplies
+the traffic that refreshes NAT mappings.
+
+## Context
+
+ADR-012 moved keep-alives to the dialling side only and took idle egress down
+78% on a 990-node testnet. It also left the accepting side with no timer of any
+kind, and that turns out to cost more than the reasoning there allowed for.
+
+A QUIC connection closes silently once it has received nothing for
+`max_idle_timeout`, 30 s here. What a connection can absorb before that happens
+is not set by the loss *rate* — it is set by how long it can be totally silent.
+The interesting failure is therefore a short outage rather than a percentage of
+lost datagrams: a stretch where nothing arrives at all, which is what receive
+buffer saturation on a loaded node looks like from the far end.
+
+Measured against a recurring bidirectional outage, on a path with 40 ms RTT and
+1.5% background loss, three connections per outage length. The outage recurs
+every 90 s inside a 300 s window, so each connection meets it three times, and
+its phase relative to the keep-alive timers is not controlled — the connections
+in a group start together, so a group shares a phase and the thresholds below
+are the behaviour at the phases sampled rather than a worst case. Loss is a
+deterministic function of each socket's datagram ordinal, so the arms meet the
+same pattern.
+
+| Outage | both sides on a timer | dialling side only |
+|---:|---:|---:|
+| 13 s | 0/3 died | 0/3 died |
+| 15 s | 0/3 | 0/3 |
+| **17 s** | **0/3** | **3/3** |
+| 21 s | 0/3 | 3/3 |
+| 25 s | 0/3 | 3/3 |
+| 29 s | 3/3 | 3/3 |
+
+**The survivable outage fell from about 28 s to about 16 s** at the sampled
+phases. A stall between those two figures took the connection down where it
+previously rode through, at every length tested in that range. Two effects
+compound, and the second is the larger:
+
+1. With a 10 s cadence the connection is already about 5 s into its silence when
+   the outage begins, against about 1 s at ADR-012's effective 2 s baseline.
+2. **Recovery afterwards is slower.** Only the dialling side probes, and its
+   probe timer backs off exponentially, so the first packet after a stall can be
+   roughly 10 s late. With a timer on both sides the accepting side probes on
+   its own and its timer re-arms on every send, so it does not inherit that
+   backoff.
+
+Uniform loss does not appear to produce this at fleet rates: at 1.5% neither
+arrangement lost a connection across twenty idle windows, and losing every
+opportunity in a 30 s window works out on the order of 1 in 10^11. That is an
+estimate from the packet arithmetic rather than a measured bound, and it says
+nothing about correlated loss, which is what the outage model above stands in
+for.
+
+This also fits where the effect was seen. Brief total stalls are a load
+phenomenon — the fleet logged 61.5M receive-buffer overflow errors per hour
+under load against 2,115 when idle — and the connection-lifecycle change
+reported after ADR-012 shipped appeared only in the loaded phase.
+
+## Decision
+
+Give the accepting side a keep-alive again, as a backstop rather than a cadence:
+
+```rust
+// accepting side
+transport_config.keep_alive_interval(Some(ACCEPT_KEEP_ALIVE_BACKSTOP)); // 25 s
+// dialling side, unchanged from ADR-012
+transport_config.keep_alive_interval(Some(DIAL_KEEP_ALIVE_INTERVAL)); // 10 s
+```
+
+**It restores the margin across the range tested.** With the backstop,
+connections survived the 17 s, 21 s and 25 s outages that killed every
+connection without it, matching the pre-ADR-012 arrangement at every length
+sampled. At 29 s both arrangements lose connections, as expected against a 30 s
+idle timeout.
+
+**It is expected to add no measurable steady-state egress.** The keep-alive timer re-arms on
+every packet received as well as sent (`connection/mod.rs` on authenticated
+receive, `connection/packet_builder.rs` on send), and the dialling peer pings
+every 10 s, so on a healthy connection the backstop has no room to fire. That is
+asserted on a lossless loopback path by `tests/keep_alive_asymmetry.rs`, which
+requires the accepting side to emit no keep-alive across a 40 s idle window. It
+is not a proof for the fleet: the real gap between received packets is the
+cadence plus a round trip, and a degraded-but-live connection that loses pings
+can stretch it further. The expectation is that ADR-012's measured 78%
+idle-egress reduction survives essentially intact, and per-node idle egress
+after rollout is the number that confirms it.
+
+**Why 25 s.** The value is bounded from both directions.
+
+Below, by the cost: too low and it fires in ordinary operation. Restoring the
+outage margin does not need a small value — 5 s was measured alongside 25 s and
+behaved identically at every length — because what restores the margin is having
+a timer at all, not how often it runs. So the interval is free to sit well clear
+of the 10 s cadence, and should.
+
+Above, by two costs.
+
+The first is the timer service margin. `handle_timeout` services timers in
+`Timer::VALUES` order and `Idle` is ordered before `KeepAlive`, so if the
+connection driver is not polled for the gap between the two deadlines, the idle
+timeout is processed first and the connection closes without the backstop being
+sent. 5 s is the nominal difference between the constants and the most that gap
+can be; the real separation can be smaller, because sending re-arms the
+keep-alive timer while the idle timer is only re-armed by the first
+ack-eliciting send after a receive. Driver stalls are a load phenomenon and load
+is the condition this ADR is about, so the margin is worth stating plainly.
+
+The second is dead-peer retention. The backstop PING is ack-eliciting, so the
+first one sent after a peer goes quiet re-arms the idle timer, and a peer that
+disappears is retained for roughly the backstop plus the idle timeout — about
+55 s, against 30 s with no timer on this side and about 32 s under the 2 s
+arrangement that preceded ADR-012. Later probes do not extend it further, since
+only the first ack-eliciting send after a receive resets the idle timer. This is
+inherent to having a backstop at all, and a lower value would shorten it. It
+matters more than it otherwise would because `P2pConfig::max_connections` is not
+enforced at the QUIC accept layer, a pre-existing gap ADR-012 also noted.
+
+25 s therefore favours not reintroducing the idle-egress cost, which is the
+whole point of the arrangement it protects, and pays for that on the other two.
+If the fleet shows either — connections closing without the backstop under load,
+or dead-peer retention pressing on connection capacity — a lower value inside
+the measured range is the lighter response than removing the backstop.
+
+## Consequences
+
+**Idle egress is expected to be unchanged in steady state**, by the argument
+above and by `tests/keep_alive_asymmetry.rs`, which asserts the accepting side
+emits zero keep-alives across a 40 s idle window while the dialling peer pings.
+That test runs on a lossless loopback path, so it establishes the mechanism
+rather than the fleet result; per-node idle egress after rollout is what
+confirms it.
+
+**The accepting side takes RTT samples again** once the backstop fires, which
+ADR-012 noted it had stopped doing. That consequence is narrowed rather than
+removed: on a healthy connection the backstop does not fire, so the estimate
+still goes stale there. Measurement found no cost either way — after idling past
+the timeout, the accepting side's estimate read within a few milliseconds of the
+true path RTT, because a stale estimate on a stable path is a correct one.
+
+**No API or wire change.** The interval is a crate-private constant, and the
+cadence is a local choice that is never negotiated, so patched and un-upgraded
+nodes interoperate in both directions.
+
+**A disappeared peer is retained for longer**, roughly 55 s rather than 30 s,
+for the reason given under the interval choice above. On a node holding many
+mostly-idle connections this raises the steady-state count of connections whose
+peer is already gone.
+
+**Rollback is a dependency pin and a rolling restart**, as with ADR-012.
+Existing connections keep the transport config they were created with, so a
+revert takes effect on reconnect and need not be atomic.
+
+### Not validated here
+
+The measurements above come from an in-process harness with an injected one-way
+delay and drop pattern, not from a testnet, and that harness is not checked in
+here — it carries a dev-dependency and an impairment layer out of proportion to
+this change. Three limits follow.
+
+The harness had to be made trustworthy before any of its numbers were: applying
+the delay with one task per datagram reorders datagrams, and QUIC declares a
+packet lost once three later ones are acknowledged, so a first attempt
+manufactured roughly twelve times more loss than it injected and produced large
+but entirely artificial differences between the arms. Delivery is now strictly
+FIFO and every run reports declared losses over injected drops, which must read
+1.0. Any repeat of this measurement should report that ratio too.
+
+Sample size is three connections per outage length, at a single phase each, so
+the thresholds locate a step rather than measure a distribution. The step itself
+is unambiguous — 0/3 against 3/3, at three consecutive lengths, reproduced
+across two runs — but the exact boundary is bracketed, not pinned.
+
+What remains unmeasured is how often stalls long enough to matter — the tested
+lengths sat between about 16 s and about 28 s — actually occur on the fleet. This ADR shows the margin was lost and that the backstop restores
+it; it does not establish how often that margin was being called upon. Watch
+connection lifetimes and reconnect rate under load after rollout, which is the
+signal ADR-012 already asked for and production does not yet record.
+
+## Alternatives Considered
+
+**Leave it as ADR-012 shipped it.** Rejected. The lost margin is real and
+reproducible, and restoring it is expected to add no measurable egress.
+
+**A tighter backstop, 5 s.** Measured, and no better across the whole outage
+range. It gives up headroom against the dialling cadence for nothing.
+
+**Shorten the dialling interval instead.** Would narrow the first of the two
+effects and none of the second, since recovery would still wait on one side's
+backing-off probe timer, and it would give back a proportional share of the
+idle-egress saving.
+
+**Raise `max_idle_timeout`.** Would widen the survivable outage on both
+arrangements, but it is a different decision with its own cost — a silent peer
+pins resources for longer, which the backstop already adds to — and it does not
+address the asymmetry this ADR is about.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,6 +22,7 @@ ADRs document significant architectural decisions made in the project. Each reco
 | [ADR-010](ADR-010-repository-ownership.md) | Repository Ownership under WithAutonomi | Accepted | 2026-05-29 |
 | [ADR-011](ADR-011-stable-relay-port-reservations.md) | Stable Relay Port Reservations (Authenticated, Leased) | Proposed | 2026-06-24 |
 | [ADR-012](ADR-012-keep-alive-dial-accept-split.md) | Keep-Alive on the Dialling Side Only | Proposed | 2026-08-14 |
+| [ADR-014](ADR-014-accept-side-keep-alive-backstop.md) | Accept-Side Keep-Alive Backstop | Proposed | 2026-08-20 |
 
 ## ADR Template
 

--- a/src/config/nat_timeouts.rs
+++ b/src/config/nat_timeouts.rs
@@ -37,10 +37,11 @@ pub struct NatTraversalTimeouts {
 
 /// QUIC keep-alive interval for connections this node dials.
 ///
-/// Only the dialling side sends keep-alives. One side is enough: a keep-alive
-/// is ack-eliciting, so the peer answers it, both idle timers reset, and each
-/// side puts a packet on the wire once per interval — which is also what
-/// refreshes a NAT mapping for that five-tuple.
+/// The dialling side sets the cadence for the connection. A keep-alive is
+/// ack-eliciting, so the peer answers it, both idle timers reset, and each side
+/// puts a packet on the wire once per interval — which is also what refreshes a
+/// NAT mapping for that five-tuple. The accepting side carries only
+/// [`ACCEPT_KEEP_ALIVE_BACKSTOP`], which this cadence normally holds off.
 ///
 /// 10 s rather than the 5 s + 2 s pair it replaces. Because any traffic resets
 /// both timers, the old arrangement ran at whichever interval was shorter, so
@@ -54,6 +55,63 @@ pub struct NatTraversalTimeouts {
 /// can provoke the ACK that would have refreshed it. 10 s is deliberately below
 /// RFC 8085's 15 s floor for general-Internet keep-alives, for that reason.
 pub(crate) const DIAL_KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Longest the accepting side will stay silent on an otherwise idle connection.
+///
+/// The accepting side does not drive the cadence — the dialling peer's 10 s
+/// keep-alive does, and every packet received re-arms this timer, so on a
+/// healthy connection it has no room to fire. It exists to bound how long a
+/// connection can be silent when the peer stops being heard.
+///
+/// Without it the whole connection depends on one side. A QUIC connection
+/// closes silently after `QUIC_MAX_IDLE_TIMEOUT_MS` with nothing received, and
+/// with only the dialling side probing, a network stall is survivable for far
+/// less than that: the connection is already part-way into its silence when the
+/// stall begins, and afterwards recovery waits on the dialling side's probe
+/// timer, which backs off exponentially. Measured against a recurring outage on
+/// a harness, at the outage lengths sampled, the survivable stall was ~28 s with
+/// both sides on a timer and ~16 s with only the dialling side; restoring a
+/// timer here took it back to ~28 s across that range.
+///
+/// The value is bounded from both directions and 25 s sits between them.
+///
+/// Too low and it fires in ordinary operation and starts charging every idle
+/// connection. The real gap between received packets on a healthy connection is
+/// the dialling cadence plus a round trip, and more when a ping is lost and
+/// waits on a probe timer, so the floor is well above 10 s. Restoring the
+/// outage margin does not need a small value: 5 s was measured alongside 25 s
+/// and behaved identically, because what restores the margin is this side
+/// having a timer at all rather than how often it runs.
+///
+/// Too high and it costs twice over.
+///
+/// It crowds [`QUIC_MAX_IDLE_TIMEOUT_MS`]. `handle_timeout` services timers in
+/// `Timer::VALUES` order and `Idle` is ordered before `KeepAlive`, so if the
+/// connection driver is not polled for the gap between the two deadlines, the
+/// idle timeout is processed first and the connection closes without the
+/// backstop ever being sent. 5 s is the nominal difference between the two
+/// constants and the most that gap can be; the real separation can be smaller,
+/// because sending re-arms the keep-alive timer while the idle timer is only
+/// re-armed by the first ack-eliciting send after a receive. That is narrower
+/// slack than the arrangement this replaces and worth knowing, because driver
+/// stalls are a load phenomenon and load is what this change is about.
+///
+/// It also holds a dead peer for longer. The backstop PING is ack-eliciting, so
+/// the first one sent after the peer goes quiet re-arms the idle timer: a peer
+/// that disappears is retained for roughly the backstop plus the idle timeout,
+/// about 55 s, against 30 s with no timer on this side and about 32 s under the
+/// 2 s arrangement that preceded it. Subsequent probes do not extend it
+/// further, since only the first ack-eliciting send after a receive resets the
+/// idle timer. This is inherent to having a backstop at all and a lower value
+/// would shorten it.
+///
+/// 25 s therefore favours not reintroducing the idle-egress cost, which is the
+/// whole point of the arrangement it is protecting, and pays for that on the
+/// other two. If the fleet shows either — connections closing without the
+/// backstop under load, or dead-peer retention pressing on connection capacity
+/// — a lower value inside the measured range is the lighter response than
+/// removing the backstop.
+pub(crate) const ACCEPT_KEEP_ALIVE_BACKSTOP: Duration = Duration::from_secs(25);
 
 /// `max_idle_timeout` applied to every QUIC connection this crate creates.
 ///

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -1822,6 +1822,108 @@ pub enum NatTraversalError {
     },
 }
 
+/// Adapt an accepting-side transport config for a relay tunnel.
+///
+/// A relay tunnel needs a smaller MTU than a direct path, and nothing else
+/// about the connection changes. Kept separate from the call site so a test can
+/// assert that adapting it does not drop the accepting-side keep-alive: this is
+/// the second endpoint that accepts connections, and it would be an easy place
+/// to lose the backstop without anything on the direct path noticing.
+fn relay_tunnel_transport_config(base: &TransportConfig) -> TransportConfig {
+    let mut tunnel = base.clone();
+    tunnel.initial_mtu(RELAY_TUNNEL_INITIAL_MTU);
+    tunnel.min_mtu(RELAY_TUNNEL_INITIAL_MTU);
+    tunnel.mtu_discovery_config(Some(MtuDiscoveryConfig::default()));
+    tunnel
+}
+
+/// Which end of a connection a transport config is being built for.
+///
+/// The two ends differ in exactly one setting, the keep-alive, and sharing the
+/// rest is the point: it is what lets a test assert against the configuration
+/// the endpoint actually consumes rather than against a copy of it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ConnectionSide {
+    /// Connections this node opens.
+    Dial,
+    /// Connections this node accepts.
+    Accept,
+}
+
+/// Build the QUIC transport configuration for one end of a connection.
+///
+/// The two direct endpoint configuration sites use this as-is, so for those the
+/// value returned here is the value that reaches the wire. The relay tunnel
+/// endpoint is the exception: it takes the accepting config and adjusts MTU,
+/// via [`relay_tunnel_transport_config`].
+///
+/// Keeping one builder matters for more than tidiness. The accepting side's
+/// keep-alive is a backstop that the peer's traffic normally holds off, so on a
+/// healthy connection it looks exactly like having no keep-alive at all. Tests
+/// that watch a healthy connection therefore cannot tell a correctly wired
+/// endpoint from a reverted one, which is why the wiring is also asserted
+/// directly against the configs this produces.
+pub(crate) fn build_transport_config(
+    config: &NatTraversalConfig,
+    side: ConnectionSide,
+) -> TransportConfig {
+    use crate::config::nat_timeouts::{
+        ACCEPT_KEEP_ALIVE_BACKSTOP, DIAL_KEEP_ALIVE_INTERVAL, QUIC_MAX_IDLE_TIMEOUT_MS,
+    };
+
+    const INITIAL_CONGESTION_WINDOW: u64 = 1024 * 1024;
+
+    let mut transport_config = TransportConfig::default();
+    transport_config.enable_address_discovery(true);
+
+    // The dialling side sets the cadence for the connection. The accepting side
+    // carries only a backstop on how long it may stay silent: every packet it
+    // receives re-arms that timer and the peer normally pings well inside the
+    // interval, so it seldom fires. On a degraded-but-live path, where the gap
+    // between received packets grows past the interval, it can. It earns its place
+    // when the peer stops being heard, because with no timer on this side at
+    // all, recovery from a network stall waits on the dialling side's probe
+    // timer backing off, which costs most of the margin against
+    // `max_idle_timeout`.
+    let keep_alive = match side {
+        ConnectionSide::Dial => DIAL_KEEP_ALIVE_INTERVAL,
+        ConnectionSide::Accept => ACCEPT_KEEP_ALIVE_BACKSTOP,
+    };
+    transport_config.keep_alive_interval(Some(keep_alive));
+    transport_config.max_idle_timeout(Some(
+        crate::VarInt::from_u32(QUIC_MAX_IDLE_TIMEOUT_MS).into(),
+    ));
+
+    // Tune QUIC flow-control windows from max_message_size
+    let window = varint_from_max_message_size(config.max_message_size);
+    transport_config.stream_receive_window(window);
+    transport_config.send_window(config.max_message_size as u64);
+
+    // Raise the initial congestion window from the default 14 KB to 1 MB. The
+    // default is too small for relay-tunnelled connections (~200-400 ms RTT →
+    // ~50 KB/s), but using the full max_message_size (10 MB) is too aggressive
+    // — it causes a burst that overflows the receiver's kernel UDP buffer
+    // (208 KB on Linux). 1 MB balances fast starts (4 MB chunk completes in
+    // ~2 RTTs through slow-start) with pacing that receivers can absorb.
+    // Uploads originate from client configs, so the dialling side needs the
+    // same bound rather than max_message_size.
+    transport_config.congestion_controller_factory(build_congestion_factory(
+        config.congestion_algorithm,
+        INITIAL_CONGESTION_WINDOW,
+        transport_config.initial_rtt,
+    ));
+
+    // v0.13.0+: All nodes use ServerSupport for full P2P capabilities
+    // Per draft-seemann-quic-nat-traversal-02, all nodes can coordinate
+    let nat_config = crate::transport_parameters::NatTraversalConfig::ServerSupport {
+        concurrency_limit: VarInt::from_u32(config.max_concurrent_attempts as u32),
+    };
+    transport_config.nat_traversal_config(Some(nat_config));
+    transport_config.allow_loopback(config.allow_loopback);
+
+    transport_config
+}
+
 impl Default for NatTraversalConfig {
     fn default() -> Self {
         Self {
@@ -3409,8 +3511,6 @@ impl NatTraversalEndpoint {
     > {
         use std::sync::Arc;
 
-        const INITIAL_CONGESTION_WINDOW: u64 = 1024 * 1024;
-
         // v0.13.0+: All nodes are symmetric P2P nodes - always create server config
         let server_config = {
             info!("Creating server config using Raw Public Keys (RFC 7250) for symmetric P2P node");
@@ -3455,47 +3555,9 @@ impl NatTraversalEndpoint {
 
             let mut server_config = ServerConfig::with_crypto(Arc::new(server_crypto));
 
-            // Configure transport parameters for NAT traversal
-            let mut transport_config = TransportConfig::default();
-            transport_config.enable_address_discovery(true);
-            // Accepting side: no keep-alive. Only one side of a connection needs
-            // one — a keep-alive is ack-eliciting, so the peer answers it and
-            // both idle timers reset — and the dialling peer supplies it. This
-            // used to be `retry_interval`, which is the NAT *retry* cadence and
-            // an unrelated concern that happens to live in the same struct.
-            transport_config.keep_alive_interval(None);
-            transport_config.max_idle_timeout(Some(
-                crate::VarInt::from_u32(crate::config::nat_timeouts::QUIC_MAX_IDLE_TIMEOUT_MS)
-                    .into(),
-            ));
-
-            // Tune QUIC flow-control windows from max_message_size
-            let window = varint_from_max_message_size(config.max_message_size);
-            transport_config.stream_receive_window(window);
-            transport_config.send_window(config.max_message_size as u64);
-
-            // Raise the initial congestion window from the default 14 KB
-            // to 1 MB.  The default is too small for relay-tunnelled
-            // connections (~200-400 ms RTT → ~50 KB/s), but using the
-            // full max_message_size (10 MB) is too aggressive — it causes
-            // a burst that overflows the receiver's kernel UDP buffer
-            // (208 KB on Linux).  1 MB balances fast starts (4 MB chunk
-            // completes in ~2 RTTs through slow-start) with pacing that
-            // receivers can absorb.
-            transport_config.congestion_controller_factory(build_congestion_factory(
-                config.congestion_algorithm,
-                INITIAL_CONGESTION_WINDOW,
-                transport_config.initial_rtt,
-            ));
-
-            // v0.13.0+: All nodes use ServerSupport for full P2P capabilities
-            // Per draft-seemann-quic-nat-traversal-02, all nodes can coordinate
-            let nat_config = crate::transport_parameters::NatTraversalConfig::ServerSupport {
-                concurrency_limit: VarInt::from_u32(config.max_concurrent_attempts as u32),
-            };
-            transport_config.nat_traversal_config(Some(nat_config));
-            transport_config.allow_loopback(config.allow_loopback);
-
+            // Used as-is, so this endpoint consumes exactly the configuration
+            // the unit tests assert against.
+            let transport_config = build_transport_config(config, ConnectionSide::Accept);
             server_config.transport_config(Arc::new(transport_config));
 
             Some(server_config)
@@ -3549,43 +3611,9 @@ impl NatTraversalEndpoint {
             }
 
             // Configure transport parameters for NAT traversal
-            let mut transport_config = TransportConfig::default();
-            transport_config.enable_address_discovery(true);
-            // Dialling side: the only keep-alive on the connection. The peer's
-            // ACK is an outbound packet there too, so both directions put a
-            // packet on the wire roughly once per interval — roughly, because
-            // the timer re-arms on receive as well as send, so each cycle drifts
-            // out by about a round trip.
-            transport_config
-                .keep_alive_interval(Some(crate::config::nat_timeouts::DIAL_KEEP_ALIVE_INTERVAL));
-            transport_config.max_idle_timeout(Some(
-                crate::VarInt::from_u32(crate::config::nat_timeouts::QUIC_MAX_IDLE_TIMEOUT_MS)
-                    .into(),
-            ));
-
-            // Tune QUIC flow-control windows from max_message_size
-            let window = varint_from_max_message_size(config.max_message_size);
-            transport_config.stream_receive_window(window);
-            transport_config.send_window(config.max_message_size as u64);
-
-            // Keep client and server sends on the same bounded startup
-            // window. Uploads originate from client configs, so using
-            // max_message_size here recreates the burst/loss problem that
-            // the server config above avoids.
-            transport_config.congestion_controller_factory(build_congestion_factory(
-                config.congestion_algorithm,
-                INITIAL_CONGESTION_WINDOW,
-                transport_config.initial_rtt,
-            ));
-
-            // v0.13.0+: All nodes use ServerSupport for full P2P capabilities
-            // Per draft-seemann-quic-nat-traversal-02, all nodes can coordinate
-            let nat_config = crate::transport_parameters::NatTraversalConfig::ServerSupport {
-                concurrency_limit: VarInt::from_u32(config.max_concurrent_attempts as u32),
-            };
-            transport_config.nat_traversal_config(Some(nat_config));
-            transport_config.allow_loopback(config.allow_loopback);
-
+            // Used as-is, so this endpoint consumes exactly the configuration
+            // the unit tests assert against.
+            let transport_config = build_transport_config(config, ConnectionSide::Dial);
             client_config.transport_config(Arc::new(transport_config));
 
             client_config
@@ -3641,12 +3669,17 @@ impl NatTraversalEndpoint {
             NatTraversalError::ConfigError("No compatible async runtime found".to_string())
         })?;
 
-        // Clone server config for potential secondary endpoint (relay accept)
-        let server_config_for_relay = server_config.clone();
+        // One authoritative server config: the endpoint is built from a clone
+        // of the value that is also returned, rather than the return being a
+        // clone taken beforehand. The returned config is what the relay accept
+        // path reuses and what the tests assert against, so it has to be the
+        // same object the endpoint runs on — otherwise anything applied between
+        // the two is invisible to both.
+        let server_config_for_relay = server_config;
 
         let mut endpoint = InnerEndpoint::new(
             EndpointConfig::default(),
-            server_config,
+            server_config_for_relay.clone(),
             std_socket,
             runtime,
         )
@@ -5631,17 +5664,13 @@ impl NatTraversalEndpoint {
             .map_err(|_| NatTraversalError::ConfigError("mutex poisoned".to_string()))?
             .clone();
 
-        // Override the inner endpoint's TransportConfig with a
-        // relay-tunnel-safe MTU profile while preserving every other
-        // setting the main endpoint cares about (NAT traversal,
-        // congestion control, idle timeouts, flow control).  We clone
-        // the existing transport config, clamp MTU, and re-attach.
+        // This is the second endpoint that accepts connections, so it needs
+        // the same keep-alive as the first. It derives from the main endpoint's
+        // server config and adjusts only MTU; `relay_tunnel_transport_config`
+        // is that adjustment, kept as one function so a test can check what
+        // comes out of it still carries the accepting-side backstop.
         let server_config = server_config.map(|mut sc| {
-            let mut tunnel_tc = (*sc.transport).clone();
-            tunnel_tc.initial_mtu(RELAY_TUNNEL_INITIAL_MTU);
-            tunnel_tc.min_mtu(RELAY_TUNNEL_INITIAL_MTU);
-            tunnel_tc.mtu_discovery_config(Some(MtuDiscoveryConfig::default()));
-            sc.transport = Arc::new(tunnel_tc);
+            sc.transport = Arc::new(relay_tunnel_transport_config(&sc.transport));
             sc
         });
 
@@ -8416,6 +8445,159 @@ impl crate::TokenStore for DefaultTokenStore {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
+
+    use super::{ConnectionSide, NatTraversalConfig, build_transport_config};
+    use crate::config::nat_timeouts::{
+        ACCEPT_KEEP_ALIVE_BACKSTOP, DIAL_KEEP_ALIVE_INTERVAL, QUIC_MAX_IDLE_TIMEOUT_MS,
+    };
+    use std::time::Duration as StdDuration;
+
+    /// Pins what each end is actually wired to.
+    ///
+    /// Watching a healthy connection cannot tell "the accepting side has a
+    /// backstop the peer holds off" from "the accepting side has no keep-alive
+    /// at all", because those are the same observation. Asserting on the
+    /// configuration is one way to make a silent revert fail; making the peer
+    /// go quiet is the other, and
+    /// `a_production_endpoint_holds_a_connection_open_for_a_silent_peer` in
+    /// `tests/keep_alive_asymmetry.rs` does that. It lives out there because it
+    /// has to idle past `max_idle_timeout`, which is far too long for the
+    /// library suite's quick-check budget.
+    ///
+    /// Literals rather than a comparison against the constants, so that moving
+    /// a constant fails here instead of quietly moving what is asserted.
+    #[test]
+    fn each_side_is_wired_to_its_own_keep_alive() {
+        let config = NatTraversalConfig::default();
+
+        let accept = build_transport_config(&config, ConnectionSide::Accept);
+        assert_eq!(
+            accept.keep_alive_interval,
+            Some(StdDuration::from_secs(25)),
+            "the accepting side must carry the 25 s backstop; without it, stalls \
+             at the 17-25 s lengths measured on the harness took connections down"
+        );
+
+        let dial = build_transport_config(&config, ConnectionSide::Dial);
+        assert_eq!(
+            dial.keep_alive_interval,
+            Some(StdDuration::from_secs(10)),
+            "the dialling side sets the cadence and must stay at 10 s"
+        );
+
+        let expected_idle = Some(crate::VarInt::from_u32(30_000));
+        assert_eq!(accept.max_idle_timeout, expected_idle);
+        assert_eq!(dial.max_idle_timeout, expected_idle);
+    }
+
+    /// The constants the wiring above reads, and the two bounds the backstop
+    /// sits between.
+    #[test]
+    fn the_backstop_sits_between_the_cadence_and_the_idle_timeout() {
+        assert_eq!(DIAL_KEEP_ALIVE_INTERVAL, StdDuration::from_secs(10));
+        assert_eq!(ACCEPT_KEEP_ALIVE_BACKSTOP, StdDuration::from_secs(25));
+        assert!(
+            ACCEPT_KEEP_ALIVE_BACKSTOP > DIAL_KEEP_ALIVE_INTERVAL,
+            "a backstop at or below the dialling cadence fires in ordinary \
+             operation and charges every idle connection"
+        );
+        let idle = StdDuration::from_millis(u64::from(QUIC_MAX_IDLE_TIMEOUT_MS));
+        assert!(
+            ACCEPT_KEEP_ALIVE_BACKSTOP < idle,
+            "a backstop at or past the idle timeout can never bound anything"
+        );
+    }
+
+    /// What the endpoint actually built, read back from the `ServerConfig` it
+    /// returns rather than from the builder.
+    ///
+    /// The builder assertions above do not cover a call site that takes the
+    /// built config and overrides it afterwards, which is a live way to revert
+    /// this change without failing anything. This is the assertion that closes
+    /// it, because it reads the configuration on its way out of the endpoint
+    /// constructor.
+    ///
+    /// Only the accepting side needs this. The dialling side's cadence is
+    /// visible on the wire and `tests/keep_alive_asymmetry.rs` already pins it
+    /// by counting and spacing its PINGs; the accepting side's backstop is
+    /// silent on a healthy connection and so has no wire signature to check.
+    #[tokio::test]
+    async fn the_endpoint_builds_the_accept_side_with_the_backstop() {
+        let config = NatTraversalConfig {
+            bind_addr: Some((std::net::Ipv4Addr::LOCALHOST, 0).into()),
+            allow_loopback: true,
+            ..NatTraversalConfig::default()
+        };
+        let registry = crate::transport::TransportRegistry::new();
+
+        let (_endpoint, _tx, _rx, _addr, server_config) =
+            super::NatTraversalEndpoint::create_inner_endpoint(&config, None, &registry, None)
+                .await
+                .expect("endpoint construction");
+
+        let server_config = server_config.expect("every node accepts connections");
+        assert_eq!(
+            server_config.transport.keep_alive_interval,
+            Some(StdDuration::from_secs(25)),
+            "the endpoint handed the accepting side a keep-alive other than the \
+             25 s backstop; without it, stalls at the 17-25 s lengths measured \
+             on the harness took connections down"
+        );
+        assert_eq!(
+            server_config.transport.max_idle_timeout,
+            Some(crate::VarInt::from_u32(30_000))
+        );
+    }
+
+    /// The relay tunnel is the other endpoint that accepts connections, and it
+    /// must carry the backstop too.
+    ///
+    /// It derives from the accepting config and changes MTU. Losing the
+    /// keep-alive here would be invisible to everything on the direct path,
+    /// and a connection arriving through a relay is exactly the kind that sits
+    /// behind a loaded middlebox, so it is the last one that should be left
+    /// depending on its peer alone.
+    ///
+    /// This is config-level coverage, not behavioural: exercising the real
+    /// relay path needs a MASQUE tunnel stood up, which is out of proportion
+    /// here. It catches the realistic regression — someone editing this
+    /// adaptation — rather than a deliberate override downstream of it.
+    #[test]
+    fn the_relay_tunnel_endpoint_keeps_the_accept_side_backstop() {
+        let config = NatTraversalConfig::default();
+        let accept = build_transport_config(&config, ConnectionSide::Accept);
+        let tunnel = super::relay_tunnel_transport_config(&accept);
+
+        assert_eq!(
+            tunnel.keep_alive_interval,
+            Some(StdDuration::from_secs(25)),
+            "the relay tunnel endpoint accepts connections and must keep the \
+             backstop; adapting the MTU must not drop it"
+        );
+        assert_eq!(tunnel.max_idle_timeout, accept.max_idle_timeout);
+        assert_ne!(
+            tunnel.get_initial_mtu(),
+            accept.get_initial_mtu(),
+            "the adaptation is supposed to change the MTU, so a test that saw \
+             no difference would be asserting against the wrong thing"
+        );
+    }
+
+    /// Everything other than the keep-alive must be identical on both ends.
+    /// The two sites were duplicated before; this is what keeps them from
+    /// drifting apart again.
+    #[test]
+    fn the_two_sides_differ_only_in_their_keep_alive() {
+        let config = NatTraversalConfig::default();
+        let accept = build_transport_config(&config, ConnectionSide::Accept);
+        let dial = build_transport_config(&config, ConnectionSide::Dial);
+
+        assert_eq!(accept.send_window, dial.send_window);
+        assert_eq!(accept.stream_receive_window, dial.stream_receive_window);
+        assert_eq!(accept.max_idle_timeout, dial.max_idle_timeout);
+        assert_ne!(accept.keep_alive_interval, dial.keep_alive_interval);
+    }
+
     use super::*;
 
     async fn detached_proactive_relay(public_addr: SocketAddr) -> ProactiveRelay {

--- a/tests/keep_alive_asymmetry.rs
+++ b/tests/keep_alive_asymmetry.rs
@@ -5,13 +5,28 @@
 //
 // Full details available at https://saorsalabs.com/licenses
 
-//! Only the dialling side keep-alives, and that is enough to hold a connection.
+//! The dialling side drives the cadence, and the accepting side's backstop
+//! stays silent while it does.
 //!
 //! Two in-process endpoints are connected and left idle for longer than the
 //! 30 s `max_idle_timeout`. Everything is read from the dialling side's
 //! `ConnectionStats`, which sees both halves of the question: `frame_tx.ping`
 //! is what this node sent and `frame_rx.ping` is what the peer sent, so the
 //! accepting side's silence is observed on the wire rather than inferred.
+//!
+//! The accepting side does carry a keep-alive, but only as a backstop on how
+//! long it may stay silent, and every packet it receives re-arms that timer.
+//! The dialling peer pings well inside the interval, so on this path the
+//! backstop stays silent — which is what `frame_rx.ping` being zero here
+//! demonstrates. That is the cost argument for the backstop, so this assertion
+//! is load-bearing: if it starts counting here, the mechanism relied on to keep
+//! the backstop cheap is not working.
+//!
+//! It is one connection on a lossless, sub-millisecond-RTT path, so it
+//! establishes the mechanism and not the fleet result. A real connection sees
+//! the cadence plus a round trip between received packets, and more when a ping
+//! is lost, so the backstop can legitimately fire on a degraded-but-live path.
+//! Per-node idle egress after rollout is what shows the steady-state cost.
 //!
 //! `frame_tx.ping` is not a keep-alive counter in general — it also counts
 //! DPLPMTUD probes, PTO probes and path validation. None of those should fire
@@ -26,8 +41,14 @@
 
 #![allow(clippy::expect_used)]
 
-use saorsa_transport::{NatConfig, P2pConfig, P2pEndpoint, PqcConfig};
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use saorsa_transport::config::{ClientConfig, ServerConfig, TransportConfig};
+use saorsa_transport::crypto::raw_public_keys::{RawPublicKeyConfigBuilder, key_utils};
+use saorsa_transport::crypto::rustls::QuicClientConfig;
+use saorsa_transport::high_level::Endpoint;
+use saorsa_transport::{NatConfig, P2pConfig, P2pEndpoint, PqcConfig, VarInt};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
 use std::time::Duration;
 
 /// The cadence and idle timeout the transport is expected to use. Written as
@@ -35,6 +56,17 @@ use std::time::Duration;
 /// fails this test instead of silently moving what it asserts.
 const EXPECTED_KEEP_ALIVE: Duration = Duration::from_secs(10);
 const EXPECTED_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+const EXPECTED_ACCEPT_BACKSTOP: Duration = Duration::from_secs(25);
+
+const _: () = assert!(
+    EXPECTED_ACCEPT_BACKSTOP.as_millis() > EXPECTED_KEEP_ALIVE.as_millis(),
+    "the backstop must sit clear of the dialling cadence or it fires in \
+     ordinary operation and the saving goes with it"
+);
+const _: () = assert!(
+    EXPECTED_ACCEPT_BACKSTOP.as_millis() < EXPECTED_IDLE_TIMEOUT.as_millis(),
+    "a backstop at or past the idle timeout cannot bound anything"
+);
 
 /// Long enough for the handshake, PQC key exchange, address discovery and the
 /// MTU search to finish, so none of them lands inside the window.
@@ -64,7 +96,7 @@ fn config(known_peers: Vec<SocketAddr>) -> P2pConfig {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn only_the_dialling_side_keep_alives_and_the_connection_survives() {
+async fn the_accept_side_backstop_stays_silent_while_the_dialler_pings() {
     let accepter = P2pEndpoint::new(config(vec![]))
         .await
         .expect("accepter endpoint");
@@ -92,20 +124,34 @@ async fn only_the_dialling_side_keep_alives_and_the_connection_survives() {
     let (sent_before, received_before, acks_before) = counters().await;
 
     // Sample across the window so the PINGs can be timed, not just counted.
+    // Each entry is (when the sampler saw the change, how many PINGs it covered).
+    // A pass covering more than one cannot time them apart, so those are kept
+    // and skipped rather than scored as arriving simultaneously.
+    // (when the sampler saw the change, how many PINGs it covered, whether the
+    // sampler was on schedule when it did).
+    const POLL: Duration = Duration::from_millis(250);
+    const LATE: Duration = Duration::from_secs(1);
     let started = tokio::time::Instant::now();
-    let mut ping_times = Vec::new();
+    let mut observations: Vec<(Duration, u64, bool)> = Vec::new();
     let mut seen = sent_before;
+    let mut last_poll = tokio::time::Instant::now();
     while started.elapsed() < IDLE_WINDOW {
-        tokio::time::sleep(Duration::from_millis(250)).await;
+        tokio::time::sleep(POLL).await;
+        // Both the timestamp and the on-schedule verdict are taken after the
+        // counter read, because that read is itself an await that can stall.
         let (sent_now, _, _) = counters().await;
-        for _ in seen..sent_now {
-            ping_times.push(started.elapsed());
+        let now = tokio::time::Instant::now();
+        let on_schedule = now.duration_since(last_poll) < POLL + LATE;
+        last_poll = now;
+        if sent_now > seen {
+            observations.push((started.elapsed(), sent_now - seen, on_schedule));
+            seen = sent_now;
         }
-        seen = sent_now;
     }
     let (sent_after, received_after, acks_after) = counters().await;
-    for _ in seen..sent_after {
-        ping_times.push(started.elapsed());
+    if sent_after > seen {
+        let on_schedule = tokio::time::Instant::now().duration_since(last_poll) < POLL + LATE;
+        observations.push((started.elapsed(), sent_after - seen, on_schedule));
     }
 
     let pings_sent = sent_after - sent_before;
@@ -115,7 +161,10 @@ async fn only_the_dialling_side_keep_alives_and_the_connection_survives() {
 
     assert_eq!(
         pings_received, 0,
-        "the accepting side must send no keep-alive of its own: {report}"
+        "the accepting side's {EXPECTED_ACCEPT_BACKSTOP:?} backstop must not fire while \
+         the dialling peer is pinging every {EXPECTED_KEEP_ALIVE:?} on a lossless path — \
+         every packet it receives re-arms it, so firing here means the mechanism that \
+         keeps the backstop cheap is not working: {report}"
     );
     assert!(
         acks_received > 0,
@@ -132,9 +181,10 @@ async fn only_the_dialling_side_keep_alives_and_the_connection_survives() {
          {EXPECTED_KEEP_ALIVE:?} cadence: {report}"
     );
     assert_eq!(
-        ping_times.len() as u64,
+        observations.iter().map(|(_, count, _)| count).sum::<u64>(),
         pings_sent,
-        "every counted PING must be timed, or the spacing check below skips it"
+        "every counted PING must be accounted for, or the spacing check below \
+         is looking at a different population"
     );
 
     // Counting alone would let an unrelated PING — an MTU or PTO probe — stand
@@ -142,12 +192,22 @@ async fn only_the_dialling_side_keep_alives_and_the_connection_survives() {
     // traffic rather than arriving on a cadence. So require the gaps to be at
     // least half the interval.
     //
-    // Deliberately one-sided: these timestamps are when the sampler *observed*
-    // a counter change, so a busy machine can only stretch a gap, never shrink
-    // one. An upper bound would flake; a lower bound cannot.
+    // Deliberately one-sided: an upper bound would flake outright. A lower
+    // bound is not unconditionally safe either, though — a sampler that runs
+    // late stamps a PING after the fact, which shortens the *next* apparent
+    // gap. So a pair is only scored when both of its observations covered
+    // exactly one PING and both were taken on schedule; anything else makes
+    // the interval unobservable rather than short.
     let minimum_gap = EXPECTED_KEEP_ALIVE / 2;
-    for pair in ping_times.windows(2) {
-        if let [earlier, later] = pair {
+    let mut scored_gaps = 0u32;
+    let mut scored_gaps_skipped = 0u32;
+    for pair in observations.windows(2) {
+        if let [(earlier, before, early_ok), (later, count, late_ok)] = pair {
+            if *before != 1 || *count != 1 || !*early_ok || !*late_ok {
+                scored_gaps_skipped += 1;
+                continue;
+            }
+            scored_gaps += 1;
             let gap = later.saturating_sub(*earlier);
             assert!(
                 gap >= minimum_gap,
@@ -158,16 +218,27 @@ async fn only_the_dialling_side_keep_alives_and_the_connection_survives() {
         }
     }
 
+    // A window where every pair was batched would pass the spacing check by
+    // scoring nothing at all, so say so rather than reporting a silent pass.
+    assert!(
+        scored_gaps > 0,
+        "no PING pair was observed cleanly enough to time ({scored_gaps_skipped} \
+         pairs skipped as batched or late-sampled); the spacing check proved nothing"
+    );
+
     // `close_reason()` would only say the local driver has not processed a close
     // yet, so instead require the far side to still be answering. This shows the
     // peer is alive and reachable; it is not proof that this particular payload
     // was delivered, since ACK counters do not identify what they acknowledge.
+    // Snapshot before the send. Taking it afterwards can miss the payload's own
+    // ACK on a fast path, leaving the loop waiting on the next keep-alive
+    // instead — a deadline the cadence only just covers.
+    let acks_at_send = counters().await.2;
     dialer
         .send(&peer, b"post-idle liveness probe")
         .await
         .expect("an idle-but-alive connection must still accept a send");
     let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
-    let acks_at_send = counters().await.2;
     loop {
         if counters().await.2 > acks_at_send {
             break;
@@ -181,4 +252,181 @@ async fn only_the_dialling_side_keep_alives_and_the_connection_survives() {
 
     let _ = tokio::time::timeout(Duration::from_secs(3), dialer.shutdown()).await;
     let _ = tokio::time::timeout(Duration::from_secs(3), accepter.shutdown()).await;
+}
+
+/// The case the backstop exists for: a peer that stops being heard.
+///
+/// The test above shows the backstop staying out of the way. This one shows it
+/// doing its job. The dialling side is configured with no keep-alive at all, so
+/// nothing but the backstop can hold the connection open, and the connection
+/// outliving `max_idle_timeout` is only possible if the accepting side probes on
+/// its own.
+///
+/// This goes through the low-level endpoint rather than `P2pEndpoint`, because
+/// the cadences are crate-private constants with no configuration surface — a
+/// silent dialler is not something the public API can express. What it locks
+/// down is the property the accepting side's constant is chosen for: that one
+/// side's timer is enough to carry a connection whose peer has gone quiet, and
+/// that it does so at the expected interval rather than by accident.
+#[tokio::test(flavor = "multi_thread")]
+async fn the_accept_side_backstop_carries_a_connection_whose_peer_is_silent() {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+    let cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
+        .expect("self-signed certificate");
+    let chain = vec![CertificateDer::from(cert.cert)];
+    let key = PrivateKeyDer::Pkcs8(cert.signing_key.serialize_der().into());
+
+    let mut accept_transport = TransportConfig::default();
+    accept_transport.keep_alive_interval(Some(EXPECTED_ACCEPT_BACKSTOP));
+    accept_transport.max_idle_timeout(Some(
+        VarInt::from_u32(
+            u32::try_from(EXPECTED_IDLE_TIMEOUT.as_millis()).expect("idle timeout fits in u32"),
+        )
+        .into(),
+    ));
+    let mut server_config =
+        ServerConfig::with_single_cert(chain.clone(), key).expect("server config");
+    server_config.transport_config(Arc::new(accept_transport));
+
+    let server =
+        Endpoint::server(server_config, (Ipv4Addr::LOCALHOST, 0).into()).expect("server endpoint");
+    let peer = server.local_addr().expect("server address");
+    tokio::spawn(async move {
+        // Hold whatever is accepted: without a live handle the connection is
+        // torn down and this would measure teardown, not the backstop.
+        let mut held = Vec::new();
+        while let Some(incoming) = server.accept().await {
+            if let Ok(conn) = incoming.await {
+                held.push(conn);
+            }
+        }
+        drop(held);
+    });
+
+    let mut roots = rustls::RootCertStore::empty();
+    for c in chain {
+        roots.add(c).expect("trust the test certificate");
+    }
+    // No keep-alive on the dialling side, so the backstop is the only thing
+    // that can hold this connection open.
+    let mut dial_transport = TransportConfig::default();
+    dial_transport.keep_alive_interval(None);
+    dial_transport.max_idle_timeout(Some(
+        VarInt::from_u32(
+            u32::try_from(EXPECTED_IDLE_TIMEOUT.as_millis()).expect("idle timeout fits in u32"),
+        )
+        .into(),
+    ));
+    let mut client_config =
+        ClientConfig::with_root_certificates(Arc::new(roots)).expect("client config");
+    client_config.transport_config(Arc::new(dial_transport));
+
+    let mut client = Endpoint::client((Ipv4Addr::LOCALHOST, 0).into()).expect("client endpoint");
+    client.set_default_client_config(client_config);
+    let conn = tokio::time::timeout(
+        Duration::from_secs(20),
+        client.connect(peer, "localhost").expect("start connect"),
+    )
+    .await
+    .expect("connect did not time out")
+    .expect("connect succeeded");
+
+    tokio::time::sleep(SETTLE).await;
+    let received_before = conn.stats().frame_rx.ping;
+    tokio::time::sleep(IDLE_WINDOW).await;
+    let received = conn.stats().frame_rx.ping - received_before;
+
+    assert!(
+        conn.close_reason().is_none(),
+        "the connection died inside {IDLE_WINDOW:?} with only the accepting side's \
+         {EXPECTED_ACCEPT_BACKSTOP:?} backstop holding it open: {:?}",
+        conn.close_reason()
+    );
+    // A 40 s window at a 25 s backstop holds one or two, depending on where the
+    // window opens relative to the timer. Zero means it never fired and the
+    // connection survived for some other reason, which this test cannot claim.
+    let most = IDLE_WINDOW
+        .as_secs()
+        .div_ceil(EXPECTED_ACCEPT_BACKSTOP.as_secs());
+    assert!(
+        (1..=most).contains(&received),
+        "expected 1 to {most} backstop keep-alives from the accepting side over \
+         {IDLE_WINDOW:?} at a {EXPECTED_ACCEPT_BACKSTOP:?} interval, saw {received}"
+    );
+}
+
+/// The test that watching a healthy connection cannot substitute for.
+///
+/// The two tests above use hand-built endpoints, and the crate's unit tests
+/// assert what the production builder and endpoint constructor produce. None of
+/// that covers a configuration mutated on its way to the endpoint, because they
+/// all read a value rather than watch behaviour.
+///
+/// This watches behaviour, through the production path: the acceptor is a real
+/// `P2pEndpoint`, wired by the same constructor the fleet uses, and the dialler
+/// is built here with no keep-alive at all so that nothing but the accepting
+/// side's backstop can hold the connection open. It has to reach past the
+/// public API for the dialler because production has no way to express a silent
+/// one — that is the whole point of the arrangement under test.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_production_endpoint_holds_a_connection_open_for_a_silent_peer() {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+    let acceptor = P2pEndpoint::new(config(vec![]))
+        .await
+        .expect("production acceptor");
+    let peer = acceptor.local_addr().expect("acceptor address");
+
+    let (public_key, secret_key) = key_utils::generate_ml_dsa_keypair().expect("ML-DSA-65 keypair");
+    let rpk = RawPublicKeyConfigBuilder::new()
+        .with_client_key(public_key, secret_key)
+        .allow_any_key()
+        .with_pqc(PqcConfig::default())
+        .build_rfc7250_client_config()
+        .expect("RFC 7250 client config");
+    let crypto = QuicClientConfig::try_from(rpk.inner().as_ref().clone()).expect("client crypto");
+
+    let mut transport = TransportConfig::default();
+    // Production enables this on both ends, and the acceptor sends an
+    // ObservedAddress frame; a dialler without it kills the connection as a
+    // protocol violation before the backstop is ever tested.
+    transport.enable_address_discovery(true);
+    transport.keep_alive_interval(None);
+    transport.max_idle_timeout(Some(
+        VarInt::from_u32(
+            u32::try_from(EXPECTED_IDLE_TIMEOUT.as_millis()).expect("idle timeout fits in u32"),
+        )
+        .into(),
+    ));
+    let mut client_config = ClientConfig::new(Arc::new(crypto));
+    client_config.transport_config(Arc::new(transport));
+
+    let mut dialler = Endpoint::client((Ipv4Addr::LOCALHOST, 0).into()).expect("dialler endpoint");
+    dialler.set_default_client_config(client_config);
+
+    let connection = tokio::time::timeout(
+        Duration::from_secs(30),
+        dialler.connect(peer, "localhost").expect("start connect"),
+    )
+    .await
+    .expect("connect did not time out")
+    .expect("connect succeeded");
+
+    tokio::time::sleep(IDLE_WINDOW).await;
+
+    let pings_from_acceptor = connection.stats().frame_rx.ping;
+    assert!(
+        connection.close_reason().is_none(),
+        "the connection closed inside {IDLE_WINDOW:?} while this side sent nothing, so the \
+         production endpoint is not sending its {EXPECTED_ACCEPT_BACKSTOP:?} backstop: {:?}",
+        connection.close_reason()
+    );
+    assert!(
+        pings_from_acceptor > 0,
+        "the connection survived without a single keep-alive arriving, so something \
+         other than the backstop kept it open and this proves nothing"
+    );
+
+    let _ = tokio::time::timeout(Duration::from_secs(3), acceptor.shutdown()).await;
 }


### PR DESCRIPTION
## Linear issue

[V2-1030](https://linear.app/autonominetwork/issue/V2-1030/bound-accept-side-keep-alive-silence-while-keeping-the-idle-egress)

## Risk tier

- [ ] T0 — docs / tooling / CI / pure UX-output. Repo CI only.
- [ ] T1 — client-only, no network-facing behavior change. CI + prod compat smoke.
- [x] T2 — node/client logic with behavioral surface, no protocol/format/economics change. Dev testnet + ADR.
- [ ] T3 — protocol / storage format / payments / routing. T2 evidence + adversarial testing.

## Compatibility

- Wire: none
- Storage: none
- API: none

**Wire.** No frame or transport-parameter change. Keep-alive cadence is a local
choice and never negotiated, so patched and un-upgraded nodes interoperate in
both directions.

**API.** No public type or signature changes. The interval is a crate-private
constant.

## Semver impact

- [ ] breaking
- [ ] feature
- [x] fix

## Test evidence

**What this fixes.** #137 left the accepting side with no keep-alive at all.
That halved the network stall a connection can ride through, because the
connection is further into its silence when a stall begins *and* recovery
afterwards waits on the dialling side's probe timer backing off exponentially.

Measured on an in-process harness at 40 ms RTT and 1.5% background loss, against
an outage recurring every 90 s inside a 300 s window, three connections per
outage length:

| Outage | both sides on a timer | dialling side only | + 25 s backstop |
|---:|---:|---:|---:|
| 13 s | 0/3 died | 0/3 | — |
| 15 s | 0/3 | 0/3 | 0/3 |
| **17 s** | **0/3** | **3/3** | **0/3** |
| 21 s | 0/3 | 3/3 | 0/3 |
| 25 s | 0/3 | 3/3 | 0/3 |
| 29 s | 3/3 | 3/3 | 2/3 |

Survivable stall about 28 s before #137, about 16 s after, and back to about
28 s with the backstop. A 5 s backstop was measured alongside 25 s and behaved
identically at every length, which is why the interval is free to sit clear of
the 10 s dialling cadence.

**Harness caveat, stated because it nearly produced a wrong answer.** A first
version applied the one-way delay with one task per datagram, which reorders
them; QUIC declares a packet lost once three later ones are acknowledged, so it
manufactured roughly 12x more loss than it injected and produced large,
entirely artificial differences between the arms. Delivery is now strictly FIFO
and every run reports declared losses over injected drops, which read 1.00 for
all figures above. The harness is not checked in — it carries a dev-dependency
and an impairment layer out of proportion to this change.

**Repo tests.** `cargo test --lib` 1500 pass / 0 fail / 3 ignored.
`cargo fmt --all --check` and `cargo clippy --all-targets -- -D warnings` clean.

Four tests cover the wiring, because a backstop the peer's traffic holds off is
indistinguishable on the wire from no keep-alive at all — watching a healthy
connection cannot tell a correctly wired endpoint from a reverted one:

- `each_side_is_wired_to_its_own_keep_alive` — the builder's output.
- `the_endpoint_builds_the_accept_side_with_the_backstop` — read back from the
  `ServerConfig` the endpoint constructor returns.
- `the_relay_tunnel_endpoint_keeps_the_accept_side_backstop` — the second
  endpoint that accepts connections, which adapts MTU and must not drop the
  keep-alive doing it.
- `a_production_endpoint_holds_a_connection_open_for_a_silent_peer` — dials a
  production-built endpoint with a peer that sends no keep-alive and requires
  the connection to outlive `max_idle_timeout`. This is the one a mutation of a
  config *copy* cannot slip past.

Each was verified by making the corresponding change and watching it fail. The
relay path has config-level coverage only; exercising it for real needs a MASQUE
tunnel.

`tests/keep_alive_asymmetry.rs` now carries the cost argument, asserting the
accepting side emits **zero** keep-alives across a 40 s idle window while the
peer pings, plus a second test holding a connection open past the idle timeout
with a silent dialler.

**What is not established here.** How often stalls long enough to matter occur
on the fleet. This shows the margin was lost and that the backstop restores it,
not how often that margin was being called upon. Per-node idle egress after
rollout is also what confirms the cost is nil — the zero-egress test runs on
lossless loopback, and on a degraded-but-live path the backstop can legitimately
fire.

Reviewed adversarially over six rounds; the findings that changed the code were
a second accepting endpoint on the relay path, tests that could not detect their
own revert, and an undisclosed dead-peer retention cost.

## New dependency

None.

## ADR

[ADR-014](https://github.com/WithAutonomi/saorsa-transport/blob/fix/accept-keepalive-backstop/docs/adr/ADR-014-accept-side-keep-alive-backstop.md)
(amends ADR-012; added here, after merge it lives at `docs/adr/` on `main`).

## Mitigation / rollback

Pin saorsa-transport to the previous version and roll-restart, as with #137.
Existing connections keep the transport config they were created with, so a
revert takes effect on reconnect and need not be atomic. There is no
configuration to change.

Two consequences worth watching rather than reverting for. A disappeared peer is
now retained about 55 s rather than 30 s, because the first backstop PING
re-arms the idle timer — relevant because `P2pConfig::max_connections` is not
enforced at the QUIC accept layer. And the slack for servicing the idle timer
narrows to a nominal 5 s. If either bites, a lower interval inside the measured
range is the lighter response than removing the backstop.
